### PR TITLE
Rename — override manuel du statut (marquer comme OK)

### DIFF
--- a/dashboard/app.py
+++ b/dashboard/app.py
@@ -1798,6 +1798,28 @@ async def rename_undo_batch_api(request: Request):
         return JSONResponse({"error": str(exc)}, status_code=exc.status)
 
 
+@app.post("/api/rename/override")
+async def rename_override_api(request: Request):
+    """Set or clear user category overrides for the rename audit.
+    Body: {profile, items: [{rel_path, category}], clear?}.
+    When clear=true, drops the override for each rel_path (the
+    category field is ignored). Otherwise sets the category — only
+    `ok` is allowed in the MVP. Returns per-item successes + errors."""
+    from fastapi.responses import JSONResponse
+
+    from dashboard import rename as rename_mod
+    body = await request.json()
+    try:
+        result = rename_mod.set_overrides(
+            profile=body.get("profile"),
+            items=body.get("items") or [],
+            clear=bool(body.get("clear")),
+        )
+        return JSONResponse(result)
+    except rename_mod.RenameError as exc:
+        return JSONResponse({"error": str(exc)}, status_code=exc.status)
+
+
 @app.get("/api/categories/entry/files")
 async def categories_entry_files_api(
     profile: str,

--- a/dashboard/rename.py
+++ b/dashboard/rename.py
@@ -14,6 +14,7 @@ import os
 import re
 import threading
 from concurrent.futures import ThreadPoolExecutor
+from datetime import datetime
 from pathlib import Path
 
 import yaml
@@ -49,6 +50,40 @@ def _profile_dir(profile: str) -> Path:
 
 def _vision_cache_path(profile: str) -> Path:
     return _profile_dir(profile) / ".cache" / "vision_cache.json"
+
+
+def _overrides_path(profile: str) -> Path:
+    """JSON file storing user manual category overrides for the rename
+    audit. Keyed by vision_cache.compute_cache_key (MD5 of file head
+    bytes + model + n_pages) so the override survives renames — the
+    cache_key only changes if the file CONTENT changes."""
+    return _profile_dir(profile) / ".cache" / "rename-overrides.json"
+
+
+def _load_overrides(profile: str) -> dict:
+    """Read the overrides JSON for a profile. Returns ``{}`` on any
+    error (missing file, bad JSON, wrong shape) — the audit must work
+    even if overrides are corrupted."""
+    path = _overrides_path(profile)
+    if not path.exists():
+        return {}
+    try:
+        raw = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return {}
+    return raw if isinstance(raw, dict) else {}
+
+
+def _save_overrides(profile: str, overrides: dict) -> None:
+    """Persist the overrides JSON atomically (write to ``.tmp`` then
+    rename). The file lives under ``.cache/`` so it's gitignored."""
+    path = _overrides_path(profile)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = path.with_suffix(path.suffix + ".tmp")
+    tmp.write_text(
+        json.dumps(overrides, ensure_ascii=False, indent=2),
+        encoding="utf-8")
+    tmp.replace(path)
 
 
 def _load_profile_yaml(profile: str) -> dict:
@@ -123,6 +158,7 @@ def _audit_single_file(
     cfg: dict,
     model: str,
     n_pages: int,
+    overrides: dict | None = None,
 ) -> dict:
     """Compute the audit verdict for ONE file.
 
@@ -135,6 +171,12 @@ def _audit_single_file(
     Pulled out of ``rename_audit`` so the targeted-patch path
     (``_patch_audit_after_rename``) can re-audit one file without
     rescanning the whole library.
+
+    If ``overrides`` is provided (a mapping ``cache_key → {"category":
+    ...}``), the user's manual category override is applied AFTER the
+    auto-categorization. The returned candidate then has
+    ``is_overridden=True`` and ``original_category`` records what the
+    algorithm said before the user intervened.
     """
     filename = os.path.basename(abs_path)
     stem, ext = os.path.splitext(filename)
@@ -166,7 +208,18 @@ def _audit_single_file(
         return {"_render_failed": True, "issues": rendered.issues}
 
     similarity = _jaccard_3grams(stem, rendered.new_stem)
-    category = _categorize(stem, similarity)
+    auto_category = _categorize(stem, similarity)
+
+    # Apply user override if one exists for this content (keyed by the
+    # MD5-of-head cache_key, which survives renames since the bytes
+    # don't change).
+    is_overridden = False
+    effective_category = auto_category
+    if overrides and key and key in overrides:
+        ov_cat = (overrides[key] or {}).get("category")
+        if ov_cat in _CATEGORY_SORT_ORDER:
+            effective_category = ov_cat
+            is_overridden = True
 
     return {
         "rel_path": rel,
@@ -175,7 +228,10 @@ def _audit_single_file(
         "suggested_name": rendered.new_name,
         "suggested_stem": rendered.new_stem,
         "similarity": round(similarity, 3),
-        "category": category,
+        "category": effective_category,
+        "auto_category": auto_category,
+        "is_overridden": is_overridden,
+        "cache_key": key,
         "title": meta["title"],
         "author": meta["author"],
         "confidence": round(conf, 2),
@@ -276,6 +332,12 @@ def rename_audit(profile: str, force_reload: bool = False) -> dict:
             or "Qwen/Qwen3-VL-32B-Instruct"
     n_pages = int((profile_yaml.get("defaults") or {}).get("pages") or 2)
 
+    # Load user category overrides once (cheap, small JSON keyed by
+    # vision cache_key). Pass to every _audit_single_file call so the
+    # category in the returned candidate already reflects the user's
+    # override choice.
+    overrides = _load_overrides(profile)
+
     # Enumerate files
     file_list: list[tuple[str, str]] = []
     target_str = str(target)
@@ -298,7 +360,7 @@ def rename_audit(profile: str, force_reload: bool = False) -> dict:
     def _process(item: tuple[str, str]) -> dict | None:
         abs_path, rel = item
         return _audit_single_file(
-            abs_path, rel, cache, cfg, model, n_pages)
+            abs_path, rel, cache, cfg, model, n_pages, overrides)
 
     with ThreadPoolExecutor(max_workers=8) as ex:
         for r in ex.map(_process, file_list):
@@ -411,10 +473,12 @@ def _load_vision_cache_for_patch(profile: str) -> dict:
     return vc if isinstance(vc, dict) else {}
 
 
-def _profile_audit_context(profile: str) -> tuple[Path, dict, dict, str, int] | None:
+def _profile_audit_context(
+    profile: str,
+) -> tuple[Path, dict, dict, str, int, dict] | None:
     """Bundle everything ``_audit_single_file`` needs in one call.
-    Returns ``(target_resolved, vc, cfg, model, n_pages)`` or ``None``
-    if the profile is misconfigured."""
+    Returns ``(target_resolved, vc, cfg, model, n_pages, overrides)``
+    or ``None`` if the profile is misconfigured."""
     target = _profile_target(profile)
     if target is None or not target.exists():
         return None
@@ -424,13 +488,14 @@ def _profile_audit_context(profile: str) -> tuple[Path, dict, dict, str, int] | 
     model = ((profile_yaml.get("llm") or {}).get("model")
              or "Qwen/Qwen3-VL-32B-Instruct")
     n_pages = int((profile_yaml.get("defaults") or {}).get("pages") or 2)
-    return target.resolve(), vc, cfg, model, n_pages
+    overrides = _load_overrides(profile)
+    return target.resolve(), vc, cfg, model, n_pages, overrides
 
 
 def _apply_patch_to_audit(
     cached: dict,
     pairs: list[tuple[str, str]],
-    ctx: tuple[Path, dict, dict, str, int],
+    ctx: tuple[Path, dict, dict, str, int, dict],
 ) -> bool:
     """Mutate ``cached`` in place for each ``(old_rel, new_rel)`` pair.
 
@@ -443,7 +508,7 @@ def _apply_patch_to_audit(
     Single sort at the end — for a bulk of 100 renames we pay one
     ``candidates.sort()`` (~50ms on 10k entries) instead of 100.
     """
-    target_resolved, vc, cfg, model, n_pages = ctx
+    target_resolved, vc, cfg, model, n_pages, overrides = ctx
     candidates: list[dict] = cached["candidates"]
     stats: dict = cached["stats"]
     # Snapshot stats so we can restore on any failure mode. We decrement
@@ -489,7 +554,7 @@ def _apply_patch_to_audit(
         if not abs_new.exists():
             return _bail()
         new_result = _audit_single_file(
-            str(abs_new), new_rel, vc, cfg, model, n_pages)
+            str(abs_new), new_rel, vc, cfg, model, n_pages, overrides)
 
         if new_result.get("_no_metadata"):
             stats["n_no_metadata"] += 1
@@ -1057,4 +1122,131 @@ def undo_single_rename(
         "inverse_entry": inverse,
         "restored_abs": match["old"],
         "restored_rel": post_rel or match["old"],
+    }
+
+
+# ─── User category override (PR ─ rename-status-override) ────────────────
+
+
+# Categories the user is allowed to set via override. We deliberately
+# limit this to "ok" for the MVP — that covers the dominant use case
+# ("this divergent is legitimately fine, stop bothering me") without
+# the conceptual mess of letting users swap placeholder/divergent/
+# minor_case arbitrarily. Extend if a real use case emerges.
+_OVERRIDE_ALLOWED_CATEGORIES: frozenset[str] = frozenset({"ok"})
+
+
+def set_overrides(
+    profile: str,
+    items: list[dict],
+    clear: bool = False,
+) -> dict:
+    """Set or clear user category overrides for one or more files.
+
+    ``items`` is ``[{"rel_path": str, "category": str}, ...]``. When
+    ``clear`` is True, ``category`` is ignored and the override for
+    each ``rel_path`` is removed (no-op if none existed). When False,
+    ``category`` must be in ``_OVERRIDE_ALLOWED_CATEGORIES`` ("ok"
+    for the MVP) — anything else returns a per-item error.
+
+    Per-item best-effort: a malformed entry doesn't abort the batch.
+    The summary lists successes and errors so the UI can show what
+    happened. After persisting, the audit cache is patched in place
+    (or dropped if patch isn't applicable) so the new category is
+    visible without a full rescan.
+    """
+    if not isinstance(items, list) or not items:
+        raise RenameError("items vide ou invalide", 400)
+
+    target = _profile_target(profile)
+    if target is None or not target.exists():
+        raise RenameError("profil sans target configuré", 400)
+    target_resolved = target.resolve()
+
+    profile_yaml = _load_profile_yaml(profile)
+    model = ((profile_yaml.get("llm") or {}).get("model")
+             or "Qwen/Qwen3-VL-32B-Instruct")
+    n_pages = int((profile_yaml.get("defaults") or {}).get("pages") or 2)
+
+    overrides = _load_overrides(profile)
+    successes: list[dict] = []
+    errors: list[dict] = []
+    touched_rels: list[str] = []
+
+    for item in items:
+        rel_path = (item or {}).get("rel_path") or ""
+        if not rel_path:
+            errors.append({"rel_path": rel_path,
+                           "error": "rel_path manquant", "status": 400})
+            continue
+
+        # Path traversal guard — resolve and assert under target
+        abs_path = (target / rel_path).resolve()
+        try:
+            abs_path.relative_to(target_resolved)
+        except ValueError:
+            errors.append({"rel_path": rel_path,
+                           "error": "hors du target", "status": 400})
+            continue
+        if not abs_path.exists():
+            errors.append({"rel_path": rel_path,
+                           "error": "fichier introuvable", "status": 404})
+            continue
+
+        # Compute cache_key — this is the override's primary key. Needs
+        # to read the file's head bytes; cheap (few KB) per file.
+        key = vision_cache.compute_cache_key(
+            str(abs_path), model=model, n_pages=n_pages)
+        if not key:
+            errors.append({"rel_path": rel_path,
+                           "error": "cache_key indisponible", "status": 500})
+            continue
+
+        if clear:
+            removed = overrides.pop(key, None)
+            successes.append({
+                "rel_path": rel_path,
+                "cache_key": key,
+                "cleared": removed is not None,
+            })
+            touched_rels.append(rel_path)
+        else:
+            category = (item or {}).get("category") or ""
+            if category not in _OVERRIDE_ALLOWED_CATEGORIES:
+                errors.append({
+                    "rel_path": rel_path,
+                    "error": (f"catégorie '{category}' non autorisée "
+                              f"(autorisées : "
+                              f"{sorted(_OVERRIDE_ALLOWED_CATEGORIES)})"),
+                    "status": 400,
+                })
+                continue
+            overrides[key] = {
+                "category": category,
+                "ts": datetime.now().isoformat(timespec="seconds"),
+            }
+            successes.append({
+                "rel_path": rel_path,
+                "cache_key": key,
+                "category": category,
+            })
+            touched_rels.append(rel_path)
+
+    if successes:
+        _save_overrides(profile, overrides)
+        # Targeted patch: re-audit each touched file. The override is
+        # now in the persisted JSON, so _audit_single_file will pick it
+        # up. Re-using the rename patch path means we get the
+        # candidates-list mutation + stats update + sort for free.
+        pairs = [(r, r) for r in touched_rels]
+        _patch_audit_after_renames(profile, pairs)
+
+    return {
+        "ok": True,
+        "n_total": len(items),
+        "n_set": len(successes),
+        "n_errors": len(errors),
+        "successes": successes,
+        "errors": errors,
+        "clear": clear,
     }

--- a/dashboard/static/js/taxonomy_rename.js
+++ b/dashboard/static/js/taxonomy_rename.js
@@ -192,6 +192,27 @@
     return body;
   }
 
+  async function postOverride(items, clear) {
+    const r = await fetch('/api/rename/override', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        profile: state.profile,
+        items: items,
+        clear: !!clear,
+      }),
+    });
+    let body = null;
+    try { body = await r.json(); } catch (_) { /* ignore */ }
+    if (!r.ok) {
+      const msg = (body && body.error) || `HTTP ${r.status}`;
+      const err = new Error(msg);
+      err.status = r.status;
+      throw err;
+    }
+    return body;
+  }
+
   // Reuses the shared modal HTML (#tax-confirm-modal) declared in
   // taxonomy.html — same pattern as taxonomy_categories.js. We can't
   // share the JS helper because each sub-tab module lives in its own
@@ -398,8 +419,11 @@
       wrap.appendChild(el('div', {
         class: 'tax-rename-row'
              + (selected ? ' selected' : '')
-             + (checked ? ' bulk-selected' : ''),
-        title: c.rel_path,
+             + (checked ? ' bulk-selected' : '')
+             + (c.is_overridden ? ' is-overridden' : ''),
+        title: c.is_overridden
+          ? `${c.rel_path}\n[Marqué OK manuellement — auto: ${c.auto_category}]`
+          : c.rel_path,
         onclick: () => selectCandidate(c.rel_path),
       }, [
         checkbox,
@@ -407,7 +431,15 @@
           class: 'tax-rename-cat tax-rename-cat-' + c.category,
           title: 'Catégorie : ' + c.category,
         }, [_catShortLabel(c.category)]),
-        el('span', { class: 'tax-rename-row-current' }, [c.current_name]),
+        el('span', { class: 'tax-rename-row-current' }, [
+          c.current_name,
+          c.is_overridden
+            ? el('span', {
+                class: 'tax-rename-row-override-badge',
+                title: `Marqué OK manuellement (auto: ${c.auto_category})`,
+              }, [' ✓'])
+            : null,
+        ].filter(Boolean)),
         el('span', { class: 'tax-rename-row-sim',
                      title: 'Similarité courant vs proposition' },
                    [sim + '%']),
@@ -715,6 +747,20 @@
       'data-tax-rename-apply': '1',
       onclick: () => applyRename(c.rel_path),
     }, ['Renommer']);
+    // Override button: toggles between "Marquer comme OK" and
+    // "Annuler l'override" based on current state.
+    const overrideBtn = c.is_overridden
+      ? el('button', {
+          class: 'btn-secondary',
+          title: 'Restaurer la catégorie auto (' + c.auto_category + ')',
+          onclick: () => toggleOverride(c.rel_path, /*clear=*/true),
+        }, ['↺ Annuler l’override'])
+      : el('button', {
+          class: 'btn-secondary',
+          title: 'Marquer ce fichier comme OK — il sortira du bucket "'
+                 + c.category + '" et n’apparaîtra plus comme à traiter',
+          onclick: () => toggleOverride(c.rel_path, /*clear=*/false),
+        }, ['✓ Marquer comme OK']);
     wrap.appendChild(el('div', { class: 'tax-rename-field',
                                   style: 'border-bottom:none;' }, [
       el('label', null, ['Actions']),
@@ -722,10 +768,7 @@
                  ['Le rename est appliqué sur disque et journalisé pour undo.']),
       renameBtn,
       ' ',
-      el('button', {
-        class: 'btn-secondary', disabled: true,
-        title: 'Disponible en PR4',
-      }, ['Ajouter au batch']),
+      overrideBtn,
     ]));
     _refreshRenameButtonState(c, nameInput);
     // Template config preview (read-only)
@@ -1366,6 +1409,102 @@
     });
   }
 
+  // ── User category override (mark a candidate as OK manually) ────────
+
+  async function toggleOverride(relPath, clear) {
+    const c = state.data && state.data.candidates.find(
+      x => x.rel_path === relPath);
+    if (!c) return;
+    const verb = clear ? 'Annuler' : 'Marquer';
+    const ok = await showConfirm({
+      title: clear
+        ? 'Annuler l\'override manuel ?'
+        : 'Marquer ce fichier comme OK ?',
+      body: clear
+        ? `Le fichier retrouvera sa catégorie auto : ${c.auto_category}.`
+        : `Catégorie actuelle : ${c.category}. Après override, ce fichier sera marqué OK et n'apparaîtra plus comme à traiter.\n\nL'override est persisté par contenu (cache_key) — il survit aux renommages.`,
+      confirmLabel: clear ? 'Annuler l\'override' : 'Marquer OK',
+      cancelLabel: 'Garder',
+      variant: clear ? 'danger' : 'primary',
+    });
+    if (!ok) return;
+    await withBusy(`${verb} OK…`, async () => {
+      try {
+        const result = await postOverride(
+          [{ rel_path: relPath, category: 'ok' }],
+          clear);
+        if (result.n_errors > 0) {
+          showToast(
+            `✗ ${result.errors[0].error || 'échec de l\'override'}`,
+            'error');
+          return;
+        }
+        // Refresh audit so the badge + category update everywhere.
+        // The backend already patched the cache in place, but we still
+        // need to swap state.data and re-render.
+        state.data = await fetchAudit();
+        renderAll();
+        showToast(
+          clear
+            ? `↺ Override annulé : ${c.current_name}`
+            : `✓ Marqué OK : ${c.current_name}`,
+          'success');
+      } catch (e) {
+        const detail = e.status ? `(${e.status}) ${e.message}` : e.message;
+        showToast(`✗ Échec : ${detail}`, 'error');
+      }
+    });
+  }
+
+  async function _applyBulkOverride() {
+    if (state.bulkSelected.size === 0 || !state.data) return;
+    const byPath = new Map(state.data.candidates.map(c => [c.rel_path, c]));
+    // Only mark not-yet-overridden candidates; an already-overridden
+    // entry would be a no-op but we surface the count so the user
+    // knows what'll happen.
+    const items = [];
+    const alreadyOk = [];
+    for (const relPath of state.bulkSelected) {
+      const c = byPath.get(relPath);
+      if (!c) continue;
+      if (c.is_overridden) { alreadyOk.push(relPath); continue; }
+      items.push({ rel_path: relPath, category: 'ok' });
+    }
+    if (items.length === 0) {
+      showToast('Tous les fichiers sélectionnés sont déjà marqués OK.', 'info');
+      return;
+    }
+    const ok = await showConfirm({
+      title: `Marquer ${items.length} fichier(s) comme OK ?`,
+      body: `Ces fichiers sortiront de leur bucket actuel (placeholder / divergent / minor_case) et ne seront plus présentés comme à traiter.\n\nL'override est annulable individuellement depuis le détail de chaque fichier.${alreadyOk.length ? `\n\n${alreadyOk.length} déjà marqué(s) — seront ignorés.` : ''}`,
+      confirmLabel: `Marquer ${items.length} comme OK`,
+      cancelLabel: 'Annuler',
+      variant: 'primary',
+    });
+    if (!ok) return;
+    await withBusy(`Override de ${items.length} fichier(s)…`, async () => {
+      try {
+        const result = await postOverride(items, /*clear=*/false);
+        state.bulkSelected.clear();
+        state.data = await fetchAudit();
+        renderAll();
+        if (result.n_errors > 0) {
+          showToast(
+            `✓ ${result.n_set} marqués OK, ${result.n_errors} en erreur (voir console)`,
+            'info');
+          console.warn('Bulk override errors:', result.errors);
+        } else {
+          showToast(
+            `✓ ${result.n_set} fichier(s) marqué(s) OK`,
+            'success');
+        }
+      } catch (e) {
+        const detail = e.status ? `(${e.status}) ${e.message}` : e.message;
+        showToast(`✗ Échec : ${detail}`, 'error');
+      }
+    });
+  }
+
   async function loadAndRender() {
     await withBusy('Audit rename…', async () => {
       try {
@@ -1528,6 +1667,10 @@
     const bulkApplyBtn = $('#tax-rename-bulkbar-apply');
     if (bulkApplyBtn) {
       bulkApplyBtn.addEventListener('click', () => _applyBulkSuggestion());
+    }
+    const bulkMarkOkBtn = $('#tax-rename-bulkbar-mark-ok');
+    if (bulkMarkOkBtn) {
+      bulkMarkOkBtn.addEventListener('click', () => _applyBulkOverride());
     }
     const bulkClearBtn = $('#tax-rename-bulkbar-clear');
     if (bulkClearBtn) {

--- a/dashboard/static/style.css
+++ b/dashboard/static/style.css
@@ -3324,6 +3324,19 @@ th {
 }
 .tax-rename-row.bulk-selected { background: rgba(88, 166, 255, 0.07); }
 .tax-rename-row.bulk-selected:hover { background: rgba(88, 166, 255, 0.12); }
+/* User has manually marked this candidate as OK — surface it with a
+ * subtle green tint + ✓ badge so the override is visible at a glance. */
+.tax-rename-row.is-overridden {
+    background: rgba(63, 185, 80, 0.06);
+}
+.tax-rename-row.is-overridden:hover { background: rgba(63, 185, 80, 0.12); }
+.tax-rename-row-override-badge {
+    color: #3fb950;
+    font-weight: 600;
+    margin-left: 4px;
+    font-size: 10px;
+    opacity: 0.8;
+}
 .tax-rename-row:hover { background: rgba(255,255,255,0.04); }
 .tax-rename-row.selected { background: rgba(88, 166, 255, 0.12); }
 .tax-rename-row-current {

--- a/dashboard/templates/taxonomy.html
+++ b/dashboard/templates/taxonomy.html
@@ -313,6 +313,11 @@
                     Renommer (suggestion)
                 </button>
                 <button type="button" class="btn-secondary btn-sm"
+                        id="tax-rename-bulkbar-mark-ok"
+                        title="Marquer la sélection comme OK — les fichiers sortent du bucket placeholder / divergent / minor_case sans être renommés">
+                    ✓ Marquer OK
+                </button>
+                <button type="button" class="btn-secondary btn-sm"
                         id="tax-rename-bulkbar-clear">
                     Tout désélectionner
                 </button>

--- a/tests/auto/test_rename_audit.py
+++ b/tests/auto/test_rename_audit.py
@@ -1337,5 +1337,186 @@ class TestTargetedAuditPatchRegressions(RenameAuditTestBase):
         self.assertEqual(len(cached["candidates"]), candidates_before_count)
 
 
+# ─── User category overrides (feature/rename-status-override) ───────────
+
+
+class TestSetOverrides(RenameAuditTestBase):
+    """User-facing semantic: 'this divergent is actually fine, mark it ok'.
+    Persists in profile/.cache/rename-overrides.json keyed by cache_key
+    (MD5-of-head), so the override survives renames automatically."""
+
+    def test_set_override_changes_category(self):
+        # A truly divergent file (random name vs. specific title)
+        self._add_file_with_cache(
+            "abcd.pdf",
+            title="Hands-On Machine Learning",
+            author="Aurélien Géron",
+        )
+        r1 = rename.rename_audit(self.profile_name)
+        c = r1["candidates"][0]
+        self.assertEqual(c["category"], "divergent")
+        self.assertFalse(c["is_overridden"])
+
+        result = rename.set_overrides(
+            self.profile_name,
+            items=[{"rel_path": "abcd.pdf", "category": "ok"}],
+        )
+        self.assertEqual(result["n_set"], 1)
+        self.assertEqual(result["n_errors"], 0)
+
+        r2 = rename.rename_audit(self.profile_name)
+        c2 = r2["candidates"][0]
+        self.assertEqual(c2["category"], "ok")
+        self.assertEqual(c2["auto_category"], "divergent")
+        self.assertTrue(c2["is_overridden"])
+        # Stats reflect the override
+        self.assertEqual(r2["stats"]["n_ok"], 1)
+        self.assertEqual(r2["stats"]["n_divergent"], 0)
+
+    def test_clear_override_restores_auto_category(self):
+        self._add_file_with_cache("xyz.pdf",
+                                   title="Some Real Title", author="Author")
+        rename.rename_audit(self.profile_name)
+        rename.set_overrides(
+            self.profile_name,
+            items=[{"rel_path": "xyz.pdf", "category": "ok"}])
+        # Now clear
+        result = rename.set_overrides(
+            self.profile_name,
+            items=[{"rel_path": "xyz.pdf"}],
+            clear=True)
+        self.assertEqual(result["n_set"], 1)
+        self.assertTrue(result["successes"][0]["cleared"])
+
+        r = rename.rename_audit(self.profile_name)
+        c = r["candidates"][0]
+        self.assertFalse(c["is_overridden"])
+        self.assertEqual(c["category"], c["auto_category"])
+
+    def test_override_persists_to_disk(self):
+        self._add_file_with_cache("f.pdf",
+                                   title="Title", author="Author")
+        rename.set_overrides(
+            self.profile_name,
+            items=[{"rel_path": "f.pdf", "category": "ok"}])
+        path = rename._overrides_path(self.profile_name)
+        self.assertTrue(path.exists())
+        on_disk = json.loads(path.read_text())
+        self.assertEqual(len(on_disk), 1)
+        first = next(iter(on_disk.values()))
+        self.assertEqual(first["category"], "ok")
+        self.assertIn("ts", first)
+
+    def test_override_survives_rename(self):
+        # The override is keyed by cache_key (MD5 of file head bytes),
+        # not by rel_path. Renaming the file MUST keep the override
+        # active under the new path.
+        self._add_file_with_cache(
+            "Title Author.pdf",
+            title="Real Book", author="Some Author")  # placeholder
+        rename.set_overrides(
+            self.profile_name,
+            items=[{"rel_path": "Title Author.pdf", "category": "ok"}])
+        r1 = rename.rename_audit(self.profile_name)
+        self.assertEqual(r1["candidates"][0]["category"], "ok")
+        self.assertTrue(r1["candidates"][0]["is_overridden"])
+
+        # Now rename the file
+        rename.commit_rename(
+            self.profile_name, "Title Author.pdf", "Real Book - Some Author.pdf")
+        # The renamed file MUST still be marked overridden
+        r2 = rename.rename_audit(self.profile_name)
+        c = r2["candidates"][0]
+        self.assertEqual(c["current_name"], "Real Book - Some Author.pdf")
+        self.assertTrue(c["is_overridden"])
+        self.assertEqual(c["category"], "ok")
+
+    def test_only_ok_category_allowed_in_mvp(self):
+        self._add_file_with_cache("f.pdf",
+                                   title="Title", author="Author")
+        result = rename.set_overrides(
+            self.profile_name,
+            items=[{"rel_path": "f.pdf", "category": "placeholder"}])
+        self.assertEqual(result["n_set"], 0)
+        self.assertEqual(result["n_errors"], 1)
+        self.assertEqual(result["errors"][0]["status"], 400)
+        self.assertIn("non autorisée", result["errors"][0]["error"])
+
+    def test_path_traversal_refused(self):
+        self._add_file_with_cache("f.pdf",
+                                   title="Title", author="Author")
+        result = rename.set_overrides(
+            self.profile_name,
+            items=[{"rel_path": "../outside.pdf", "category": "ok"}])
+        self.assertEqual(result["n_set"], 0)
+        # The resolved path lands outside target, or doesn't exist —
+        # either way it's a 400 or 404.
+        self.assertEqual(result["n_errors"], 1)
+        self.assertIn(result["errors"][0]["status"], (400, 404))
+
+    def test_empty_items_400(self):
+        with self.assertRaises(rename.RenameError) as cm:
+            rename.set_overrides(self.profile_name, items=[])
+        self.assertEqual(cm.exception.status, 400)
+
+    def test_bulk_override_mixed_outcomes(self):
+        self._add_file_with_cache("a.pdf",
+                                   title="A book", author="A")
+        self._add_file_with_cache("b.pdf",
+                                   title="B book", author="B")
+        result = rename.set_overrides(
+            self.profile_name,
+            items=[
+                {"rel_path": "a.pdf", "category": "ok"},          # OK
+                {"rel_path": "b.pdf", "category": "placeholder"}, # bad
+                {"rel_path": "ghost.pdf", "category": "ok"},      # 404
+            ])
+        self.assertEqual(result["n_set"], 1)
+        self.assertEqual(result["n_errors"], 2)
+        self.assertEqual(result["successes"][0]["rel_path"], "a.pdf")
+
+
+class TestOverrideEndpoints(RenameAuditTestBase):
+
+    def setUp(self):
+        super().setUp()
+        from fastapi.testclient import TestClient
+
+        from dashboard.app import app
+        self.client = TestClient(app)
+
+    def test_endpoint_set_happy(self):
+        self._add_file_with_cache("a.pdf",
+                                   title="A book", author="A")
+        r = self.client.post("/api/rename/override", json={
+            "profile": self.profile_name,
+            "items": [{"rel_path": "a.pdf", "category": "ok"}],
+        })
+        self.assertEqual(r.status_code, 200)
+        self.assertEqual(r.json()["n_set"], 1)
+
+    def test_endpoint_clear(self):
+        self._add_file_with_cache("a.pdf",
+                                   title="A book", author="A")
+        self.client.post("/api/rename/override", json={
+            "profile": self.profile_name,
+            "items": [{"rel_path": "a.pdf", "category": "ok"}],
+        })
+        r = self.client.post("/api/rename/override", json={
+            "profile": self.profile_name,
+            "items": [{"rel_path": "a.pdf"}],
+            "clear": True,
+        })
+        self.assertEqual(r.status_code, 200)
+        self.assertTrue(r.json()["successes"][0]["cleared"])
+
+    def test_endpoint_empty_items_400(self):
+        r = self.client.post("/api/rename/override", json={
+            "profile": self.profile_name,
+            "items": [],
+        })
+        self.assertEqual(r.status_code, 400)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Description

Première des "petites modifs identifiées" sur l'onglet Rename. Permet à l'utilisateur de **marquer manuellement** un candidat (placeholder, divergent, minor_case) comme **OK** quand l'algorithme se trompe — typiquement les hallucinations LLM où la même suggestion est appliquée à plusieurs fichiers différents (ex: 3 chapitres d'une même encyclopédie tous suggérés "Encyclopedia of Surface and Colloid Science").

## Cas d'usage

- Tu vois un fichier classé "divergent" mais tu sais qu'il est bien nommé → tu cliques `✓ Marquer comme OK`
- Le fichier sort du bucket "divergent", entre dans "OK", arrête d'apparaître comme à traiter
- L'override **persiste** sur disque (`profile/.cache/rename-overrides.json`)
- L'override **survit aux renommages** (clé = MD5 du head du fichier, pas le rel_path)
- Annulable à tout moment via `↺ Annuler l'override`

## Backend

- `_audit_single_file` : nouveau paramètre optionnel `overrides`. Après calcul de `auto_category`, lookup `cache_key` dans les overrides → remplace la catégorie. Le candidat retourné expose maintenant `is_overridden: bool` + `auto_category: str` (toujours la catégorie algo, même quand overridée).
- Overrides chargés une seule fois en début d'audit, threadés dans le tuple de contexte → marche dans le full-rebuild ET dans le patch ciblé sans double IO.
- `set_overrides(profile, items, clear=False)` : fonction publique. Per-item best-effort, path-traversal guard, whitelist de catégories (`{"ok"}` pour le MVP). Réutilise `_patch_audit_after_renames` pour invalidation ciblée du cache.
- Persistance : JSON atomique (write `.tmp` puis rename).

## Endpoint

`POST /api/rename/override` — body `{profile, items: [{rel_path, category}], clear?: false}`.

## Frontend

- **Par candidat (col 3)** : bouton qui bascule entre `✓ Marquer comme OK` et `↺ Annuler l'override` selon l'état. Modal de confirmation explique la sémantique.
- **Bulk (barre de sélection)** : nouveau bouton `✓ Marquer OK` à côté de `Renommer (suggestion)` — applique l'override sur toute la sélection en un POST.
- **Visuel liste** : teinte verte légère sur les lignes overridées + badge `✓` à droite du nom. Tooltip affiche la catégorie auto pour mémoire.

## Limite volontaire (MVP)

Seul `ok` est une cible d'override autorisée. Re-catégoriser arbitrairement (placeholder ↔ divergent etc.) n'a pas de cas d'usage clair et brouillerait le message de l'audit. Extension triviale : éditer `_OVERRIDE_ALLOWED_CATEGORIES`.

## Tests

**12 nouveaux** :
- `TestSetOverrides` × 8 : set, clear, persistance disque, survit aux renommages, seul `ok` autorisé, path traversal refusé, items vide → 400, bulk mixed outcomes.
- `TestOverrideEndpoints` × 4 : POST set happy, POST clear, items vide → 400.

**Smoke test** sur le profil réel via curl : divergent → POST override → ok (is_overridden=true) → POST clear → divergent. OK.

**769/769** tests verts. Lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)