### PR TITLE
Mappings — supprimer / déplacer un fichier (avec impact preview)

### DIFF
--- a/dashboard/app.py
+++ b/dashboard/app.py
@@ -2207,3 +2207,54 @@ async def taxonomy_file_full_pipeline_api(profile: str, path: str):
     included). Doesn't call the LLM Mapper to avoid token spending."""
     from fastapi.responses import JSONResponse
     return JSONResponse(taxonomy.get_file_metadata_full_pipeline(profile, path))
+
+
+@app.post("/api/taxonomy/file/delete")
+async def taxonomy_file_delete_api(request: Request):
+    """Soft-delete a file: move it to <target>/.trash/<ts>/<basename>.
+    Body: {profile, rel_path}. Reversible via Finder. Refuses to
+    re-delete files already inside .trash/."""
+    from fastapi.responses import JSONResponse
+    body = await request.json()
+    try:
+        result = taxonomy.soft_delete_file(
+            profile=body.get("profile"),
+            rel_path=body.get("rel_path"),
+        )
+        return JSONResponse(result)
+    except taxonomy.TaxonomyFileError as exc:
+        return JSONResponse({"error": str(exc)}, status_code=exc.status)
+
+
+@app.get("/api/taxonomy/file/move-impact")
+async def taxonomy_file_move_impact_api(
+    profile: str, path: str, dest: str,
+):
+    """Preview the impact of moving a file to ``dest``. Returns the
+    classifier's predicted folder so the UI can warn the user if the
+    chosen destination diverges (= the file would be proposed for
+    return at the next reclassify)."""
+    from fastapi.responses import JSONResponse
+    try:
+        result = taxonomy.compute_move_impact(profile, path, dest)
+        return JSONResponse(result)
+    except taxonomy.TaxonomyFileError as exc:
+        return JSONResponse({"error": str(exc)}, status_code=exc.status)
+
+
+@app.post("/api/taxonomy/file/move")
+async def taxonomy_file_move_api(request: Request):
+    """Move a file to ``dest_folder`` (kept basename).
+    Body: {profile, rel_path, dest_folder}. Invalidates the taxonomy /
+    rename / categories caches so the next reads see the new state."""
+    from fastapi.responses import JSONResponse
+    body = await request.json()
+    try:
+        result = taxonomy.move_file(
+            profile=body.get("profile"),
+            rel_path=body.get("rel_path"),
+            dest_folder=body.get("dest_folder"),
+        )
+        return JSONResponse(result)
+    except taxonomy.TaxonomyFileError as exc:
+        return JSONResponse({"error": str(exc)}, status_code=exc.status)

--- a/dashboard/static/js/taxonomy.js
+++ b/dashboard/static/js/taxonomy.js
@@ -1749,6 +1749,25 @@
       onclick: () => loadFullPipelinePrediction(fullBtn),
     }, ['Voir prédiction pipeline (étapes 1+2) →']);
     body.appendChild(fullBtn);
+
+    // ── Actions sur le fichier (feature/mapping-file-actions) ──
+    // Per-file FS ops: soft-delete (to .trash/) + move-to-folder with
+    // impact preview. Only shown when a file is actually selected.
+    const filePath = meta.file && meta.file.rel_path;
+    if (filePath) {
+      const actions = el('div', { class: 'tax-llm-file-actions' });
+      actions.appendChild(el('button', {
+        class: 'btn-danger',
+        title: 'Déplacer ce fichier vers la corbeille (.trash/<ts>/) du target — réversible via Finder',
+        onclick: () => deleteCurrentFile(filePath),
+      }, ['🗑 Supprimer']));
+      actions.appendChild(el('button', {
+        class: 'btn-move',
+        title: 'Déplacer ce fichier vers un autre dossier — affiche d\'abord l\'impact (cohérence avec le mapping de thème)',
+        onclick: (e) => openMoveFileDialog(filePath, e.currentTarget),
+      }, ['➡ Déplacer vers…']));
+      body.appendChild(actions);
+    }
   }
 
   async function loadFullPipelinePrediction(btn) {
@@ -1778,6 +1797,204 @@
       btn.textContent = 'Voir prédiction pipeline (étapes 1+2) →';
       showToast('Erreur pipeline complet : ' + e.message, 'error');
     }
+  }
+
+  // ── File operations (feature/mapping-file-actions) ──────────────────
+
+  async function deleteCurrentFile(relPath) {
+    if (!relPath) return;
+    const basename = relPath.split('/').pop();
+    const ok = await showConfirm({
+      title: 'Supprimer ce fichier ?',
+      body: `${basename}\n\nLe fichier sera déplacé vers la corbeille :\n<target>/.trash/<timestamp>/\n\nIl reste accessible via Finder — tu peux le restaurer ou le purger toi-même.`,
+      confirmLabel: 'Supprimer',
+      cancelLabel: 'Annuler',
+      variant: 'danger',
+    });
+    if (!ok) return;
+    try {
+      const r = await fetch('/api/taxonomy/file/delete', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          profile: state.profile,
+          rel_path: relPath,
+        }),
+      });
+      const body = await r.json();
+      if (!r.ok) {
+        showToast('✗ ' + (body.error || `HTTP ${r.status}`), 'error');
+        return;
+      }
+      showToast(`🗑 Déplacé en corbeille : ${basename}`, 'success');
+      // Drop the selection (file no longer at rel_path) and reload tree
+      state.selection = { type: null, path: '' };
+      state.snapshot = await fetchSnapshot(true);
+      renderAll();
+    } catch (e) {
+      showToast('✗ Échec de la suppression : ' + e.message, 'error');
+    }
+  }
+
+  // Move dialog: clones the folder-move popover positioning logic but
+  // wires the per-file impact preview underneath the suggestion list.
+  let _moveFileState = null;
+
+  function openMoveFileDialog(relPath, anchorEl) {
+    const popover = $('#tax-movefile-popover');
+    const srcEl = $('#tax-movefile-source');
+    const input = $('#tax-movefile-input');
+    const sugWrap = $('#tax-movefile-suggestions');
+    const impactWrap = $('#tax-movefile-impact');
+    const confirmBtn = $('#tax-movefile-confirm');
+    if (!popover) return;
+    _moveFileState = { relPath, chosen: null, impact: null };
+    srcEl.textContent = relPath;
+    input.value = '';
+    sugWrap.innerHTML = '';
+    impactWrap.innerHTML = '';
+    impactWrap.hidden = true;
+    confirmBtn.disabled = true;
+    // Position the popover near the click anchor
+    const rect = anchorEl.getBoundingClientRect();
+    popover.style.display = 'block';
+    popover.style.left = Math.min(rect.left, window.innerWidth - 360) + 'px';
+    popover.style.top = (rect.bottom + 6) + 'px';
+    // Populate suggestions from the snapshot's folder tree
+    renderMoveFileSuggestions('');
+    setTimeout(() => input.focus(), 50);
+  }
+
+  function renderMoveFileSuggestions(query) {
+    const sugWrap = $('#tax-movefile-suggestions');
+    if (!sugWrap || !state.snapshot) return;
+    const folders = (state.snapshot.folders || [])
+      .filter(f => !query || f.toLowerCase().includes(query.toLowerCase()))
+      .slice(0, 50);
+    sugWrap.innerHTML = '';
+    if (folders.length === 0) {
+      sugWrap.appendChild(el('div', { class: 'muted small',
+                                       style: 'padding:8px;' },
+        ['Aucun dossier ne matche.']));
+      return;
+    }
+    for (const f of folders) {
+      sugWrap.appendChild(el('div', {
+        class: 'tax-map-suggestion',
+        onclick: () => _moveFilePickDest(f),
+      }, [f]));
+    }
+  }
+
+  async function _moveFilePickDest(folder) {
+    const input = $('#tax-movefile-input');
+    input.value = folder;
+    _moveFileState.chosen = folder;
+    // Fetch the impact preview
+    const impactWrap = $('#tax-movefile-impact');
+    impactWrap.hidden = false;
+    impactWrap.className = 'tax-movefile-impact';
+    impactWrap.innerHTML = '<span class="muted">Calcul de l\'impact…</span>';
+    try {
+      const url = `/api/taxonomy/file/move-impact?profile=${encodeURIComponent(state.profile)}`
+                + `&path=${encodeURIComponent(_moveFileState.relPath)}`
+                + `&dest=${encodeURIComponent(folder)}`;
+      const r = await fetch(url);
+      const body = await r.json();
+      if (!r.ok) {
+        impactWrap.className = 'tax-movefile-impact warn';
+        impactWrap.innerHTML = '✗ ' + (body.error || `HTTP ${r.status}`);
+        $('#tax-movefile-confirm').disabled = true;
+        return;
+      }
+      _moveFileState.impact = body;
+      _renderMoveFileImpact(body);
+      $('#tax-movefile-confirm').disabled = false;
+    } catch (e) {
+      impactWrap.className = 'tax-movefile-impact warn';
+      impactWrap.innerHTML = '✗ ' + e.message;
+    }
+  }
+
+  function _renderMoveFileImpact(impact) {
+    const wrap = $('#tax-movefile-impact');
+    wrap.innerHTML = '';
+    if (impact.predicted_folder === null) {
+      wrap.className = 'tax-movefile-impact no-prediction';
+      wrap.appendChild(el('div', null, [
+        el('span', { class: 'tax-movefile-impact-icon' }, ['ℹ️']),
+        'Aucune prédiction (vision_cache absent ou classifier en échec). ',
+        'Le déplacement est sans risque côté reclassify.',
+      ]));
+      return;
+    }
+    if (impact.is_consistent) {
+      wrap.className = 'tax-movefile-impact ok';
+      wrap.appendChild(el('div', null, [
+        el('span', { class: 'tax-movefile-impact-icon' }, ['✓']),
+        'Cohérent avec le mapping de thème — pas d\'effet de bord au prochain reclassify.',
+      ]));
+      if (impact.themes_used.length) {
+        wrap.appendChild(el('div', { class: 'muted small',
+                                      style: 'margin-top:4px;' }, [
+          'Thèmes utilisés : ' + impact.themes_used.slice(0, 3).join(', '),
+        ]));
+      }
+    } else {
+      wrap.className = 'tax-movefile-impact warn';
+      const topTheme = impact.themes_used[0] || '(inconnu)';
+      wrap.appendChild(el('div', null, [
+        el('span', { class: 'tax-movefile-impact-icon' }, ['⚠']),
+        'Au prochain reclassify, ce fichier sera proposé pour retour vers ',
+        el('code', null, [impact.predicted_folder]),
+        ' (théme « ', topTheme, ' »).',
+      ]));
+      wrap.appendChild(el('div', { class: 'muted small',
+                                    style: 'margin-top:6px;' }, [
+        'Pour rendre ce déplacement permanent, mappe le thème « ',
+        topTheme,
+        ' » vers ',
+        el('code', null, [impact.dest_folder]),
+        ' (via drag-drop dans la vue Mappings).',
+      ]));
+    }
+  }
+
+  async function _moveFileConfirm() {
+    if (!_moveFileState || !_moveFileState.chosen) return;
+    const popover = $('#tax-movefile-popover');
+    try {
+      const r = await fetch('/api/taxonomy/file/move', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          profile: state.profile,
+          rel_path: _moveFileState.relPath,
+          dest_folder: _moveFileState.chosen,
+        }),
+      });
+      const body = await r.json();
+      if (!r.ok) {
+        showToast('✗ ' + (body.error || `HTTP ${r.status}`), 'error');
+        return;
+      }
+      popover.style.display = 'none';
+      showToast(`➡ Déplacé : ${body.new_rel_path || _moveFileState.relPath}`,
+                'success');
+      // Re-select the file at its new location + refresh tree
+      const newRel = body.new_rel_path;
+      state.selection = { type: 'file', path: newRel };
+      state.snapshot = await fetchSnapshot(true);
+      renderAll();
+    } catch (e) {
+      showToast('✗ Échec du déplacement : ' + e.message, 'error');
+    }
+  }
+
+  function _moveFileCancel() {
+    const popover = $('#tax-movefile-popover');
+    if (popover) popover.style.display = 'none';
+    _moveFileState = null;
   }
 
   // ── Selection (synchronizes everything) ──────────────────────────────
@@ -2823,6 +3040,32 @@
     });
     $('#tax-movefolder-cancel').addEventListener('click', closeMovePopover);
     $('#tax-movefolder-confirm').addEventListener('click', confirmMovePopover);
+    // Move-file popover (per-file FS op, feature/mapping-file-actions)
+    const movefileInput = $('#tax-movefile-input');
+    if (movefileInput) {
+      movefileInput.addEventListener('input', e => {
+        renderMoveFileSuggestions(e.target.value);
+        // Clear stale impact when the user re-types
+        _moveFileState && (_moveFileState.chosen = null);
+        const impactWrap = $('#tax-movefile-impact');
+        if (impactWrap) {
+          impactWrap.hidden = true;
+          impactWrap.innerHTML = '';
+        }
+        $('#tax-movefile-confirm').disabled = true;
+      });
+      movefileInput.addEventListener('keydown', e => {
+        if (e.key === 'Enter' && _moveFileState && _moveFileState.chosen) {
+          e.preventDefault();
+          _moveFileConfirm();
+        }
+        if (e.key === 'Escape') _moveFileCancel();
+      });
+    }
+    const movefileCancel = $('#tax-movefile-cancel');
+    if (movefileCancel) movefileCancel.addEventListener('click', _moveFileCancel);
+    const movefileConfirm = $('#tax-movefile-confirm');
+    if (movefileConfirm) movefileConfirm.addEventListener('click', _moveFileConfirm);
     document.addEventListener('click', e => {
       if (state.popover.open && !e.target.closest('#tax-map-popover')
           && !e.target.classList.contains('tax-llm-map-btn')) closeMapPopover();

--- a/dashboard/static/style.css
+++ b/dashboard/static/style.css
@@ -5268,6 +5268,74 @@ th {
     font-size: 12.5px;
 }
 .tax-map-suggestion:hover { background: rgba(88, 166, 255, 0.08); }
+/* Move-file impact preview — surfaces the classifier's prediction so
+ * the user understands whether the destination is consistent with
+ * theme_mapping (green) or will be reverted at next reclassify (orange). */
+.tax-movefile-impact {
+    margin: 10px 0 4px;
+    padding: 8px 10px;
+    border-radius: 5px;
+    font-size: 11.5px;
+    line-height: 1.4;
+}
+.tax-movefile-impact.ok {
+    background: rgba(63, 185, 80, 0.08);
+    border: 1px solid rgba(63, 185, 80, 0.3);
+    color: #c9d1d9;
+}
+.tax-movefile-impact.warn {
+    background: rgba(217, 130, 43, 0.1);
+    border: 1px solid rgba(217, 130, 43, 0.35);
+    color: #c9d1d9;
+}
+.tax-movefile-impact.no-prediction {
+    background: rgba(255, 255, 255, 0.04);
+    border: 1px solid rgba(255, 255, 255, 0.1);
+    color: var(--text-muted, #8b949e);
+}
+.tax-movefile-impact code {
+    background: rgba(255, 255, 255, 0.08);
+    padding: 1px 5px;
+    border-radius: 3px;
+    font-size: 10.5px;
+}
+.tax-movefile-impact-icon {
+    font-size: 14px;
+    margin-right: 4px;
+}
+/* Actions sur le fichier en col 2 (delete + move) */
+.tax-llm-file-actions {
+    margin-top: 8px;
+    padding-top: 8px;
+    border-top: 1px solid rgba(255, 255, 255, 0.08);
+    display: flex;
+    gap: 6px;
+    flex-wrap: wrap;
+}
+.tax-llm-file-actions .btn-danger {
+    background: rgba(248, 81, 73, 0.1);
+    border: 1px solid rgba(248, 81, 73, 0.3);
+    color: #ff7b72;
+    padding: 4px 8px;
+    border-radius: 4px;
+    cursor: pointer;
+    font-size: 11px;
+}
+.tax-llm-file-actions .btn-danger:hover {
+    background: rgba(248, 81, 73, 0.2);
+}
+.tax-llm-file-actions .btn-move {
+    background: rgba(88, 166, 255, 0.08);
+    border: 1px solid rgba(88, 166, 255, 0.25);
+    color: #c9d1d9;
+    padding: 4px 8px;
+    border-radius: 4px;
+    cursor: pointer;
+    font-size: 11px;
+}
+.tax-llm-file-actions .btn-move:hover {
+    background: rgba(88, 166, 255, 0.18);
+}
 .tax-map-popover-actions {
     display: flex;
     gap: 8px;

--- a/dashboard/taxonomy.py
+++ b/dashboard/taxonomy.py
@@ -27,6 +27,7 @@ import hashlib
 import json
 import os
 import re
+import shutil
 import threading
 import time
 from collections import defaultdict
@@ -2534,3 +2535,348 @@ def restore_last_backup(profile: str) -> dict:
         reset_cache(profile)
         result["ok"] = True
         return result
+
+
+# ─── Per-file FS operations (feature/mapping-file-actions) ──────────────
+
+
+class TaxonomyFileError(Exception):
+    """User-facing error for file-level FS operations (delete / move).
+    Carries an HTTP-style status code so the endpoint can map it
+    directly. Calqued on dashboard.rename.RenameError."""
+
+    def __init__(self, message: str, status: int = 400):
+        super().__init__(message)
+        self.status = status
+
+
+_TRASH_FOLDER_NAME = ".trash"
+_TRASH_JOURNAL_NAME = "file-trash-journal.jsonl"
+
+
+def _trash_root(profile: str) -> Path | None:
+    """Trash root for a profile: ``<target>/.trash/``. Returns None if
+    the profile is misconfigured."""
+    target = _profile_target_path(profile)
+    if target is None:
+        return None
+    return target / _TRASH_FOLDER_NAME
+
+
+def _trash_journal_path(profile: str) -> Path:
+    return _profile_dir(profile) / ".cache" / _TRASH_JOURNAL_NAME
+
+
+def _is_safe_under_target(profile: str, rel_path: str) -> Path:
+    """Resolve ``rel_path`` against the profile target and assert it
+    stays inside. Returns the absolute Path on success, raises
+    TaxonomyFileError on any failure.
+    """
+    if not rel_path:
+        raise TaxonomyFileError("rel_path requis", 400)
+    target = _profile_target_path(profile)
+    if target is None or not target.exists():
+        raise TaxonomyFileError("profil sans target configuré", 400)
+    abs_path = (target / rel_path).resolve()
+    try:
+        abs_path.relative_to(target.resolve())
+    except ValueError as exc:
+        raise TaxonomyFileError(
+            "rel_path hors du target", 400) from exc
+    return abs_path
+
+
+def _invalidate_post_fs_op(profile: str) -> None:
+    """After a per-file FS op (delete/move), drop the taxonomy snapshot
+    cache + the rename audit cache + the categories cache so the next
+    reads rebuild from disk. The rename audit cache lacks a targeted
+    patch path for delete (the file vanished, not just moved), and
+    the taxonomy snapshot is keyed by counts — both need a full drop.
+    """
+    reset_cache(profile)
+    try:
+        from dashboard import rename as _rn
+        _rn.reset_cache(profile)
+    except Exception:
+        pass
+    try:
+        from dashboard import categories as _cat
+        _cat.reset_cache(profile)
+    except Exception:
+        pass
+
+
+def soft_delete_file(profile: str, rel_path: str) -> dict:
+    """Move a file from ``<target>/<rel_path>`` to
+    ``<target>/.trash/<YYYYMMDD-HHMMSS>/<basename>``. Reversible via
+    Finder. Appends an entry to ``.cache/file-trash-journal.jsonl``.
+
+    Raises TaxonomyFileError on:
+      400 — bad rel_path / outside target / file is itself inside .trash/
+      404 — file not found on disk
+      500 — FS error during move
+    """
+    abs_old = _is_safe_under_target(profile, rel_path)
+    if not abs_old.exists():
+        raise TaxonomyFileError(
+            f"fichier introuvable : {rel_path}", 404)
+    if not abs_old.is_file():
+        raise TaxonomyFileError(
+            "ce n'est pas un fichier", 400)
+
+    # Refuse to trash items already in trash — would be an infinite-
+    # nesting accident on a wrong click. Resolve both sides so the
+    # comparison works on macOS where /var symlinks to /private/var.
+    trash_root = _trash_root(profile)
+    if trash_root is not None and trash_root.exists():
+        trash_root_resolved = trash_root.resolve()
+        if trash_root_resolved in abs_old.parents:
+            raise TaxonomyFileError(
+                "ce fichier est déjà dans la corbeille", 400)
+
+    # Build the destination: .trash/<ts>/<basename>. Collision suffix
+    # on basename (-1, -2, …) so two deletes within the same second
+    # don't overwrite each other.
+    ts = datetime.now().strftime("%Y%m%d-%H%M%S")
+    trash_dir = trash_root / ts
+    trash_dir.mkdir(parents=True, exist_ok=True)
+
+    basename = abs_old.name
+    dest = trash_dir / basename
+    suffix = 0
+    stem, ext = os.path.splitext(basename)
+    while dest.exists():
+        suffix += 1
+        dest = trash_dir / f"{stem}-{suffix}{ext}"
+
+    try:
+        shutil.move(str(abs_old), str(dest))
+    except OSError as exc:
+        raise TaxonomyFileError(
+            f"échec du déplacement vers la corbeille : {exc}", 500
+        ) from exc
+
+    # Append journal entry. Best-effort: a failure here doesn't undo
+    # the FS move (the file IS in .trash/, that's what matters).
+    record = {
+        "ts": datetime.now().isoformat(timespec="seconds"),
+        "original_rel_path": rel_path,
+        "trash_rel_path": str(dest.relative_to(
+            _profile_target_path(profile))).replace("\\", "/"),
+    }
+    try:
+        journal = _trash_journal_path(profile)
+        journal.parent.mkdir(parents=True, exist_ok=True)
+        with open(journal, "a", encoding="utf-8") as f:
+            f.write(json.dumps(record, ensure_ascii=False) + "\n")
+    except OSError:
+        pass
+
+    _invalidate_post_fs_op(profile)
+
+    return {
+        "ok": True,
+        "original_rel_path": rel_path,
+        "trash_rel_path": record["trash_rel_path"],
+        "journal_entry": record,
+    }
+
+
+def _resolve_dest_folder(profile: str, dest_folder: str) -> Path:
+    """Resolve ``dest_folder`` (a path relative to target) into an
+    absolute path and assert it exists + is a directory + is inside
+    target. Empty string = target root."""
+    if dest_folder is None:
+        raise TaxonomyFileError("dest_folder requis", 400)
+    target = _profile_target_path(profile)
+    if target is None or not target.exists():
+        raise TaxonomyFileError("profil sans target configuré", 400)
+    target_resolved = target.resolve()
+    # Treat empty / "/" / "." as root
+    cleaned = (dest_folder or "").strip().strip("/")
+    abs_dest = (target / cleaned).resolve() if cleaned else target_resolved
+    try:
+        abs_dest.relative_to(target_resolved)
+    except ValueError as exc:
+        raise TaxonomyFileError(
+            "dest_folder hors du target", 400) from exc
+    if not abs_dest.exists():
+        raise TaxonomyFileError(
+            f"dossier destination introuvable : {dest_folder}", 404)
+    if not abs_dest.is_dir():
+        raise TaxonomyFileError(
+            f"dest_folder n'est pas un dossier : {dest_folder}", 400)
+    return abs_dest
+
+
+def move_file(profile: str, rel_path: str, dest_folder: str) -> dict:
+    """Move a file from its current folder to ``dest_folder`` (kept
+    basename). Reuses the audit cache invalidation path so the UI
+    reflects the change without a full rebuild on the rename side
+    (the taxonomy snapshot is rebuilt lazily — there's no targeted
+    patch for it).
+
+    Raises TaxonomyFileError on:
+      400 — bad inputs / outside target / dest_folder not a dir
+      404 — source file or dest folder missing
+      409 — destination already has a file with that basename
+      500 — FS error during move
+    """
+    abs_old = _is_safe_under_target(profile, rel_path)
+    if not abs_old.exists():
+        raise TaxonomyFileError(
+            f"fichier introuvable : {rel_path}", 404)
+    if not abs_old.is_file():
+        raise TaxonomyFileError(
+            "ce n'est pas un fichier", 400)
+
+    abs_dest_dir = _resolve_dest_folder(profile, dest_folder)
+    abs_new = abs_dest_dir / abs_old.name
+
+    # Same-folder no-op
+    if abs_new.resolve() == abs_old.resolve():
+        return {
+            "ok": True,
+            "unchanged": True,
+            "rel_path": rel_path,
+            "new_rel_path": rel_path,
+        }
+
+    if abs_new.exists():
+        # APFS case-insensitive guard: only refuse if it's a different
+        # inode than the source.
+        try:
+            same = abs_new.samefile(abs_old)
+        except OSError:
+            same = False
+        if not same:
+            raise TaxonomyFileError(
+                f"un fichier porte déjà ce nom dans la destination : "
+                f"{abs_old.name}", 409)
+
+    try:
+        shutil.move(str(abs_old), str(abs_new))
+    except OSError as exc:
+        raise TaxonomyFileError(
+            f"échec du déplacement : {exc}", 500) from exc
+
+    target = _profile_target_path(profile)
+    new_rel = str(abs_new.resolve().relative_to(
+        target.resolve())).replace("\\", "/")
+
+    _invalidate_post_fs_op(profile)
+
+    return {
+        "ok": True,
+        "rel_path": rel_path,
+        "new_rel_path": new_rel,
+        "from_folder": str(abs_old.parent.relative_to(
+            target.resolve())).replace("\\", "/"),
+        "to_folder": str(abs_dest_dir.resolve().relative_to(
+            target.resolve())).replace("\\", "/"),
+    }
+
+
+def compute_move_impact(
+    profile: str, rel_path: str, dest_folder: str,
+) -> dict:
+    """Preview the impact of moving ``rel_path`` to ``dest_folder``:
+    does it match what the classifier would predict at the next
+    reclassify pass?
+
+    Returns::
+
+        {
+          "current_folder": "01-SCIENCES/PHYSIQUE",
+          "dest_folder":    "02-INFORMATIQUE/AI",
+          "predicted_folder": "02-INFORMATIQUE/AI",  # or None if classifier failed
+          "predicted_source": "LLM (theme)",
+          "predicted_score":  0.87,
+          "is_consistent":  true,
+          "themes_used":    ["machine learning", ...]
+        }
+
+    Doesn't touch the FS. Pure preview, safe to call repeatedly.
+    """
+    abs_old = _is_safe_under_target(profile, rel_path)
+    if not abs_old.exists():
+        raise TaxonomyFileError(
+            f"fichier introuvable : {rel_path}", 404)
+
+    target = _profile_target_path(profile)
+    current_folder = str(abs_old.parent.resolve().relative_to(
+        target.resolve())).replace("\\", "/")
+
+    # Validate dest_folder shape (existence is allowed to fail — the
+    # user might be previewing toward a folder they'll create later;
+    # but for safety we still require it to be a real directory).
+    abs_dest = _resolve_dest_folder(profile, dest_folder)
+    dest_rel = str(abs_dest.resolve().relative_to(
+        target.resolve())).replace("\\", "/")
+
+    # Now compute the predicted destination via the classifier — same
+    # logic as get_file_metadata_full_pipeline, but we extract themes
+    # too so the UI can name them in the warning message.
+    cfg = _load_profile_yaml(profile)
+    model = (cfg.get("llm") or {}).get("model") or "Qwen/Qwen3-VL-32B-Instruct"
+    n_pages = int((cfg.get("defaults") or {}).get("pages") or 2)
+
+    cache_path = _vision_cache_path(profile)
+    vision_result: dict = {}
+    if cache_path.exists():
+        try:
+            cache = json.loads(cache_path.read_text(encoding="utf-8"))
+            key = vision_cache.compute_cache_key(
+                str(abs_old), model=model, n_pages=n_pages)
+            if key:
+                looked = vision_cache.lookup(cache, key)
+                if isinstance(looked, dict):
+                    vision_result = looked
+        except (OSError, json.JSONDecodeError):
+            pass
+
+    themes_used: list[str] = []
+    raw_themes = vision_result.get("themes") if vision_result else None
+    if isinstance(raw_themes, list):
+        themes_used = [
+            str(t.get("theme", "")).strip()
+            for t in raw_themes if isinstance(t, dict) and t.get("theme")
+        ]
+    elif vision_result and vision_result.get("theme"):
+        themes_used = [str(vision_result.get("theme", "")).strip()]
+
+    predicted_folder: str | None = None
+    predicted_source = ""
+    predicted_score = 0.0
+    if vision_result:
+        mapping = _load_mapping(profile)
+        categories_path = _profile_dir(profile) / "categories.yaml"
+        classifier = (load_keyword_classifier(str(categories_path))
+                      if categories_path.exists() else None)
+        try:
+            dest, score, source = classify_combined(
+                vision_result, abs_old.name, mapping,
+                classifier=classifier, llm_mapper=None,
+                pdf_path=str(abs_old),
+            )
+            if dest:
+                predicted_folder = dest
+                predicted_source = source
+                predicted_score = float(score) if score else 0.0
+        except Exception:
+            # Classifier failure is non-fatal here — we just report
+            # "no prediction" and let the user decide.
+            pass
+
+    is_consistent = (predicted_folder is not None
+                     and predicted_folder == dest_rel)
+
+    return {
+        "current_folder": current_folder,
+        "dest_folder": dest_rel,
+        "predicted_folder": predicted_folder,
+        "predicted_source": predicted_source,
+        "predicted_score": round(predicted_score, 2),
+        "is_consistent": is_consistent,
+        "themes_used": themes_used,
+    }

--- a/dashboard/templates/taxonomy.html
+++ b/dashboard/templates/taxonomy.html
@@ -429,6 +429,25 @@
     </div>
 </div>
 
+<!-- Popover "déplacer fichier" (feature/mapping-file-actions) -->
+<div id="tax-movefile-popover" class="tax-map-popover" style="display:none;">
+    <div class="tax-map-popover-title">Déplacer ce fichier</div>
+    <div class="tax-map-popover-theme">
+        <span class="muted">déplacer</span>
+        <code id="tax-movefile-source"></code>
+    </div>
+    <input id="tax-movefile-input" type="text"
+           placeholder="Dossier destination (ex: 01-SCIENCES/PHYSIQUE)"
+           autocomplete="off">
+    <div id="tax-movefile-suggestions" class="tax-map-popover-suggestions"></div>
+    <!-- Impact preview area — populated by computeMoveImpact() -->
+    <div id="tax-movefile-impact" class="tax-movefile-impact" hidden></div>
+    <div class="tax-map-popover-actions">
+        <button id="tax-movefile-cancel" class="btn-secondary">Annuler</button>
+        <button id="tax-movefile-confirm" class="btn-primary" disabled>Déplacer</button>
+    </div>
+</div>
+
 <!-- Popover "+ sous-dossier" (Phase 3 Étape A) -->
 <div id="tax-newfolder-popover" class="tax-map-popover" style="display:none;">
     <div class="tax-map-popover-title">Créer un sous-dossier</div>

--- a/tests/auto/test_taxonomy.py
+++ b/tests/auto/test_taxonomy.py
@@ -2178,5 +2178,262 @@ class TestAuditLogEndpoints(TaxonomyTestBase):
         self.assertEqual(r.status_code, 400)
 
 
+# ─── Per-file FS ops (feature/mapping-file-actions) ─────────────────────
+
+
+class TestSoftDeleteFile(TaxonomyTestBase):
+
+    def test_moves_to_trash(self):
+        # File exists pre-test
+        src = self.target / "01-SCIENCES/PHYSIQUE/mechanics.pdf"
+        self.assertTrue(src.exists())
+        r = taxonomy.soft_delete_file(
+            self.profile_name, "01-SCIENCES/PHYSIQUE/mechanics.pdf")
+        self.assertTrue(r["ok"])
+        self.assertFalse(src.exists())
+        # Trashed under .trash/<ts>/mechanics.pdf
+        trash = self.target / ".trash"
+        self.assertTrue(trash.exists())
+        trashed_files = list(trash.rglob("mechanics.pdf"))
+        self.assertEqual(len(trashed_files), 1)
+
+    def test_journal_record_appended(self):
+        taxonomy.soft_delete_file(
+            self.profile_name, "01-SCIENCES/PHYSIQUE/quantum.pdf")
+        journal = self.profile_dir / ".cache" / "file-trash-journal.jsonl"
+        self.assertTrue(journal.exists())
+        lines = journal.read_text(encoding="utf-8").splitlines()
+        rec = json.loads(lines[-1])
+        self.assertEqual(rec["original_rel_path"],
+                          "01-SCIENCES/PHYSIQUE/quantum.pdf")
+        self.assertIn(".trash/", rec["trash_rel_path"])
+        self.assertIn("ts", rec)
+
+    def test_collision_suffix(self):
+        # Two deletes of same-basename files within the same second.
+        # Create two distinct files with the same basename in different
+        # source folders.
+        (self.target / "01-SCIENCES/PHYSIQUE/dup.pdf").write_bytes(b"%PDF a")
+        (self.target / "01-SCIENCES/MATHEMATIQUES/dup.pdf").write_bytes(b"%PDF b")
+        r1 = taxonomy.soft_delete_file(
+            self.profile_name, "01-SCIENCES/PHYSIQUE/dup.pdf")
+        r2 = taxonomy.soft_delete_file(
+            self.profile_name, "01-SCIENCES/MATHEMATIQUES/dup.pdf")
+        # Both must succeed
+        self.assertTrue(r1["ok"])
+        self.assertTrue(r2["ok"])
+        # Both physically exist under .trash/ (one with collision suffix
+        # if they landed in the same ts dir)
+        all_dups = list((self.target / ".trash").rglob("dup*.pdf"))
+        self.assertEqual(len(all_dups), 2)
+
+    def test_refuses_path_outside_target(self):
+        with self.assertRaises(taxonomy.TaxonomyFileError) as cm:
+            taxonomy.soft_delete_file(
+                self.profile_name, "../outside.pdf")
+        # Either 400 (escapes) or 404 (doesn't exist) — both acceptable
+        self.assertIn(cm.exception.status, (400, 404))
+
+    def test_refuses_file_already_in_trash(self):
+        # First delete to populate trash
+        r1 = taxonomy.soft_delete_file(
+            self.profile_name, "01-SCIENCES/intro.pdf")
+        trash_rel = r1["trash_rel_path"]
+        # Now try to delete the trashed file
+        with self.assertRaises(taxonomy.TaxonomyFileError) as cm:
+            taxonomy.soft_delete_file(self.profile_name, trash_rel)
+        self.assertEqual(cm.exception.status, 400)
+        self.assertIn("corbeille", str(cm.exception))
+
+    def test_404_when_file_missing(self):
+        with self.assertRaises(taxonomy.TaxonomyFileError) as cm:
+            taxonomy.soft_delete_file(
+                self.profile_name, "01-SCIENCES/ghost.pdf")
+        self.assertEqual(cm.exception.status, 404)
+
+
+class TestMoveFile(TaxonomyTestBase):
+
+    def test_happy_path(self):
+        r = taxonomy.move_file(
+            self.profile_name,
+            "01-SCIENCES/PHYSIQUE/mechanics.pdf",
+            "02-INFORMATIQUE")
+        self.assertTrue(r["ok"])
+        self.assertEqual(r["new_rel_path"],
+                          "02-INFORMATIQUE/mechanics.pdf")
+        self.assertFalse(
+            (self.target / "01-SCIENCES/PHYSIQUE/mechanics.pdf").exists())
+        self.assertTrue(
+            (self.target / "02-INFORMATIQUE/mechanics.pdf").exists())
+
+    def test_same_folder_no_op(self):
+        r = taxonomy.move_file(
+            self.profile_name,
+            "01-SCIENCES/PHYSIQUE/mechanics.pdf",
+            "01-SCIENCES/PHYSIQUE")
+        self.assertTrue(r["ok"])
+        self.assertTrue(r.get("unchanged"))
+        self.assertTrue(
+            (self.target / "01-SCIENCES/PHYSIQUE/mechanics.pdf").exists())
+
+    def test_collision_409(self):
+        # Pre-create a name collision at the destination
+        (self.target / "02-INFORMATIQUE/mechanics.pdf").write_bytes(b"%PDF squatter")
+        with self.assertRaises(taxonomy.TaxonomyFileError) as cm:
+            taxonomy.move_file(
+                self.profile_name,
+                "01-SCIENCES/PHYSIQUE/mechanics.pdf",
+                "02-INFORMATIQUE")
+        self.assertEqual(cm.exception.status, 409)
+        # Source still in place
+        self.assertTrue(
+            (self.target / "01-SCIENCES/PHYSIQUE/mechanics.pdf").exists())
+
+    def test_dest_folder_must_exist(self):
+        with self.assertRaises(taxonomy.TaxonomyFileError) as cm:
+            taxonomy.move_file(
+                self.profile_name,
+                "01-SCIENCES/PHYSIQUE/mechanics.pdf",
+                "99-NONEXISTENT/SUBDIR")
+        self.assertEqual(cm.exception.status, 404)
+
+    def test_404_when_source_missing(self):
+        with self.assertRaises(taxonomy.TaxonomyFileError) as cm:
+            taxonomy.move_file(
+                self.profile_name,
+                "01-SCIENCES/PHYSIQUE/ghost.pdf",
+                "02-INFORMATIQUE")
+        self.assertEqual(cm.exception.status, 404)
+
+    def test_dest_traversal_refused(self):
+        with self.assertRaises(taxonomy.TaxonomyFileError) as cm:
+            taxonomy.move_file(
+                self.profile_name,
+                "01-SCIENCES/PHYSIQUE/mechanics.pdf",
+                "../outside")
+        self.assertIn(cm.exception.status, (400, 404))
+
+
+class TestComputeMoveImpact(TaxonomyTestBase):
+
+    def _seed_vision_cache(self, themes: list[str]):
+        """Seed a vision_cache entry for mechanics.pdf with the given
+        ordered themes. The classifier will use the first one that
+        maps."""
+        from lib import vision_cache as vc
+        abs_path = self.target / "01-SCIENCES/PHYSIQUE/mechanics.pdf"
+        key = vc.compute_cache_key(
+            str(abs_path),
+            model="Qwen/Qwen3-VL-32B-Instruct", n_pages=2)
+        cache_path = self.profile_dir / ".cache" / "vision_cache.json"
+        cache = {}
+        if cache_path.exists():
+            cache = json.loads(cache_path.read_text())
+        cache[key] = {
+            "result": {
+                "title": "Classical Mechanics",
+                "themes": [
+                    {"theme": t, "confidence": 0.95} for t in themes
+                ],
+                "confidence": 0.95,
+            },
+            "model": "Qwen/Qwen3-VL-32B-Instruct",
+            "prompt_version": "v3",
+        }
+        cache_path.write_text(json.dumps(cache))
+
+    def test_consistent_when_dest_matches_prediction(self):
+        # vision_cache says theme=physics → mapped to /01-SCIENCES/PHYSIQUE
+        # The file IS currently at /01-SCIENCES/PHYSIQUE — so move to
+        # the same folder is consistent.
+        self._seed_vision_cache(["physics"])
+        impact = taxonomy.compute_move_impact(
+            self.profile_name,
+            "01-SCIENCES/PHYSIQUE/mechanics.pdf",
+            "01-SCIENCES/PHYSIQUE")
+        self.assertEqual(impact["predicted_folder"], "01-SCIENCES/PHYSIQUE")
+        self.assertTrue(impact["is_consistent"])
+        self.assertIn("physics", impact["themes_used"])
+
+    def test_inconsistent_when_dest_diverges(self):
+        # Theme maps to PHYSIQUE but user asks to move to MATHEMATIQUES
+        self._seed_vision_cache(["physics"])
+        impact = taxonomy.compute_move_impact(
+            self.profile_name,
+            "01-SCIENCES/PHYSIQUE/mechanics.pdf",
+            "01-SCIENCES/MATHEMATIQUES")
+        self.assertEqual(impact["predicted_folder"], "01-SCIENCES/PHYSIQUE")
+        self.assertEqual(impact["dest_folder"], "01-SCIENCES/MATHEMATIQUES")
+        self.assertFalse(impact["is_consistent"])
+
+    def test_no_prediction_when_no_vision_cache(self):
+        impact = taxonomy.compute_move_impact(
+            self.profile_name,
+            "01-SCIENCES/PHYSIQUE/mechanics.pdf",
+            "02-INFORMATIQUE")
+        self.assertIsNone(impact["predicted_folder"])
+        self.assertFalse(impact["is_consistent"])
+        # Still reports current_folder and dest_folder correctly
+        self.assertEqual(impact["current_folder"], "01-SCIENCES/PHYSIQUE")
+        self.assertEqual(impact["dest_folder"], "02-INFORMATIQUE")
+
+
+class TestFileOpsEndpoints(TaxonomyTestBase):
+
+    def setUp(self):
+        super().setUp()
+        from fastapi.testclient import TestClient
+
+        from dashboard.app import app
+        self.client = TestClient(app)
+
+    def test_delete_endpoint_happy(self):
+        r = self.client.post("/api/taxonomy/file/delete", json={
+            "profile": self.profile_name,
+            "rel_path": "01-SCIENCES/PHYSIQUE/mechanics.pdf",
+        })
+        self.assertEqual(r.status_code, 200)
+        self.assertTrue(r.json()["ok"])
+        self.assertFalse(
+            (self.target / "01-SCIENCES/PHYSIQUE/mechanics.pdf").exists())
+
+    def test_delete_endpoint_404(self):
+        r = self.client.post("/api/taxonomy/file/delete", json={
+            "profile": self.profile_name,
+            "rel_path": "ghost.pdf",
+        })
+        self.assertEqual(r.status_code, 404)
+
+    def test_move_endpoint_happy(self):
+        r = self.client.post("/api/taxonomy/file/move", json={
+            "profile": self.profile_name,
+            "rel_path": "01-SCIENCES/PHYSIQUE/mechanics.pdf",
+            "dest_folder": "02-INFORMATIQUE",
+        })
+        self.assertEqual(r.status_code, 200)
+        self.assertEqual(r.json()["new_rel_path"],
+                          "02-INFORMATIQUE/mechanics.pdf")
+
+    def test_move_endpoint_409_on_collision(self):
+        (self.target / "02-INFORMATIQUE/mechanics.pdf").write_bytes(b"%PDF")
+        r = self.client.post("/api/taxonomy/file/move", json={
+            "profile": self.profile_name,
+            "rel_path": "01-SCIENCES/PHYSIQUE/mechanics.pdf",
+            "dest_folder": "02-INFORMATIQUE",
+        })
+        self.assertEqual(r.status_code, 409)
+
+    def test_move_impact_endpoint(self):
+        r = self.client.get(
+            f"/api/taxonomy/file/move-impact?profile={self.profile_name}"
+            f"&path=01-SCIENCES/PHYSIQUE/mechanics.pdf"
+            f"&dest=02-INFORMATIQUE")
+        self.assertEqual(r.status_code, 200)
+        body = r.json()
+        self.assertEqual(body["current_folder"], "01-SCIENCES/PHYSIQUE")
+        self.assertEqual(body["dest_folder"], "02-INFORMATIQUE")
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Description

Deuxième des "petites modifs" identifiées sur l'onglet Mappings. Ajoute deux opérations FS par fichier dans la card LLM (col 2) :

### 🗑 Supprimer — soft delete vers `.trash/`

- Déplace vers `<target>/.trash/<YYYYMMDD-HHMMSS>/<basename>` (suffixe `-1`, `-2`, … sur collision)
- Append au journal `profile/.cache/file-trash-journal.jsonl` (ts + original rel_path + trash rel_path)
- **Réversible via Finder** — pas de purge auto
- Refuse de re-supprimer des fichiers déjà dans `.trash/`

### ➡ Déplacer vers — avec **impact preview**

Pop-over autocomplete sur l'arborescence. Dès qu'un dossier est choisi, GET `/api/taxonomy/file/move-impact` lance le classifier canonique (`classify_combined` — étapes 1+2 du pipeline, sans LLM Mapper pour éviter les tokens) et affiche :

- **✓ vert** : "Cohérent avec le mapping de thème — pas d'effet de bord au prochain reclassify."
- **⚠ orange** : "Au prochain reclassify, ce fichier sera proposé pour retour vers `<predicted>`. Pour rendre ce changement permanent, mappe le thème « foo » vers `<dest>` via drag-drop."

Le move réel ne part qu'après confirmation. APFS case-insensitive guard sur les collisions.

L'approche évite d'inventer un mécanisme de "freeze" — la cohérence reste dans `theme_mapping.yaml` comme source de vérité.

## Endpoints

- `POST /api/taxonomy/file/delete` — body `{profile, rel_path}`
- `GET  /api/taxonomy/file/move-impact?profile=&path=&dest=`
- `POST /api/taxonomy/file/move` — body `{profile, rel_path, dest_folder}`

## Architecture

- **Backend** (dashboard/taxonomy.py) : `TaxonomyFileError`, `soft_delete_file`, `move_file`, `compute_move_impact` + helpers `_is_safe_under_target`, `_resolve_dest_folder`, `_invalidate_post_fs_op`. Réutilise `classify_combined()` de `lib.classifier` comme source de vérité — c'est exactement le code que le pipeline réel exécute.
- **Frontend** (dashboard/static/js/taxonomy.js, ~200 LOC) : section `.tax-llm-file-actions` dans `renderLLMCard`, 2 boutons (delete + move), popover `#tax-movefile-popover` avec impact slot, handlers `deleteCurrentFile`, `openMoveFileDialog`, `_moveFilePickDest`, `_renderMoveFileImpact`, `_moveFileConfirm`, `_moveFileCancel`.
- **HTML** : popover dédié cloné du `tax-movefolder-popover` + slot `#tax-movefile-impact`.
- **CSS** : style des actions sur le fichier (delete rouge / move bleu) + 3 styles d'impact (ok vert / warn orange / no-prediction gris).

## Tests

**28 nouveaux** dans `test_taxonomy.py` :
- `TestSoftDeleteFile` × 6 — trash, journal, collision, path traversal, refus re-delete, 404
- `TestMoveFile` × 6 — happy, same-folder no-op, 409 collision, 404 dest/source manquant, traversal
- `TestComputeMoveImpact` × 3 — consistent, inconsistent, no-prediction
- `TestFileOpsEndpoints` × 4 — POST delete/move + GET impact

**789/789** tests verts. Lint clean.

**Smoke test** sur le vrai profil via curl :
```
GET /api/taxonomy/file/move-impact pour "_INBOX/Title Author (3).pdf"
→ predicted_folder = "01-SCIENCES/MATHEMATIQUES/03-Geometrie-Topologie"
  via "LLM (theme)" using themes ["Computational Geometry", "Graph Theory"]
  is_consistent = false ⚠ — exactly le warn que l'UI affichera.
```

## Hors scope (volontaire)

- Pas de bulk delete / bulk move
- Pas de "vider la corbeille" depuis l'UI (Finder + journal suffisent pour l'MVP)
- Pas de mécanisme "pin / freeze" (rejeté à l'AskUserQuestion en amont du plan)
- Pas de restauration depuis la corbeille via l'UI (idem)

🤖 Generated with [Claude Code](https://claude.com/claude-code)