### PR TITLE
fix: tree bulk checkbox — état initial + réactivité au clic

### DIFF
--- a/dashboard/static/js/taxonomy.js
+++ b/dashboard/static/js/taxonomy.js
@@ -1339,11 +1339,16 @@
         type: 'checkbox',
         class: 'tax-tree-file-check',
         title: 'Cocher pour inclure dans la sélection multiple',
-        checked: isChecked || undefined,
       });
+      // Use the .checked PROPERTY (runtime state) rather than the
+      // `checked` attribute (default state). setAttribute('checked', ...)
+      // sets defaultChecked, which can desync with the visible state
+      // after re-renders and was causing rows to render as already
+      // checked on first load.
+      checkbox.checked = isChecked;
       checkbox.addEventListener('click', (e) => e.stopPropagation());
       checkbox.addEventListener('change', () => {
-        _toggleTreeBulk(filePath, checkbox.checked);
+        _toggleTreeBulk(filePath, checkbox.checked, checkbox);
       });
       if (isChecked) cls += ' bulk-selected';
       const children = [
@@ -1869,20 +1874,31 @@
 
   // ── Tree bulk selection + bulk delete ────────────────────────────────
 
-  function _toggleTreeBulk(relPath, checked) {
+  function _toggleTreeBulk(relPath, checked, anchorEl) {
     if (checked) state.treeBulkSelected.add(relPath);
     else state.treeBulkSelected.delete(relPath);
     renderTreeBulkbar();
-    // Re-render the tree so the .bulk-selected class on the row updates.
-    // Cheap relative to the visible row count (already lazy-loaded).
-    renderTree();
+    // Targeted DOM update: just toggle the .bulk-selected class on this
+    // one row. A full renderTree() would destroy the checkbox the user
+    // just clicked and was producing inconsistent states on toggle.
+    if (anchorEl) {
+      const row = anchorEl.closest('.tax-tree-file');
+      if (row) row.classList.toggle('bulk-selected', checked);
+    }
   }
 
   function _clearTreeBulk() {
     if (state.treeBulkSelected.size === 0) return;
     state.treeBulkSelected.clear();
     renderTreeBulkbar();
-    renderTree();
+    // Uncheck every visible checkbox + drop the .bulk-selected class on
+    // every row. Cheap: only visible rows (lazy-loaded, capped at ~50/dir).
+    document.querySelectorAll('.tax-tree-file-check').forEach(cb => {
+      cb.checked = false;
+    });
+    document.querySelectorAll('.tax-tree-file.bulk-selected').forEach(row => {
+      row.classList.remove('bulk-selected');
+    });
   }
 
   function renderTreeBulkbar() {


### PR DESCRIPTION
## Description

Fix de 2 bugs reportés sur PR #142 (multi-select tree delete) :

1. **Checkboxes cochées par défaut** au premier load alors que `state.treeBulkSelected` est vide.
   - Cause : `setAttribute('checked', isChecked || undefined)` manipule l'attribut `defaultChecked` qui peut se désynchroniser avec la propriété `.checked` runtime.
   - Fix : assignation directe de la propriété `checkbox.checked = isChecked` — le runtime state est explicite, plus d'ambiguïté avec l'attribut.

2. **Clics ne réagissent pas**.
   - Cause : `_toggleTreeBulk` appelait `renderTree()` dans le change handler, ce qui détruisait la checkbox que l'utilisateur venait de cliquer (et reconstruisait toutes les rows). Toggle suivant → click sur un élément qui vient d'être remplacé → comportement incohérent.
   - Fix : MAJ DOM ciblée — toggle juste la classe `.bulk-selected` sur la row concernée. La checkbox reste intacte, le click handling natif reste propre. `_clearTreeBulk` fait pareil sur toutes les rows visibles.

Pure frontend. 797/797 tests verts (les bugs étaient au niveau DOM, non testables depuis unittest).

🤖 Generated with [Claude Code](https://claude.com/claude-code)