### PR TITLE
Mappings — bouton 🗑 inline sur chaque ligne fichier du tree

### DIFF
--- a/dashboard/static/js/taxonomy.js
+++ b/dashboard/static/js/taxonomy.js
@@ -1339,6 +1339,19 @@
           title: `Concerné par « ${spotlight.theme} » (${spotlight.mode === 'future' ? 'futur' : 'actuel'})`,
         }, ['📍']));
       }
+      // Inline delete button, hover-revealed. Reuses deleteCurrentFile()
+      // which handles confirm modal + soft delete + tree refresh, so the
+      // tree action is just shorthand for "select then delete".
+      children.push(el('button', {
+        type: 'button',
+        class: 'tax-tree-file-delete',
+        title: 'Supprimer ce fichier (corbeille — réversible via Finder)',
+        'aria-label': 'Supprimer ' + f.name,
+        onclick: (e) => {
+          e.stopPropagation();
+          deleteCurrentFile(filePath);
+        },
+      }, ['🗑']));
       wrap.appendChild(el('div', {
         class: cls,
         title: f.name,

--- a/dashboard/static/style.css
+++ b/dashboard/static/style.css
@@ -4280,6 +4280,29 @@ th {
     cursor: pointer;
     border-radius: 4px;
     transition: background 0.1s, color 0.1s;
+    align-items: center;
+}
+/* Hover-revealed delete button on the file row. Pushed to the right
+ * via margin-left:auto on the .tax-tree-name so the layout doesn't
+ * shift when it appears/disappears. */
+.tax-tree-file .tax-tree-name { flex: 1; }
+.tax-tree-file-delete {
+    background: transparent;
+    border: 0;
+    color: var(--text-muted, #6e7681);
+    cursor: pointer;
+    padding: 0 5px;
+    font-size: 11px;
+    border-radius: 3px;
+    opacity: 0;
+    transition: opacity 0.1s, background 0.1s, color 0.1s;
+    flex-shrink: 0;
+}
+.tax-tree-file:hover .tax-tree-file-delete { opacity: 0.7; }
+.tax-tree-file-delete:hover {
+    opacity: 1 !important;
+    background: rgba(248, 81, 73, 0.18);
+    color: #ff7b72;
 }
 .tax-tree-file:hover {
     background: rgba(255, 255, 255, 0.05);


### PR DESCRIPTION
## Description

Raccourci pour la suppression : bouton 🗑 hover-revealed sur chaque ligne fichier du tree (col 1). Évite le flow en 2 clics "sélectionner puis supprimer depuis la card LLM" quand on sait déjà ce qu'on veut virer.

## Comportement

- Bouton caché par défaut (opacity 0)
- Apparaît à 0.7 au hover sur la ligne
- Full opacity + teinte rouge au hover sur le bouton lui-même
- `stopPropagation` sur le clic → ne déclenche pas la sélection du fichier
- Click → `deleteCurrentFile()` (le même handler que la card LLM utilise) → confirm modal → soft delete vers `.trash/<ts>/` → refresh tree

## Code

- `dashboard/static/js/taxonomy.js` : ajout du bouton dans `lazyLoadFiles()` à côté du nom du fichier
- `dashboard/static/style.css` : `.tax-tree-file-delete` (hidden → hover-revealed) + layout flex pour éviter le jitter au hover

**Pure frontend** — pas de changement backend / API. 789/789 tests verts (le path soft delete sous-jacent est déjà couvert par `TestFileOpsEndpoints`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)