### PR TITLE
Mappings — multi-sélection + suppression bulk dans le tree

### DIFF
--- a/dashboard/app.py
+++ b/dashboard/app.py
@@ -2226,6 +2226,24 @@ async def taxonomy_file_delete_api(request: Request):
         return JSONResponse({"error": str(exc)}, status_code=exc.status)
 
 
+@app.post("/api/taxonomy/file/delete-bulk")
+async def taxonomy_file_delete_bulk_api(request: Request):
+    """Bulk soft-delete: move N files to <target>/.trash/<ts>/ in one
+    call. Body: {profile, rel_paths: [...]}. Best-effort — per-item
+    failures surface in errors[]. Single cache invalidation at the
+    end so a 100-file deletion doesn't pay 100× the overhead."""
+    from fastapi.responses import JSONResponse
+    body = await request.json()
+    try:
+        result = taxonomy.soft_delete_bulk(
+            profile=body.get("profile"),
+            rel_paths=body.get("rel_paths") or [],
+        )
+        return JSONResponse(result)
+    except taxonomy.TaxonomyFileError as exc:
+        return JSONResponse({"error": str(exc)}, status_code=exc.status)
+
+
 @app.get("/api/taxonomy/file/move-impact")
 async def taxonomy_file_move_impact_api(
     profile: str, path: str, dest: str,

--- a/dashboard/static/js/taxonomy.js
+++ b/dashboard/static/js/taxonomy.js
@@ -62,6 +62,11 @@
     // decide whether to allow the drop (cycle prevention).
     draggingFolderPath: null,
 
+    // Tree bulk selection for file delete. Set of rel_paths checked
+    // in the tree's hover-revealed checkboxes. Cleared on profile
+    // change and on a successful bulk delete.
+    treeBulkSelected: new Set(),
+
     // Mapped panel — when an item is clicked, fetches the list of files
     // concerned (future = vision_cache theme, current = files in target folder).
     // selectedMappedTheme stores the lowercased theme key for highlight.
@@ -1329,7 +1334,20 @@
       if (isSel) cls += ' selected';
       if (isSpotlit) cls += ' spotlight-file-affected';
       else if (isDimmed) cls += ' spotlight-file-dim';
+      const isChecked = state.treeBulkSelected.has(filePath);
+      const checkbox = el('input', {
+        type: 'checkbox',
+        class: 'tax-tree-file-check',
+        title: 'Cocher pour inclure dans la sélection multiple',
+        checked: isChecked || undefined,
+      });
+      checkbox.addEventListener('click', (e) => e.stopPropagation());
+      checkbox.addEventListener('change', () => {
+        _toggleTreeBulk(filePath, checkbox.checked);
+      });
+      if (isChecked) cls += ' bulk-selected';
       const children = [
+        checkbox,
         el('span', { class: 'tax-tree-icon' }, ['📄']),
         el('span', { class: 'tax-tree-name' }, [f.name]),
       ];
@@ -1846,6 +1864,88 @@
       renderAll();
     } catch (e) {
       showToast('✗ Échec de la suppression : ' + e.message, 'error');
+    }
+  }
+
+  // ── Tree bulk selection + bulk delete ────────────────────────────────
+
+  function _toggleTreeBulk(relPath, checked) {
+    if (checked) state.treeBulkSelected.add(relPath);
+    else state.treeBulkSelected.delete(relPath);
+    renderTreeBulkbar();
+    // Re-render the tree so the .bulk-selected class on the row updates.
+    // Cheap relative to the visible row count (already lazy-loaded).
+    renderTree();
+  }
+
+  function _clearTreeBulk() {
+    if (state.treeBulkSelected.size === 0) return;
+    state.treeBulkSelected.clear();
+    renderTreeBulkbar();
+    renderTree();
+  }
+
+  function renderTreeBulkbar() {
+    const bar = $('#tax-tree-bulkbar');
+    const n = $('#tax-tree-bulkbar-n');
+    if (!bar || !n) return;
+    const count = state.treeBulkSelected.size;
+    n.textContent = String(count);
+    bar.hidden = count === 0;
+  }
+
+  async function _deleteTreeBulk() {
+    if (state.treeBulkSelected.size === 0) return;
+    const paths = Array.from(state.treeBulkSelected);
+    const preview = paths.slice(0, 5)
+      .map(p => '• ' + (p.split('/').pop()))
+      .join('\n');
+    const extra = paths.length > 5
+      ? `\n…et ${paths.length - 5} autres` : '';
+    const ok = await showConfirm({
+      title: `Supprimer ${paths.length} fichier(s) ?`,
+      body: `Les fichiers seront déplacés vers la corbeille du target :\n<target>/.trash/<timestamp>/\n\n${preview}${extra}\n\nRéversible via Finder.`,
+      confirmLabel: `Supprimer ${paths.length} fichier(s)`,
+      cancelLabel: 'Annuler',
+      variant: 'danger',
+    });
+    if (!ok) return;
+    try {
+      const r = await fetch('/api/taxonomy/file/delete-bulk', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          profile: state.profile,
+          rel_paths: paths,
+        }),
+      });
+      const body = await r.json();
+      if (!r.ok) {
+        showToast('✗ ' + (body.error || `HTTP ${r.status}`), 'error');
+        return;
+      }
+      // Drop selection (the files are gone), refresh snapshot, rerender.
+      // Clear the LLM-card selection if the displayed file was in the batch.
+      if (state.selection.type === 'file'
+          && state.treeBulkSelected.has(state.selection.path)) {
+        state.selection = { type: null, path: '' };
+      }
+      state.treeBulkSelected.clear();
+      renderTreeBulkbar();
+      state.snapshot = await fetchSnapshot(true);
+      renderAll();
+      if (body.n_errors > 0) {
+        showToast(
+          `🗑 ${body.n_deleted} supprimé(s), ${body.n_errors} en erreur (voir console)`,
+          'info');
+        console.warn('Bulk delete errors:', body.errors);
+      } else {
+        showToast(
+          `🗑 ${body.n_deleted} fichier(s) déplacé(s) en corbeille`,
+          'success');
+      }
+    } catch (e) {
+      showToast('✗ Échec : ' + e.message, 'error');
     }
   }
 
@@ -2957,8 +3057,15 @@
       state.expanded = new Set();
       state.filesByPath = new Map();
       state.selectedMappedTheme = null;   // spotlight is per-profile
+      state.treeBulkSelected.clear();     // bulk selection is per-profile
+      renderTreeBulkbar();
       await loadAndRender();
     }));
+    // Tree bulk delete bar
+    const treeBulkDelete = $('#tax-tree-bulkbar-delete');
+    if (treeBulkDelete) treeBulkDelete.addEventListener('click', _deleteTreeBulk);
+    const treeBulkClear = $('#tax-tree-bulkbar-clear');
+    if (treeBulkClear) treeBulkClear.addEventListener('click', _clearTreeBulk);
     $('#tax-refresh').addEventListener('click', () => withBusy('Rechargement…', async () => {
       state.filesByPath = new Map();
       try { state.snapshot = await fetchSnapshot(true); renderAll(); showToast('Snapshot rechargé', 'success'); }

--- a/dashboard/static/style.css
+++ b/dashboard/static/style.css
@@ -4304,6 +4304,56 @@ th {
     background: rgba(248, 81, 73, 0.18);
     color: #ff7b72;
 }
+/* Multi-select checkbox on each tree file row. Hidden by default to
+ * keep the tree clean; appears on row hover. Stays visible once
+ * checked so the user can see what they've picked. */
+.tax-tree-file-check {
+    width: 13px;
+    height: 13px;
+    cursor: pointer;
+    accent-color: #58a6ff;
+    opacity: 0;
+    transition: opacity 0.1s;
+    flex-shrink: 0;
+}
+.tax-tree-file:hover .tax-tree-file-check { opacity: 0.7; }
+.tax-tree-file-check:checked { opacity: 1 !important; }
+.tax-tree-file.bulk-selected {
+    background: rgba(88, 166, 255, 0.08);
+}
+.tax-tree-file.bulk-selected:hover {
+    background: rgba(88, 166, 255, 0.14);
+}
+
+/* Sticky bulkbar at the bottom of col 1 — appears when ≥ 1 file is
+ * checked. Same visual language as the Rename bulkbar. */
+.tax-tree-bulkbar {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: 6px 10px;
+    background: rgba(88, 166, 255, 0.1);
+    border-top: 1px solid rgba(88, 166, 255, 0.25);
+    font-size: 11px;
+    flex-shrink: 0;
+}
+.tax-tree-bulkbar[hidden] { display: none; }
+.tax-tree-bulkbar-count { color: var(--text, #c9d1d9); flex: 1; }
+.tax-tree-bulkbar-count strong { color: #58a6ff; }
+.tax-tree-bulkbar .btn-sm {
+    padding: 3px 8px;
+    font-size: 11px;
+    border-radius: 3px;
+}
+.tax-tree-bulkbar .btn-danger {
+    background: rgba(248, 81, 73, 0.1);
+    border: 1px solid rgba(248, 81, 73, 0.3);
+    color: #ff7b72;
+    cursor: pointer;
+}
+.tax-tree-bulkbar .btn-danger:hover {
+    background: rgba(248, 81, 73, 0.2);
+}
 .tax-tree-file:hover {
     background: rgba(255, 255, 255, 0.05);
     color: var(--text, #c9d1d9);

--- a/dashboard/taxonomy.py
+++ b/dashboard/taxonomy.py
@@ -2709,6 +2709,137 @@ def _resolve_dest_folder(profile: str, dest_folder: str) -> Path:
     return abs_dest
 
 
+def soft_delete_bulk(profile: str, rel_paths: list[str]) -> dict:
+    """Bulk-soft-delete N files in one call. Each one goes through the
+    same FS move + journal append as ``soft_delete_file``, but the
+    cache invalidation runs ONCE at the end (instead of N times) and
+    a per-second timestamp is reused — files trashed within the same
+    call land under the same ``<target>/.trash/<ts>/`` folder, with
+    -1/-2 suffixes on basename collisions.
+
+    Best-effort: a per-item failure is captured in ``errors[]`` and
+    does NOT abort the batch. Returns:
+
+      {
+        ok: True,
+        n_total: int,
+        n_deleted: int,
+        n_errors: int,
+        successes: [{rel_path, trash_rel_path}, ...],
+        errors:    [{rel_path, error, status}, ...],
+      }
+    """
+    if not isinstance(rel_paths, list) or not rel_paths:
+        raise TaxonomyFileError("rel_paths vide ou invalide", 400)
+
+    target = _profile_target_path(profile)
+    if target is None or not target.exists():
+        raise TaxonomyFileError("profil sans target configuré", 400)
+    target_resolved = target.resolve()
+
+    trash_root = _trash_root(profile)
+    trash_root_resolved = None
+    if trash_root is not None and trash_root.exists():
+        trash_root_resolved = trash_root.resolve()
+
+    # Single timestamp + journal handle for the whole batch — keeps
+    # related deletions grouped on disk.
+    ts = datetime.now().strftime("%Y%m%d-%H%M%S")
+    trash_dir = trash_root / ts
+    trash_dir.mkdir(parents=True, exist_ok=True)
+    journal_path = _trash_journal_path(profile)
+    journal_path.parent.mkdir(parents=True, exist_ok=True)
+
+    successes: list[dict] = []
+    errors: list[dict] = []
+
+    # De-dup the input list — the same rel_path twice in a batch is
+    # a UI bug, not a user intent.
+    seen: set[str] = set()
+
+    with open(journal_path, "a", encoding="utf-8") as journal_fh:
+        for raw in rel_paths:
+            rel_path = str(raw or "").strip()
+            if not rel_path:
+                errors.append({"rel_path": rel_path,
+                               "error": "rel_path manquant", "status": 400})
+                continue
+            if rel_path in seen:
+                errors.append({"rel_path": rel_path,
+                               "error": "doublon dans la batch",
+                               "status": 400})
+                continue
+            seen.add(rel_path)
+
+            try:
+                abs_old = (target / rel_path).resolve()
+                abs_old.relative_to(target_resolved)
+            except (ValueError, OSError):
+                errors.append({"rel_path": rel_path,
+                               "error": "hors du target", "status": 400})
+                continue
+            if not abs_old.exists():
+                errors.append({"rel_path": rel_path,
+                               "error": "fichier introuvable",
+                               "status": 404})
+                continue
+            if not abs_old.is_file():
+                errors.append({"rel_path": rel_path,
+                               "error": "pas un fichier", "status": 400})
+                continue
+            if (trash_root_resolved is not None
+                    and trash_root_resolved in abs_old.parents):
+                errors.append({"rel_path": rel_path,
+                               "error": "déjà dans la corbeille",
+                               "status": 400})
+                continue
+
+            basename = abs_old.name
+            dest = trash_dir / basename
+            suffix = 0
+            stem, ext = os.path.splitext(basename)
+            while dest.exists():
+                suffix += 1
+                dest = trash_dir / f"{stem}-{suffix}{ext}"
+
+            try:
+                shutil.move(str(abs_old), str(dest))
+            except OSError as exc:
+                errors.append({"rel_path": rel_path,
+                               "error": f"échec FS : {exc}", "status": 500})
+                continue
+
+            trash_rel = str(dest.relative_to(target)).replace("\\", "/")
+            record = {
+                "ts": datetime.now().isoformat(timespec="seconds"),
+                "original_rel_path": rel_path,
+                "trash_rel_path": trash_rel,
+            }
+            try:
+                journal_fh.write(
+                    json.dumps(record, ensure_ascii=False) + "\n")
+            except OSError:
+                # Journal write failure doesn't undo the FS move.
+                pass
+            successes.append({
+                "rel_path": rel_path,
+                "trash_rel_path": trash_rel,
+            })
+
+    # Single cache drop for the whole batch — way cheaper than N drops.
+    if successes:
+        _invalidate_post_fs_op(profile)
+
+    return {
+        "ok": True,
+        "n_total": len(rel_paths),
+        "n_deleted": len(successes),
+        "n_errors": len(errors),
+        "successes": successes,
+        "errors": errors,
+    }
+
+
 def move_file(profile: str, rel_path: str, dest_folder: str) -> dict:
     """Move a file from its current folder to ``dest_folder`` (kept
     basename). Reuses the audit cache invalidation path so the UI

--- a/dashboard/templates/taxonomy.html
+++ b/dashboard/templates/taxonomy.html
@@ -90,6 +90,21 @@
         <div class="tax-tree-scroll">
             <div id="tax-tree" class="tax-tree"></div>
         </div>
+        <!-- Sticky bulkbar for multi-file delete in the tree -->
+        <div class="tax-tree-bulkbar" id="tax-tree-bulkbar" hidden>
+            <span class="tax-tree-bulkbar-count">
+                <strong id="tax-tree-bulkbar-n">0</strong> sélectionné(s)
+            </span>
+            <button type="button" class="btn-danger btn-sm"
+                    id="tax-tree-bulkbar-delete"
+                    title="Déplacer tous les fichiers cochés vers la corbeille (.trash/<ts>/) — réversible via Finder">
+                🗑 Supprimer la sélection
+            </button>
+            <button type="button" class="btn-secondary btn-sm"
+                    id="tax-tree-bulkbar-clear">
+                Tout désélectionner
+            </button>
+        </div>
     </section>
 
     <!-- Colonne 2 — Viewer + Analyse LLM + Treemap -->

--- a/tests/auto/test_taxonomy.py
+++ b/tests/auto/test_taxonomy.py
@@ -2252,6 +2252,125 @@ class TestSoftDeleteFile(TaxonomyTestBase):
         self.assertEqual(cm.exception.status, 404)
 
 
+class TestSoftDeleteBulk(TaxonomyTestBase):
+
+    def test_happy_path_all_succeed(self):
+        r = taxonomy.soft_delete_bulk(
+            self.profile_name,
+            rel_paths=[
+                "01-SCIENCES/PHYSIQUE/mechanics.pdf",
+                "01-SCIENCES/PHYSIQUE/quantum.pdf",
+                "01-SCIENCES/MATHEMATIQUES/algebra.pdf",
+            ])
+        self.assertTrue(r["ok"])
+        self.assertEqual(r["n_deleted"], 3)
+        self.assertEqual(r["n_errors"], 0)
+        # All three sources gone, all three in .trash/
+        for orig in (
+            "01-SCIENCES/PHYSIQUE/mechanics.pdf",
+            "01-SCIENCES/PHYSIQUE/quantum.pdf",
+            "01-SCIENCES/MATHEMATIQUES/algebra.pdf",
+        ):
+            self.assertFalse((self.target / orig).exists())
+        trashed = list((self.target / ".trash").rglob("*.pdf"))
+        self.assertEqual(len(trashed), 3)
+
+    def test_shared_timestamp_groups_them(self):
+        # All deletions in one batch land under the same .trash/<ts>/
+        # subdir, since the function uses a single timestamp.
+        r = taxonomy.soft_delete_bulk(
+            self.profile_name,
+            rel_paths=[
+                "01-SCIENCES/PHYSIQUE/mechanics.pdf",
+                "01-SCIENCES/PHYSIQUE/quantum.pdf",
+            ])
+        self.assertEqual(r["n_deleted"], 2)
+        # The two trash_rel_paths share the same <ts> folder
+        ts_folders = {
+            s["trash_rel_path"].split("/")[1]
+            for s in r["successes"]
+        }
+        self.assertEqual(len(ts_folders), 1)
+
+    def test_partial_failure_continues_batch(self):
+        # Mix valid + invalid items — batch must continue
+        r = taxonomy.soft_delete_bulk(
+            self.profile_name,
+            rel_paths=[
+                "01-SCIENCES/PHYSIQUE/mechanics.pdf",  # OK
+                "ghost.pdf",                            # 404
+                "../outside.pdf",                       # 400 (traversal)
+                "01-SCIENCES/intro.pdf",               # OK
+            ])
+        self.assertEqual(r["n_deleted"], 2)
+        self.assertEqual(r["n_errors"], 2)
+        success_paths = {s["rel_path"] for s in r["successes"]}
+        self.assertIn("01-SCIENCES/PHYSIQUE/mechanics.pdf", success_paths)
+        self.assertIn("01-SCIENCES/intro.pdf", success_paths)
+
+    def test_dedupes_duplicate_paths(self):
+        # Same path twice in the input: first one deletes, second one
+        # is rejected as a duplicate (not as 404).
+        r = taxonomy.soft_delete_bulk(
+            self.profile_name,
+            rel_paths=[
+                "01-SCIENCES/PHYSIQUE/mechanics.pdf",
+                "01-SCIENCES/PHYSIQUE/mechanics.pdf",
+            ])
+        self.assertEqual(r["n_deleted"], 1)
+        self.assertEqual(r["n_errors"], 1)
+        self.assertIn("doublon", r["errors"][0]["error"])
+
+    def test_empty_rel_paths_400(self):
+        with self.assertRaises(taxonomy.TaxonomyFileError) as cm:
+            taxonomy.soft_delete_bulk(self.profile_name, rel_paths=[])
+        self.assertEqual(cm.exception.status, 400)
+
+    def test_journal_records_each_success(self):
+        taxonomy.soft_delete_bulk(
+            self.profile_name,
+            rel_paths=[
+                "01-SCIENCES/PHYSIQUE/mechanics.pdf",
+                "01-SCIENCES/intro.pdf",
+            ])
+        journal = self.profile_dir / ".cache" / "file-trash-journal.jsonl"
+        lines = journal.read_text(encoding="utf-8").splitlines()
+        # At least our two new entries (file may have prior entries from
+        # other tests sharing the fixture — but each test gets a fresh
+        # tmpdir, so it's exactly 2).
+        self.assertEqual(len(lines), 2)
+
+
+class TestSoftDeleteBulkEndpoint(TaxonomyTestBase):
+
+    def setUp(self):
+        super().setUp()
+        from fastapi.testclient import TestClient
+
+        from dashboard.app import app
+        self.client = TestClient(app)
+
+    def test_endpoint_happy(self):
+        r = self.client.post("/api/taxonomy/file/delete-bulk", json={
+            "profile": self.profile_name,
+            "rel_paths": [
+                "01-SCIENCES/PHYSIQUE/mechanics.pdf",
+                "01-SCIENCES/PHYSIQUE/quantum.pdf",
+            ],
+        })
+        self.assertEqual(r.status_code, 200)
+        body = r.json()
+        self.assertEqual(body["n_deleted"], 2)
+        self.assertEqual(body["n_errors"], 0)
+
+    def test_endpoint_empty_400(self):
+        r = self.client.post("/api/taxonomy/file/delete-bulk", json={
+            "profile": self.profile_name,
+            "rel_paths": [],
+        })
+        self.assertEqual(r.status_code, 400)
+
+
 class TestMoveFile(TaxonomyTestBase):
 
     def test_happy_path(self):


### PR DESCRIPTION
## Description

Étend le bouton 🗑 inline de #141 avec la multi-sélection. Checkbox hover-revealed à gauche de chaque ligne fichier du tree + bulkbar sticky en bas de la col 1 avec une seule action : **soft-delete de la sélection en un batch**.

## Comportement

- Checkbox cachée par défaut, apparaît à 0.7 au hover de la ligne, full opacity dès qu'elle est cochée
- Click sur la checkbox : `stopPropagation` → ne déclenche pas la sélection du fichier pour la card LLM
- Lignes cochées teintées en bleu léger
- Bulkbar apparaît dès N≥1 : `[N sélectionné(s)] [🗑 Supprimer la sélection] [Tout désélectionner]`
- Sélection per-profile : cleared au changement de profil

## Backend

- `dashboard.taxonomy.soft_delete_bulk(profile, rel_paths)` — best-effort, **un seul timestamp partagé** sur `.trash/<ts>/` pour grouper le batch, dedup des doublons, **une seule invalidation de cache** à la fin (économie massive vs N appels individuels)
- Endpoint `POST /api/taxonomy/file/delete-bulk` body `{profile, rel_paths: [...]}`
- Retourne `{n_total, n_deleted, n_errors, successes[], errors[]}`

## Tests

8 nouveaux :
- `TestSoftDeleteBulk` × 6 — happy / shared timestamp / partial failure / dedup / empty 400 / journal
- `TestSoftDeleteBulkEndpoint` × 2 — POST happy / empty 400

**797/797 tests verts**. Lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)