### PR TITLE
Rename — patch ciblé du cache audit + bouton 🔄 Rescanner

### DIFF
--- a/dashboard/rename.py
+++ b/dashboard/rename.py
@@ -116,6 +116,90 @@ def _categorize(current_stem: str, similarity: float) -> str:
     return "ok"
 
 
+def _audit_single_file(
+    abs_path: str,
+    rel: str,
+    cache: dict,
+    cfg: dict,
+    model: str,
+    n_pages: int,
+) -> dict:
+    """Compute the audit verdict for ONE file.
+
+    Returns one of three shapes:
+      - ``{"_no_metadata": True}``     — no vision_cache hit or empty title
+      - ``{"_low_confidence": True}``  — cache hit below ``min_title_confidence``
+      - ``{"_render_failed": True, "issues": [...]}`` — template rejected
+      - the full candidate dict ready to insert in ``candidates``
+
+    Pulled out of ``rename_audit`` so the targeted-patch path
+    (``_patch_audit_after_rename``) can re-audit one file without
+    rescanning the whole library.
+    """
+    filename = os.path.basename(abs_path)
+    stem, ext = os.path.splitext(filename)
+    ext = ext.lower() or ".pdf"
+
+    key = vision_cache.compute_cache_key(
+        abs_path, model=model, n_pages=n_pages)
+    result = vision_cache.lookup(cache, key) if key else None
+    if not isinstance(result, dict):
+        return {"_no_metadata": True}
+
+    conf = float(result.get("confidence") or 0.0)
+    if conf < cfg["min_title_confidence"]:
+        return {"_low_confidence": True}
+
+    meta = _extract_metadata(result)
+    if not meta["title"]:
+        return {"_no_metadata": True}
+
+    rendered = rename_template.render_with_fallback(
+        template=cfg["template"],
+        fallback=cfg["fallback"],
+        metadata=meta,
+        extension=ext,
+        sanitize_cfg=cfg["sanitize"],
+        max_length=cfg["max_length"],
+    )
+    if not rendered.is_valid:
+        return {"_render_failed": True, "issues": rendered.issues}
+
+    similarity = _jaccard_3grams(stem, rendered.new_stem)
+    category = _categorize(stem, similarity)
+
+    return {
+        "rel_path": rel,
+        "current_name": filename,
+        "current_stem": stem,
+        "suggested_name": rendered.new_name,
+        "suggested_stem": rendered.new_stem,
+        "similarity": round(similarity, 3),
+        "category": category,
+        "title": meta["title"],
+        "author": meta["author"],
+        "confidence": round(conf, 2),
+        "issues": rendered.issues,
+        "used_fallback": rendered.used_fallback,
+    }
+
+
+# Single source of truth for the candidate sort order — used by the
+# full-rebuild path AND the targeted-patch path so both produce the
+# same ordering.
+_CATEGORY_SORT_ORDER = {
+    "placeholder": 0, "divergent": 1, "minor_case": 2, "ok": 3,
+}
+
+
+def _candidate_sort_key(c: dict) -> tuple:
+    return (
+        _CATEGORY_SORT_ORDER.get(c["category"], 9),
+        c["similarity"],
+        c["rel_path"].lower(),
+    )
+
+
 def _extract_metadata(result: dict) -> dict:
     """Pull out the variables the template engine knows about."""
     if not isinstance(result, dict):
@@ -213,53 +297,8 @@ def rename_audit(profile: str, force_reload: bool = False) -> dict:
 
     def _process(item: tuple[str, str]) -> dict | None:
         abs_path, rel = item
-        filename = os.path.basename(abs_path)
-        stem, ext = os.path.splitext(filename)
-        ext = ext.lower() or ".pdf"
-
-        # Cache lookup
-        key = vision_cache.compute_cache_key(
-            abs_path, model=model, n_pages=n_pages)
-        result = vision_cache.lookup(cache, key) if key else None
-        if not isinstance(result, dict):
-            return {"_no_metadata": True}
-
-        conf = float(result.get("confidence") or 0.0)
-        if conf < cfg["min_title_confidence"]:
-            return {"_low_confidence": True}
-
-        meta = _extract_metadata(result)
-        if not meta["title"]:
-            return {"_no_metadata": True}
-
-        rendered = rename_template.render_with_fallback(
-            template=cfg["template"],
-            fallback=cfg["fallback"],
-            metadata=meta,
-            extension=ext,
-            sanitize_cfg=cfg["sanitize"],
-            max_length=cfg["max_length"],
-        )
-        if not rendered.is_valid:
-            return {"_render_failed": True, "issues": rendered.issues}
-
-        similarity = _jaccard_3grams(stem, rendered.new_stem)
-        category = _categorize(stem, similarity)
-
-        return {
-            "rel_path": rel,
-            "current_name": filename,
-            "current_stem": stem,
-            "suggested_name": rendered.new_name,
-            "suggested_stem": rendered.new_stem,
-            "similarity": round(similarity, 3),
-            "category": category,
-            "title": meta["title"],
-            "author": meta["author"],
-            "confidence": round(conf, 2),
-            "issues": rendered.issues,
-            "used_fallback": rendered.used_fallback,
-        }
+        return _audit_single_file(
+            abs_path, rel, cache, cfg, model, n_pages)
 
     with ThreadPoolExecutor(max_workers=8) as ex:
         for r in ex.map(_process, file_list):
@@ -280,10 +319,7 @@ def rename_audit(profile: str, force_reload: bool = False) -> dict:
             candidates.append(r)
 
     # Sort: placeholder first, then divergent (worst sim), then minor, then ok
-    cat_order = {"placeholder": 0, "divergent": 1, "minor_case": 2, "ok": 3}
-    candidates.sort(key=lambda c: (cat_order.get(c["category"], 9),
-                                    c["similarity"],
-                                    c["rel_path"].lower()))
+    candidates.sort(key=_candidate_sort_key)
 
     result_dict = {
         "candidates": candidates,
@@ -360,13 +396,161 @@ def _validate_new_basename(new_name: str) -> str:
     return name
 
 
-def _invalidate_dependent_caches(profile: str) -> None:
-    """After any FS rename (apply OR undo), drop the rename / taxonomy /
-    categories caches so subsequent reads rebuild from the current state.
-    Failures to import a sibling module are swallowed: the rename
-    succeeded, a missing cache is at worst a stale read.
+def _load_vision_cache_for_patch(profile: str) -> dict:
+    """Read the profile's vision_cache.json once for a patch operation.
+    Cheap (~50 MB JSON read, parsed by C json module) compared to a
+    full audit rescan, but still better to do once per patch batch
+    than once per file."""
+    cache_path = _vision_cache_path(profile)
+    if not cache_path.exists():
+        return {}
+    try:
+        vc = json.loads(cache_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return {}
+    return vc if isinstance(vc, dict) else {}
+
+
+def _profile_audit_context(profile: str) -> tuple[Path, dict, dict, str, int] | None:
+    """Bundle everything ``_audit_single_file`` needs in one call.
+    Returns ``(target_resolved, vc, cfg, model, n_pages)`` or ``None``
+    if the profile is misconfigured."""
+    target = _profile_target(profile)
+    if target is None or not target.exists():
+        return None
+    cfg = get_rename_config(profile)
+    vc = _load_vision_cache_for_patch(profile)
+    profile_yaml = _load_profile_yaml(profile)
+    model = ((profile_yaml.get("llm") or {}).get("model")
+             or "Qwen/Qwen3-VL-32B-Instruct")
+    n_pages = int((profile_yaml.get("defaults") or {}).get("pages") or 2)
+    return target.resolve(), vc, cfg, model, n_pages
+
+
+def _apply_patch_to_audit(
+    cached: dict,
+    pairs: list[tuple[str, str]],
+    ctx: tuple[Path, dict, dict, str, int],
+) -> bool:
+    """Mutate ``cached`` in place for each ``(old_rel, new_rel)`` pair.
+
+    Returns True on success, False if any pair couldn't be patched
+    cleanly (caller should drop the cache for safety).
+
+    Single sort at the end — for a bulk of 100 renames we pay one
+    ``candidates.sort()`` (~50ms on 10k entries) instead of 100.
     """
-    reset_cache(profile)
+    target_resolved, vc, cfg, model, n_pages = ctx
+    candidates: list[dict] = cached["candidates"]
+    stats: dict = cached["stats"]
+    # Build an index for O(1) lookup of old entries
+    by_rel: dict[str, int] = {
+        c["rel_path"]: i for i, c in enumerate(candidates)
+    }
+    # Track removed indices to delete in one pass at the end
+    to_remove: set[int] = set()
+    additions: list[dict] = []
+
+    for old_rel, new_rel in pairs:
+        idx = by_rel.get(old_rel)
+        if idx is None:
+            # Old entry sat in a non-candidate bucket (n_no_metadata /
+            # n_low_confidence / n_render_failed). We can't know which
+            # without re-scanning the now-vanished file. Bail to a full
+            # rebuild so stats don't drift.
+            return False
+        if idx in to_remove:
+            # Same file referenced twice in the batch — shouldn't happen
+            return False
+        to_remove.add(idx)
+        old_entry = candidates[idx]
+        stats[f"n_{old_entry['category']}"] -= 1
+        stats["n_with_title"] -= 1
+
+        abs_new = target_resolved / new_rel
+        if not abs_new.exists():
+            return False
+        new_result = _audit_single_file(
+            str(abs_new), new_rel, vc, cfg, model, n_pages)
+
+        if new_result.get("_no_metadata"):
+            stats["n_no_metadata"] += 1
+        elif new_result.get("_low_confidence"):
+            stats["n_low_confidence"] += 1
+        elif new_result.get("_render_failed"):
+            stats["n_render_failed"] += 1
+        else:
+            stats["n_with_title"] += 1
+            stats[f"n_{new_result['category']}"] += 1
+            additions.append(new_result)
+
+    # Apply removals + additions in one pass, then a single sort
+    if to_remove:
+        cached["candidates"] = [
+            c for i, c in enumerate(candidates) if i not in to_remove
+        ]
+        candidates = cached["candidates"]
+    if additions:
+        candidates.extend(additions)
+    if to_remove or additions:
+        candidates.sort(key=_candidate_sort_key)
+    return True
+
+
+def _patch_audit_after_renames(
+    profile: str, pairs: list[tuple[str, str]],
+) -> None:
+    """Targeted invalidation of the in-memory rename audit cache.
+
+    Each ``(old_rel, new_rel)`` pair has its old entry dropped from
+    ``candidates`` and its new entry re-audited and re-inserted.
+    Stats are mutated in place. Saves the ~5s full os.walk +
+    ThreadPoolExecutor rescan after every rename on an 18k-file lib.
+
+    Falls back to a full ``reset_cache(profile)`` when:
+      - no cache is loaded (lazy rebuild on next read anyway)
+      - the profile is misconfigured
+      - any old entry sat in a non-candidate bucket (stats drift risk)
+      - any new file is missing on disk (patch is stale)
+    """
+    if not pairs:
+        return
+    with _cache_lock:
+        cached = _audit_cache.get(profile)
+    if cached is None:
+        return  # nothing to patch, next read does a full scan anyway
+
+    ctx = _profile_audit_context(profile)
+    if ctx is None:
+        reset_cache(profile)
+        return
+
+    with _cache_lock:
+        cached = _audit_cache.get(profile)
+        if cached is None:
+            return
+        ok = _apply_patch_to_audit(cached, pairs, ctx)
+        if not ok:
+            _audit_cache.pop(profile, None)
+
+
+def _patch_audit_after_rename(
+    profile: str, old_rel: str, new_rel: str,
+) -> None:
+    """Single-rename convenience wrapper around _patch_audit_after_renames."""
+    _patch_audit_after_renames(profile, [(old_rel, new_rel)])
+
+
+def _invalidate_dependent_caches(profile: str) -> None:
+    """Drop the taxonomy + categories caches after an FS rename.
+
+    The rename audit cache is NOT dropped here — callers should use
+    ``_patch_audit_after_rename(s)`` for that, which mutates in place
+    instead of forcing a full rescan. Taxonomy + categories are
+    cheaper to rebuild (lazy on next view visit) so a full drop is
+    still acceptable for them. Failures to import a sibling module
+    are swallowed: the rename succeeded, a stale cache is harmless.
+    """
     try:
         from dashboard import taxonomy as _tx
         _tx.reset_cache(profile)
@@ -462,15 +646,18 @@ def commit_rename(
         batch_id=batch_id,
     )
 
-    # Invalidate dependent caches. They're all keyed by rel_path so a
-    # filename change makes them stale. They rebuild lazily on next query.
-    _invalidate_dependent_caches(profile)
-
     # ``target.resolve()`` is required because ``abs_new`` came from
     # ``abs_old.resolve().parent`` — on macOS ``/var`` is a symlink to
     # ``/private/var``, so an un-resolved ``target`` would not be a parent
     # of ``abs_new`` and ``relative_to`` would raise.
     new_rel = str(abs_new.relative_to(target.resolve())).replace("\\", "/")
+
+    # Targeted patch of the rename audit cache (no full rescan); still
+    # drop the taxonomy + categories caches since they're cheaper and
+    # rebuild lazily on tab visit.
+    _patch_audit_after_rename(profile, rel_path, new_rel)
+    _invalidate_dependent_caches(profile)
+
     return {
         "ok": True,
         "old_rel_path": rel_path,
@@ -671,8 +858,13 @@ def commit_rename_bulk(
             "journal_entry": record,
         })
 
-    # Single cache invalidation for the whole batch
+    # Targeted patch of the audit cache + lazy invalidation of
+    # taxonomy / categories. Building the (old, new) pair list lets
+    # _patch_audit_after_renames do ONE sort at the end of the batch.
     if successes:
+        pairs = [(s["rel_path"], s["new_rel_path"])
+                 for s in successes if not s.get("unchanged")]
+        _patch_audit_after_renames(profile, pairs)
         _invalidate_dependent_caches(profile)
 
     return {
@@ -703,13 +895,45 @@ def undo_batch_for_profile(profile: str, batch_id: str) -> dict:
 
     from lib import rename_journal
     profile_dir = _profile_dir(profile)
+
+    # Snapshot the batch's (old, new) pairs BEFORE undoing — after the
+    # undo runs, the files are at their `old` paths and the audit
+    # patch needs to know which `new` paths to drop from candidates.
+    pre_records = [
+        (r["old"], r["new"])
+        for r in rename_journal.read_journal(profile_dir)
+        if (r.get("batch") or "") == batch_id
+    ]
+    target_resolved = target.resolve()
+
     try:
         summary = rename_journal.undo_batch(profile_dir, batch_id)
     except FileNotFoundError as exc:
         raise RenameError(str(exc), 404) from exc
 
-    # Even partial success warrants a cache invalidation (the FS moved)
     if summary.get("n_undone", 0) > 0:
+        # Build pairs as (post_rel = file's new path = the one being
+        # dropped, pre_rel = old path = where the file lives after undo).
+        # Restrict to records that actually got undone (in summary["undone"]).
+        undone_olds = set(summary.get("undone", []))
+        pairs: list[tuple[str, str]] = []
+        for old_abs, new_abs in pre_records:
+            if old_abs not in undone_olds:
+                continue
+            try:
+                pre_rel = str(Path(new_abs).resolve()
+                              .relative_to(target_resolved)).replace("\\", "/")
+                post_rel = str(Path(old_abs).resolve()
+                               .relative_to(target_resolved)).replace("\\", "/")
+            except (ValueError, OSError):
+                # Path outside target — abandon the patch, fall back full
+                pairs = []
+                break
+            pairs.append((pre_rel, post_rel))
+        if pairs:
+            _patch_audit_after_renames(profile, pairs)
+        else:
+            reset_cache(profile)
         _invalidate_dependent_caches(profile)
 
     return {"ok": True, **summary}
@@ -791,14 +1015,31 @@ def undo_single_rename(
     except OSError as exc:
         raise RenameError(f"Échec de l'undo : {exc}", 500) from exc
 
+    # Compute the rel paths for the targeted audit patch. The file
+    # moved from match["new"] back to match["old"] — so the audit
+    # entry keyed at the post-rename path must drop, and the entry
+    # at the pre-rename (restored) path must be (re-)inserted.
+    def _maybe_rel(abs_path: str) -> str | None:
+        if not _path_under(target_resolved, abs_path):
+            return None
+        try:
+            return str(Path(abs_path).resolve()
+                       .relative_to(target_resolved)).replace("\\", "/")
+        except (ValueError, OSError):
+            return None
+
+    pre_rel = _maybe_rel(match["new"])   # path the file lived at, now gone
+    post_rel = _maybe_rel(match["old"])  # path the file now sits at
+    if pre_rel and post_rel:
+        _patch_audit_after_rename(profile, pre_rel, post_rel)
+    else:
+        # Edge case: paths outside target. Bail to a full rebuild.
+        reset_cache(profile)
     _invalidate_dependent_caches(profile)
 
     return {
         "ok": True,
         "inverse_entry": inverse,
         "restored_abs": match["old"],
-        "restored_rel": str(
-            Path(match["old"]).resolve().relative_to(target_resolved)
-        ).replace("\\", "/") if _path_under(target_resolved, match["old"])
-            else match["old"],
+        "restored_rel": post_rel or match["old"],
     }

--- a/dashboard/static/js/taxonomy_rename.js
+++ b/dashboard/static/js/taxonomy_rename.js
@@ -55,6 +55,11 @@
     bulkSelected: new Set(),
     // Active tab of the 📜 modal: "records" or "batches"
     historyTab: 'records',
+    // Timestamp (ms epoch) of the last full audit (force=true OR initial
+    // load). Patches don't update this — the cache may be in-sync but
+    // the os.walk hasn't run, so files added manually since are still
+    // invisible.
+    lastFullScanTs: 0,
   };
 
   function _sessionKey() {
@@ -1255,6 +1260,7 @@
     renderPreview();
     renderSession();
     renderBulkbar();
+    renderRescanAge();
   }
 
   // ── Bulk selection (multi-rename) ────────────────────────────────────
@@ -1365,6 +1371,7 @@
       try {
         state.data = await fetchAudit();
         state.loaded = true;
+        state.lastFullScanTs = Date.now();
         // Pre-select the first candidate so the detail panel is not empty
         if (state.data.candidates.length) {
           state.selectedRelPath = state.data.candidates[0].rel_path;
@@ -1377,6 +1384,55 @@
           wrap.appendChild(el('div', { class: 'error', style: 'padding:20px;' },
             ['✗ ' + e.message]));
         }
+      }
+    });
+  }
+
+  // ── Manual rescan (force=true → full os.walk + ThreadPoolExecutor) ──
+
+  // Format "il y a Xmin" for the rescan button label. Refreshed on every
+  // renderAll() call (≈ on every user interaction), so it stays fresh
+  // enough without a setInterval.
+  function _formatScanAge() {
+    if (!state.lastFullScanTs) return '';
+    const sec = Math.max(0, Math.round((Date.now() - state.lastFullScanTs) / 1000));
+    if (sec < 60) return `${sec}s`;
+    const min = Math.floor(sec / 60);
+    if (min < 60) return `${min}min`;
+    const h = Math.floor(min / 60);
+    return `${h}h`;
+  }
+
+  function renderRescanAge() {
+    const span = $('#tax-rename-rescan-age');
+    if (span) span.textContent = _formatScanAge();
+  }
+
+  async function manualRescan() {
+    const btn = $('#tax-rename-rescan-btn');
+    if (!btn || btn.disabled) return;
+    btn.disabled = true;
+    await withBusy('Rescan complet…', async () => {
+      try {
+        state.data = await fetchAudit(true);
+        state.lastFullScanTs = Date.now();
+        // Keep the current selection if the file still exists; otherwise
+        // pick the first candidate so the detail panel isn't empty.
+        const stillThere = state.selectedRelPath
+          && state.data.candidates.some(
+              c => c.rel_path === state.selectedRelPath);
+        if (!stillThere && state.data.candidates.length) {
+          state.selectedRelPath = state.data.candidates[0].rel_path;
+        }
+        renderAll();
+        showToast(
+          `🔄 Scan terminé : ${state.data.stats.n_total} fichiers, `
+          + `${state.data.stats.n_with_title} audités`,
+          'success');
+      } catch (e) {
+        showToast('✗ Échec du rescan : ' + e.message, 'error');
+      } finally {
+        btn.disabled = false;
       }
     });
   }
@@ -1398,6 +1454,7 @@
       state.renaming = false;
       state.searchQuery = '';
       state.bulkSelected.clear();
+      state.lastFullScanTs = 0;
       // Session log is keyed per profile so each profile has its own
       // history. Load the new profile's log; the previous one stays in
       // sessionStorage untouched.
@@ -1456,6 +1513,16 @@
     // Initial render of the session panel so the count/list reflect
     // sessionStorage from the start (even before the user clicks Rename).
     renderSession();
+
+    // ── Manual rescan button ──
+    const rescanBtn = $('#tax-rename-rescan-btn');
+    if (rescanBtn) {
+      rescanBtn.addEventListener('click', () => manualRescan());
+    }
+    // Passively refresh the "il y a Xmin" label so it stays sensible
+    // when the user keeps the tab open without interacting. Cheap:
+    // one DOM write per minute.
+    setInterval(renderRescanAge, 60_000);
 
     // ── Bulk action bar ──
     const bulkApplyBtn = $('#tax-rename-bulkbar-apply');

--- a/dashboard/static/js/taxonomy_rename.js
+++ b/dashboard/static/js/taxonomy_rename.js
@@ -81,6 +81,12 @@
 
   // ── API ──────────────────────────────────────────────────────────────
 
+  // Note: callers after a rename or undo should NOT pass force=true.
+  // The backend patches the audit cache in place (see
+  // dashboard.rename._patch_audit_after_renames), so a normal fetch
+  // returns the already-up-to-date cache without paying the ~5s full
+  // rescan of an 18k-file lib. force=true is reserved for the
+  // "manual refresh" button when the user wants a fresh os.walk.
   async function fetchAudit(force) {
     const url = `/api/rename/audit?profile=${encodeURIComponent(state.profile)}${force ? '&force=true' : ''}`;
     const r = await fetch(url);
@@ -805,7 +811,7 @@
           undone: false,
         });
         // Refresh the audit so the renamed file shows up under its new name
-        state.data = await fetchAudit(true);
+        state.data = await fetchAudit();
         // Try to re-select the renamed file under its new path
         const found = (state.data.candidates || []).find(
           x => x.rel_path === newRel);
@@ -951,7 +957,7 @@
         _saveSessionToStorage();
         // Refresh the audit so the restored file shows up under its
         // original name. Try to select it.
-        state.data = await fetchAudit(true);
+        state.data = await fetchAudit();
         const found = (state.data.candidates || []).find(
           c => c.rel_path === entry.old_rel_path);
         if (found) {
@@ -1111,7 +1117,7 @@
           }
         }
         _saveSessionToStorage();
-        state.data = await fetchAudit(true);
+        state.data = await fetchAudit();
         renderAll();
         const data = await fetchJournal(200);
         state._historyData = data;
@@ -1211,7 +1217,7 @@
         }
         _saveSessionToStorage();
         // Refresh both the audit and the modal list
-        state.data = await fetchAudit(true);
+        state.data = await fetchAudit();
         renderAll();
         const data = await fetchJournal(200);
         state._historyData = data;
@@ -1334,7 +1340,7 @@
           });
         }
         state.bulkSelected.clear();
-        state.data = await fetchAudit(true);
+        state.data = await fetchAudit();
         renderAll();
         _refreshHistoryCount();
         if (result.n_errors > 0) {

--- a/dashboard/static/style.css
+++ b/dashboard/static/style.css
@@ -3127,6 +3127,33 @@ th {
     font-variant-numeric: tabular-nums;
 }
 
+/* 🔄 Rescan button — forces a full os.walk on the target. Used after
+ * manually adding files to the lib or running `klodo.sh rename`. */
+.tax-rename-rescan-btn {
+    flex: none;
+    background: rgba(120, 200, 140, 0.08);
+    border: 1px solid rgba(120, 200, 140, 0.2);
+    color: var(--text, #c9d1d9);
+    padding: 4px 8px;
+    border-radius: 4px;
+    cursor: pointer;
+    font-size: 11px;
+    line-height: 1.3;
+    white-space: nowrap;
+    transition: background 0.12s, border-color 0.12s;
+}
+.tax-rename-rescan-btn:hover {
+    background: rgba(120, 200, 140, 0.15);
+    border-color: rgba(120, 200, 140, 0.4);
+}
+.tax-rename-rescan-btn[disabled] { opacity: 0.45; cursor: default; }
+.tax-rename-rescan-age {
+    margin-left: 3px;
+    color: var(--text-muted, #8b949e);
+    font-size: 10px;
+    font-variant-numeric: tabular-nums;
+}
+
 /* 📜 Renommages button — opens the journal modal */
 .tax-rename-history-btn {
     flex: none;

--- a/dashboard/templates/taxonomy.html
+++ b/dashboard/templates/taxonomy.html
@@ -286,6 +286,11 @@
                 <button type="button" id="tax-rename-search-clear"
                         class="tax-rename-search-clear" hidden
                         aria-label="Effacer la recherche">✕</button>
+                <button type="button" id="tax-rename-rescan-btn"
+                        class="tax-rename-rescan-btn"
+                        title="Forcer un nouveau scan du target (~5s sur 18k fichiers) — utile après un ajout manuel ou un cycle `klodo.sh rename` qui a enrichi vision_cache.json">
+                    🔄 <span id="tax-rename-rescan-age" class="tax-rename-rescan-age"></span>
+                </button>
                 <button type="button" id="tax-rename-history-btn"
                         class="tax-rename-history-btn"
                         title="Voir le journal des renommages (avec undo)">

--- a/tests/auto/test_rename_audit.py
+++ b/tests/auto/test_rename_audit.py
@@ -1035,5 +1035,167 @@ class TestBulkEndpoints(RenameAuditTestBase):
         self.assertEqual(r.status_code, 404)
 
 
+# ─── Targeted cache invalidation (perf — no full rescan after rename) ───
+
+
+class TestTargetedAuditPatch(RenameAuditTestBase):
+    """commit_rename / commit_rename_bulk / undo_* must mutate the audit
+    cache in place instead of dropping it (the previous behaviour forced
+    a full os.walk + 18k-file rescan after every single rename).
+
+    Each test verifies BOTH that the patched cache is correct AND that
+    no rebuild happened (we replace ``_audit_cache`` with a sentinel
+    after the rename and check it's still there)."""
+
+    def test_single_rename_patches_in_place(self):
+        self._add_file_with_cache("ugly.pdf", title="Clean Title")
+        # Prime the cache
+        audit_before = rename.rename_audit(self.profile_name)
+        cached = rename._audit_cache[self.profile_name]
+        self.assertIs(audit_before, cached, "Cached object reference")
+        # Sentinel so we detect a full rebuild
+        cached["_sentinel"] = "must-survive-patch"
+
+        rename.commit_rename(self.profile_name, "ugly.pdf", "Clean Title.pdf")
+
+        cached_after = rename._audit_cache[self.profile_name]
+        # Same dict instance → mutated in place, not replaced
+        self.assertIs(cached_after, cached)
+        self.assertEqual(cached_after.get("_sentinel"), "must-survive-patch")
+        # And the candidate now reflects the new name
+        names = {c["current_name"] for c in cached_after["candidates"]}
+        self.assertIn("Clean Title.pdf", names)
+        self.assertNotIn("ugly.pdf", names)
+
+    def test_patch_keeps_stats_accurate(self):
+        # Three placeholders + one already-OK
+        self._add_file_with_cache("Title Author.pdf",
+                                   title="Real Book", author="X")
+        self._add_file_with_cache("Title Author (2).pdf",
+                                   title="Other Book", author="Y")
+        self._add_file_with_cache("Real Book - X.pdf",
+                                   title="Real Book", author="X")
+        rename.rename_audit(self.profile_name)
+        stats_before = dict(rename._audit_cache[self.profile_name]["stats"])
+        self.assertEqual(stats_before["n_placeholder"], 2)
+
+        # Rename one placeholder → it now matches "Real Book - X" template
+        # (which is "ok"). Stats must decrement placeholder, increment ok.
+        rename.commit_rename(
+            self.profile_name, "Title Author.pdf", "Real Book - X (v2).pdf")
+        stats_after = rename._audit_cache[self.profile_name]["stats"]
+        self.assertEqual(stats_after["n_placeholder"],
+                         stats_before["n_placeholder"] - 1)
+        # n_with_title unchanged (file count is the same, just relabeled)
+        self.assertEqual(stats_after["n_with_title"],
+                         stats_before["n_with_title"])
+        # n_total unchanged
+        self.assertEqual(stats_after["n_total"], stats_before["n_total"])
+
+    def test_patch_result_matches_full_rebuild(self):
+        # Same lib, two ways to reach the post-rename state — must match
+        self._add_file_with_cache("a.pdf", title="A book", author="A")
+        self._add_file_with_cache("b.pdf", title="B book", author="B")
+        self._add_file_with_cache("placeholder.pdf",
+                                   title="Real C", author="C")
+        rename.rename_audit(self.profile_name)
+        rename.commit_rename(
+            self.profile_name, "placeholder.pdf", "Real C - C.pdf")
+        patched = dict(rename._audit_cache[self.profile_name])
+        patched_candidates = [
+            {**c} for c in patched["candidates"]
+        ]
+        patched_stats = dict(patched["stats"])
+
+        # Force a full rebuild and compare
+        rename.reset_cache(self.profile_name)
+        rebuilt = rename.rename_audit(
+            self.profile_name, force_reload=True)
+        rebuilt_candidates = [{**c} for c in rebuilt["candidates"]]
+        rebuilt_stats = dict(rebuilt["stats"])
+
+        # Same order, same content
+        self.assertEqual(
+            [c["rel_path"] for c in patched_candidates],
+            [c["rel_path"] for c in rebuilt_candidates])
+        self.assertEqual(patched_stats, rebuilt_stats)
+
+    def test_bulk_rename_single_sort_in_place(self):
+        for i in range(5):
+            self._add_file_with_cache(
+                f"Title Author ({i}).pdf",
+                title=f"Real {i}", author="Author")
+        rename.rename_audit(self.profile_name)
+        cached = rename._audit_cache[self.profile_name]
+        cached["_sentinel"] = "bulk-survivor"
+
+        rename.commit_rename_bulk(
+            self.profile_name,
+            items=[{"rel_path": f"Title Author ({i}).pdf",
+                    "new_name": f"Real {i} - Author.pdf"} for i in range(5)],
+        )
+        # No rebuild happened: same dict + sentinel survives
+        self.assertIs(rename._audit_cache[self.profile_name], cached)
+        self.assertEqual(cached.get("_sentinel"), "bulk-survivor")
+        names = {c["current_name"] for c in cached["candidates"]}
+        for i in range(5):
+            self.assertIn(f"Real {i} - Author.pdf", names)
+            self.assertNotIn(f"Title Author ({i}).pdf", names)
+
+    def test_undo_patches_in_place(self):
+        self._add_file_with_cache("orig.pdf", title="Renamed", author="X")
+        # Audit before rename so the cache exists to be patched
+        rename.rename_audit(self.profile_name)
+        rename.commit_rename(
+            self.profile_name, "orig.pdf", "Renamed - X.pdf")
+        cached = rename._audit_cache[self.profile_name]
+        cached["_sentinel"] = "undo-survivor"
+        # Find the journal entry to undo
+        j = rename.get_journal(self.profile_name)
+        rec = j["records"][0]
+        rename.undo_single_rename(
+            self.profile_name, rec["ts"], rec["old"], rec["new"])
+        # Same dict, sentinel survives
+        self.assertIs(rename._audit_cache[self.profile_name], cached)
+        self.assertEqual(cached.get("_sentinel"), "undo-survivor")
+        names = {c["current_name"] for c in cached["candidates"]}
+        self.assertIn("orig.pdf", names)
+        self.assertNotIn("Renamed - X.pdf", names)
+
+    def test_falls_back_when_no_audit_loaded(self):
+        # No audit done — _audit_cache is empty. Patch should be a no-op,
+        # and the next audit should rebuild fresh (and be correct).
+        self._add_file_with_cache("foo.pdf", title="Foo", author="X")
+        # Sanity: no cache yet
+        self.assertNotIn(self.profile_name, rename._audit_cache)
+        rename.commit_rename(
+            self.profile_name, "foo.pdf", "Foo - X.pdf")
+        # Still no cache (no audit was loaded, so no patch happened)
+        self.assertNotIn(self.profile_name, rename._audit_cache)
+        # The lazy rebuild on next read produces a correct audit
+        r = rename.rename_audit(self.profile_name)
+        names = {c["current_name"] for c in r["candidates"]}
+        self.assertIn("Foo - X.pdf", names)
+
+    def test_falls_back_when_old_entry_not_in_candidates(self):
+        # File audited as n_no_metadata (no cache hit) — its rename can't
+        # be safely patched because we don't know its bucket. Fall back
+        # to a full rebuild (cache dropped).
+        # Setup: a file with no vision_cache entry
+        (self.target / "untracked.pdf").write_bytes(b"%PDF noop")
+        # Add another file WITH cache so the audit has something to scan
+        self._add_file_with_cache("tracked.pdf", title="Tracked", author="X")
+        rename.rename_audit(self.profile_name)
+        cached = rename._audit_cache[self.profile_name]
+        cached["_sentinel"] = "should-be-dropped"
+        # Rename the untracked file
+        rename.commit_rename(
+            self.profile_name, "untracked.pdf", "Different.pdf")
+        # Cache was dropped — sentinel is gone (either key absent or new dict)
+        # Wait — n_no_metadata files don't actually appear in candidates.
+        # The patch logic recognises this and drops the profile cache.
+        self.assertNotIn(self.profile_name, rename._audit_cache)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Description

Suite directe de #136 — résout le coût de **~5s par rename** induit par l'ancien `reset_cache(profile)` global.

### 1. Patch ciblé du cache audit (`859f8ad`)

Avant : chaque `commit_rename` / `undo_*` droppait `_audit_cache[profile]` → le prochain `fetchAudit()` rebuild via `os.walk` + `ThreadPoolExecutor` sur 18 145 fichiers → ~5s d'UI freeze. 10 renames consécutifs = 50s perdues.

Après : mutation en place du cache. Pour chaque paire `(old_rel, new_rel)` :
- retrait du candidat à `old_rel`
- re-audit du fichier à `new_rel` (1 lookup vision_cache + 1 render + 1 jaccard ≈ 5ms)
- update des compteurs stats
- 1 seul `sort()` à la fin du batch

**Mesures locales** : single rename `~5s → <50ms`, bulk de 100 `~5s → <100ms`.

Le code retombe automatiquement sur `reset_cache(profile)` quand le patch ne peut pas s'appliquer proprement (profil mal configuré, fichier disparu, ancien entry hors `candidates`).

### 2. Bouton 🔄 Rescanner (`c067d71`)

Le patch ciblé referme accidentellement la détection passive des fichiers ajoutés manuellement à la lib (le cache restant, le prochain `os.walk` n'a pas lieu).

Ajout d'un bouton vert 🔄 à côté de 📜 dans la search bar :
- Click → `fetchAudit(true)` → rescan complet à la demande
- Affiche un compteur "il y a Xs/Xmin/Xh" depuis le dernier scan (rafraîchi passivement toutes les 60s)
- Tooltip explicite l'usage : *"utile après un ajout manuel ou un cycle `klodo.sh rename` qui a enrichi vision_cache.json"*

## Type de changement
- [x] **Perf** — patch ciblé du cache audit
- [x] Nouvelle fonctionnalité — bouton manuel 🔄 Rescanner
- [x] Tests — 7 nouveaux dans `TestTargetedAuditPatch`

## Checklist
- [x] Les tests passent (`uv run python -m unittest discover -s tests/auto` → 754/754)
- [x] Le lint passe (`ruff check .` → All checks passed)
- [x] La documentation est à jour (commentaires détaillés sur le helper de patch + sa fallback)
- [ ] CHANGELOG.md — à faire si on cut une release

## Tests effectués

7 tests nouveaux dans `TestTargetedAuditPatch` :
- `test_single_rename_patches_in_place` — sentinel survit, identité du dict préservée
- `test_patch_keeps_stats_accurate` — compteurs par catégorie cohérents post-rename
- `test_patch_result_matches_full_rebuild` — patch == force_reload (consistency check)
- `test_bulk_rename_single_sort_in_place` — bulk de 5 sans rebuild
- `test_undo_patches_in_place` — même invariant sur le chemin undo
- `test_falls_back_when_no_audit_loaded` — pas de cache → patch no-op
- `test_falls_back_when_old_entry_not_in_candidates` — bucket non-candidat → drop cache

Test fonctionnel sur la vraie bibliothèque (18k fichiers) : single rename `~5s → <50ms`, vérifié via DevTools Network sur `GET /api/rename/audit`.

## Points d'attention

1. **Frontend** : tous les `fetchAudit(true)` post-rename/undo passés à `fetchAudit()` — le cache backend est patché, force=true serait du gaspillage.
2. **Taxonomy + categories caches** : restent en `reset_cache()` global. Leur rebuild est lazy (au moment de visiter ces onglets), donc l'onglet Rename ne paie pas leur coût. Optimisation séparée trackée dans la mémoire (`project_taxonomy_snapshot_perf`).
3. **Détection des ajouts manuels** : intentionnellement passée du mode "implicite via reset_cache" à "explicite via bouton 🔄". Tooltip + indicateur d'âge rendent le coût visible et contrôlé.

🤖 Generated with [Claude Code](https://claude.com/claude-code)