### PR TITLE
Rename cache patch — review follow-up fixes (C1/C2/I1/I2)

### DIFF
--- a/dashboard/rename.py
+++ b/dashboard/rename.py
@@ -435,7 +435,10 @@ def _apply_patch_to_audit(
     """Mutate ``cached`` in place for each ``(old_rel, new_rel)`` pair.
 
     Returns True on success, False if any pair couldn't be patched
-    cleanly (caller should drop the cache for safety).
+    cleanly. On False, ``stats`` is restored to its pre-call state so
+    the cache stays self-consistent even if the caller forgets to
+    drop it. ``candidates`` is only rebuilt at the very end so it
+    cannot be partially mutated.
 
     Single sort at the end — for a bulk of 100 renames we pay one
     ``candidates.sort()`` (~50ms on 10k entries) instead of 100.
@@ -443,6 +446,12 @@ def _apply_patch_to_audit(
     target_resolved, vc, cfg, model, n_pages = ctx
     candidates: list[dict] = cached["candidates"]
     stats: dict = cached["stats"]
+    # Snapshot stats so we can restore on any failure mode. We decrement
+    # the old entry's bucket BEFORE we know if its replacement will land
+    # successfully — without this snapshot, a mid-batch failure would
+    # leave the cache with half-decremented counters even though the
+    # caller's `pop(profile)` fixes it. Defensive: belt + suspenders.
+    stats_backup: dict = dict(stats)
     # Build an index for O(1) lookup of old entries
     by_rel: dict[str, int] = {
         c["rel_path"]: i for i, c in enumerate(candidates)
@@ -451,6 +460,14 @@ def _apply_patch_to_audit(
     to_remove: set[int] = set()
     additions: list[dict] = []
 
+    def _bail() -> bool:
+        # Restore the stats to their pre-call state. ``candidates`` was
+        # never mutated (we only collected indices in ``to_remove``),
+        # so nothing else needs undoing.
+        stats.clear()
+        stats.update(stats_backup)
+        return False
+
     for old_rel, new_rel in pairs:
         idx = by_rel.get(old_rel)
         if idx is None:
@@ -458,10 +475,11 @@ def _apply_patch_to_audit(
             # n_low_confidence / n_render_failed). We can't know which
             # without re-scanning the now-vanished file. Bail to a full
             # rebuild so stats don't drift.
-            return False
+            return _bail()
         if idx in to_remove:
-            # Same file referenced twice in the batch — shouldn't happen
-            return False
+            # Duplicate rel_path in the batch — punt to a full rebuild
+            # to avoid mutating the same entry twice.
+            return _bail()
         to_remove.add(idx)
         old_entry = candidates[idx]
         stats[f"n_{old_entry['category']}"] -= 1
@@ -469,7 +487,7 @@ def _apply_patch_to_audit(
 
         abs_new = target_resolved / new_rel
         if not abs_new.exists():
-            return False
+            return _bail()
         new_result = _audit_single_file(
             str(abs_new), new_rel, vc, cfg, model, n_pages)
 
@@ -484,16 +502,13 @@ def _apply_patch_to_audit(
             stats[f"n_{new_result['category']}"] += 1
             additions.append(new_result)
 
-    # Apply removals + additions in one pass, then a single sort
-    if to_remove:
-        cached["candidates"] = [
-            c for i, c in enumerate(candidates) if i not in to_remove
-        ]
-        candidates = cached["candidates"]
-    if additions:
-        candidates.extend(additions)
-    if to_remove or additions:
-        candidates.sort(key=_candidate_sort_key)
+    # Apply removals + additions in one pass, then a single sort. We
+    # always rebuild the list to keep this branch unconditional — clearer
+    # than the previous "rebind if to_remove" pattern and equally cheap.
+    new_list = [c for i, c in enumerate(candidates) if i not in to_remove]
+    new_list.extend(additions)
+    new_list.sort(key=_candidate_sort_key)
+    cached["candidates"] = new_list
     return True
 
 

--- a/tests/auto/test_rename_audit.py
+++ b/tests/auto/test_rename_audit.py
@@ -1192,9 +1192,149 @@ class TestTargetedAuditPatch(RenameAuditTestBase):
         rename.commit_rename(
             self.profile_name, "untracked.pdf", "Different.pdf")
         # Cache was dropped — sentinel is gone (either key absent or new dict)
-        # Wait — n_no_metadata files don't actually appear in candidates.
+        # n_no_metadata files don't actually appear in candidates.
         # The patch logic recognises this and drops the profile cache.
         self.assertNotIn(self.profile_name, rename._audit_cache)
+        # And the lazy rebuild on the next read produces a correct audit.
+        # This is the assertion the original test was missing: confirming
+        # that the drop-then-rebuild cycle actually yields the right state
+        # (not just that the drop happened).
+        r = rename.rename_audit(self.profile_name)
+        names = {c["current_name"] for c in r["candidates"]}
+        # 'tracked.pdf' still audited (cache key untouched), the rename
+        # to 'Different.pdf' is visible. The renamed file lands in
+        # n_no_metadata since it has no vision_cache entry, but n_total
+        # still counts it.
+        self.assertIn("tracked.pdf", names)
+        self.assertNotIn("untracked.pdf", names)
+        self.assertEqual(r["stats"]["n_total"], 2)
+        self.assertEqual(r["stats"]["n_no_metadata"], 1)
+
+
+# ─── Follow-up regression coverage (PR review #137) ─────────────────────
+
+
+class TestTargetedAuditPatchRegressions(RenameAuditTestBase):
+    """Plug the test-coverage gaps surfaced by the post-merge code review:
+
+      - bulk path stats consistency (I2)
+      - undo_batch_for_profile in-place patch (I1)
+      - stats restored to pre-call state on _apply_patch_to_audit
+        failure, regardless of caller behaviour (C1)
+    """
+
+    def test_bulk_rename_updates_stats_per_pair(self):
+        # 4 placeholders that will all land in "ok" after rename. Verify
+        # n_placeholder drops by 4 and n_ok rises by 4 — proves the
+        # per-pair stat mutations aren't dropped, doubled, or off-by-one.
+        for i in range(4):
+            self._add_file_with_cache(
+                f"Title Author ({i}).pdf",
+                title=f"Real Book {i}", author=f"Author {i}")
+        rename.rename_audit(self.profile_name)
+        before = dict(rename._audit_cache[self.profile_name]["stats"])
+        self.assertEqual(before["n_placeholder"], 4)
+        self.assertEqual(before["n_ok"], 0)
+
+        rename.commit_rename_bulk(
+            self.profile_name,
+            items=[{"rel_path": f"Title Author ({i}).pdf",
+                    "new_name": f"Real Book {i} - Author {i}.pdf"}
+                   for i in range(4)],
+        )
+        after = rename._audit_cache[self.profile_name]["stats"]
+        self.assertEqual(after["n_placeholder"], 0)
+        self.assertEqual(after["n_ok"], 4)
+        # n_with_title + n_total preserved (files were renamed, not added)
+        self.assertEqual(after["n_with_title"], before["n_with_title"])
+        self.assertEqual(after["n_total"], before["n_total"])
+
+    def test_undo_batch_patches_in_place(self):
+        # Mirror of test_undo_patches_in_place but for the batch path.
+        # Sets a sentinel, runs a bulk + undo_batch, asserts the cache
+        # dict is the SAME instance and the sentinel survives.
+        for i in range(3):
+            self._add_file_with_cache(
+                f"orig-{i}.pdf",
+                title=f"Renamed {i}", author=f"Author {i}")
+        rename.rename_audit(self.profile_name)
+        # Do the bulk
+        result = rename.commit_rename_bulk(
+            self.profile_name,
+            items=[{"rel_path": f"orig-{i}.pdf",
+                    "new_name": f"Renamed {i} - Author {i}.pdf"}
+                   for i in range(3)],
+        )
+        batch_id = result["batch_id"]
+        # Now mark the cache and undo the batch
+        cached = rename._audit_cache[self.profile_name]
+        cached["_sentinel"] = "batch-undo-survivor"
+        summary = rename.undo_batch_for_profile(self.profile_name, batch_id)
+        self.assertEqual(summary["n_undone"], 3)
+        # Same dict instance — patched in place, not rebuilt
+        self.assertIs(rename._audit_cache[self.profile_name], cached)
+        self.assertEqual(cached.get("_sentinel"), "batch-undo-survivor")
+        # And the files are back at their original names
+        names = {c["current_name"] for c in cached["candidates"]}
+        for i in range(3):
+            self.assertIn(f"orig-{i}.pdf", names)
+            self.assertNotIn(f"Renamed {i} - Author {i}.pdf", names)
+
+    def test_undo_batch_consistency_with_full_rebuild(self):
+        # Same lib + same actions, two ways to reach the final state:
+        # via in-place patch vs via force_reload. Stats and candidates
+        # must be identical.
+        for i in range(3):
+            self._add_file_with_cache(
+                f"src-{i}.pdf", title=f"T{i}", author=f"A{i}")
+        rename.rename_audit(self.profile_name)
+        r = rename.commit_rename_bulk(
+            self.profile_name,
+            items=[{"rel_path": f"src-{i}.pdf",
+                    "new_name": f"T{i} - A{i}.pdf"} for i in range(3)],
+        )
+        rename.undo_batch_for_profile(self.profile_name, r["batch_id"])
+        patched_stats = dict(
+            rename._audit_cache[self.profile_name]["stats"])
+        patched_rel_paths = [
+            c["rel_path"]
+            for c in rename._audit_cache[self.profile_name]["candidates"]
+        ]
+        # Force a clean rebuild and compare
+        rebuilt = rename.rename_audit(
+            self.profile_name, force_reload=True)
+        self.assertEqual(patched_stats, dict(rebuilt["stats"]))
+        self.assertEqual(
+            patched_rel_paths,
+            [c["rel_path"] for c in rebuilt["candidates"]])
+
+    def test_apply_patch_stats_restored_on_bail(self):
+        # Direct exercise of _apply_patch_to_audit's bail path. Verifies
+        # the C1 fix: stats must be back to their pre-call state when
+        # the function returns False — regardless of whether the caller
+        # subsequently drops the cache.
+        self._add_file_with_cache("a.pdf", title="AAA", author="X")
+        self._add_file_with_cache("b.pdf", title="BBB", author="Y")
+        rename.rename_audit(self.profile_name)
+        cached = rename._audit_cache[self.profile_name]
+        stats_before = dict(cached["stats"])
+        candidates_before_count = len(cached["candidates"])
+
+        ctx = rename._profile_audit_context(self.profile_name)
+        self.assertIsNotNone(ctx)
+        # Force a bail: second pair points to a file that doesn't exist
+        # on disk, AFTER the first pair has already decremented stats.
+        pairs = [
+            ("a.pdf", "AAA - X.pdf"),               # would succeed
+            ("b.pdf", "this-file-does-not-exist.pdf"),  # bails here
+        ]
+        ok = rename._apply_patch_to_audit(cached, pairs, ctx)
+        self.assertFalse(ok)
+        # Stats restored to exactly the pre-call values — no half-mutation
+        self.assertEqual(dict(cached["stats"]), stats_before)
+        # Candidates unchanged in count (the list rebuild only happens on
+        # the True path; on bail, candidates is the same list reference)
+        self.assertEqual(len(cached["candidates"]), candidates_before_count)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Description

Follow-up de la code review de #137 (lancée via `/superpowers:requesting-code-review`). Trois durcissements de correction + une lacune de couverture de tests. Aucune ne bloque le merged work, mais elles évitent qu'une régression future passe silencieusement.

## Issues traitées

### C1 — Mutation partielle des stats avant `return False`

`_apply_patch_to_audit` décrémentait `n_{old_category}` + `n_with_title` AVANT le check `abs_new.exists()`. Sur un échec mi-batch, le cache restait avec des compteurs à moitié décrémentés. Le caller fixait l'état en droppant le cache mais ça reposait sur ce comportement.

→ Snapshot de `stats` au début + helper `_bail()` qui restaure sur chaque retour `False`. Belt + suspenders.

→ Tant qu'à faire, simplifié le rebuild post-loop (toujours assigne, plus de conditional rebind).

### C2 — Test de fallback incomplet

`test_falls_back_when_old_entry_not_in_candidates` vérifiait seulement que le cache était dropé. Ajout des assertions sur le rebuild qui suit, pour que un casse du rebuild path (et pas seulement du drop) échoue aussi.

### I1 — Aucun test pour le patch dans `undo_batch_for_profile`

Le chemin le plus complexe (snapshot pre-records + filtre `summary["undone"]` + inversion `pre_rel`/`post_rel`) n'était pas couvert. Nouveau `TestTargetedAuditPatchRegressions` avec :
- `test_undo_batch_patches_in_place` — sentinel + `assertIs` sur l'identité du dict
- `test_undo_batch_consistency_with_full_rebuild` — comparaison patch vs `force_reload`

### I2 — Bulk test ne vérifiait pas les stats

`test_bulk_rename_single_sort_in_place` n'asseyait que les noms. Un double-décrément serait passé silencieusement. Nouveau `test_bulk_rename_updates_stats_per_pair` : 4 placeholders → 4 ok doit décrémenter `n_placeholder` de 4, incrémenter `n_ok` de 4, préserver `n_with_title` + `n_total`.

### Bonus

`test_apply_patch_stats_restored_on_bail` — exercice direct du fix C1, vérifie via un appel `_apply_patch_to_audit` artificiel que les stats sont restaurées exactement à leur état pré-call sur `return False`.

## Type de changement
- [x] Bug fix (C1)
- [x] Tests (C2 + I1 + I2 + bonus)
- [x] Refactoring mineur (rebuild post-loop unconditional)

## Checklist
- [x] Les tests passent : 758/758 (était 754, +4 tests)
- [x] Le lint passe : `ruff check .` → All checks passed
- [x] Pas de changement d'API ni de comportement utilisateur — purement défensif + couverture
- [ ] CHANGELOG — n/a (pas de release en vue)

🤖 Generated with [Claude Code](https://claude.com/claude-code)