### PR TITLE
Thumbnail cache unification (content-keyed + pipeline hook + backfill CLI)

### DIFF
--- a/commands/__init__.py
+++ b/commands/__init__.py
@@ -9,3 +9,4 @@ from commands.misc import cmd_suggest as cmd_suggest
 from commands.process import cmd_process as cmd_process
 from commands.refine import cmd_refine as cmd_refine
 from commands.rename import cmd_rename as cmd_rename
+from commands.thumbnails import cmd_thumbnails as cmd_thumbnails

--- a/commands/classify.py
+++ b/commands/classify.py
@@ -96,6 +96,10 @@ def scan_and_classify(source_dir, profile, api_key,
     min_confidence = profile.defaults.get('min_confidence', 0.5)
     max_api_errors = profile.defaults.get('max_api_errors', 10)
     vision_cache_path = os.path.join(profile.cache_dir, 'vision_cache.json')
+    # Capitalise on the cover extraction: dump the PIL images into the
+    # dashboard's thumbnail cache so it doesn't have to re-extract on
+    # first viewer open. Same key the dashboard uses (MD5 of head bytes).
+    thumbnails_base_dir = os.path.join(profile.cache_dir, 'thumbnails')
 
     classifier, mapper = load_classifiers(profile, api_key, verbose, vision=vision)
 
@@ -110,7 +114,8 @@ def scan_and_classify(source_dir, profile, api_key,
             pdf_path, api_key, endpoint, model,
             theme_mapping, classifier, mapper, verbose=verbose,
             min_confidence=min_confidence, n_pages=n_pages,
-            vision_cache_path=vision_cache_path)
+            vision_cache_path=vision_cache_path,
+            thumbnails_base_dir=thumbnails_base_dir)
 
         with progress_lock:
             progress[pdf_path] = result

--- a/commands/helpers.py
+++ b/commands/helpers.py
@@ -200,13 +200,21 @@ def process_single_file(pdf_path, api_key, endpoint, model,
                         theme_mapping, classifier=None, llm_mapper=None,
                         verbose=False, min_confidence=CONFIDENCE_THRESHOLD, n_pages=1,
                         n_candidates=0,
-                        vision_cache_path=None):
-    # type: (str, str, str, str, dict[str, str], object, object, bool, float, int, int, str | None) -> dict
+                        vision_cache_path=None,
+                        thumbnails_base_dir=None):
+    # type: (str, str, str, str, dict[str, str], object, object, bool, float, int, int, str | None, str | None) -> dict
     """
     Pipeline de classification pour un fichier :
     1. Extraction couverture → image (smart selection si n_candidates>n_pages)
     2. Envoi au LLM Vision → titre, auteur, thème (via cache si `vision_cache_path` fourni)
     3. Classification thématique
+
+    Si `thumbnails_base_dir` est fourni, capitalise sur l'extraction
+    déjà faite pour pré-remplir le cache thumbnail du dashboard (gratuit,
+    évite une 2e extraction au moment où l'utilisateur ouvre le fichier
+    dans le viewer). Le sous-dossier par fichier est calculé via
+    `lib.thumbnail.compute_content_key()` (MD5 des head bytes, identique
+    au dashboard).
     """
     filename = os.path.basename(pdf_path)
     result = {
@@ -223,15 +231,28 @@ def process_single_file(pdf_path, api_key, endpoint, model,
         'status': 'pending',
     }  # type: dict
 
+    # Compute the per-file thumbnail dir once. Uses the file's content
+    # key (MD5 of head bytes) — same key the dashboard uses, so the
+    # write here is visible from the dashboard without any further
+    # bookkeeping.
+    thumb_dir = None
+    if thumbnails_base_dir:
+        from lib.thumbnail import compute_content_key
+        ck = compute_content_key(pdf_path)
+        if ck:
+            thumb_dir = os.path.join(thumbnails_base_dir, ck)
+
     if vision_cache_path:
         vision = analyze_cover_cached(pdf_path, vision_cache_path,
                                       api_key, endpoint, model,
                                       verbose=verbose, n_pages=n_pages,
-                                      n_candidates=n_candidates)
+                                      n_candidates=n_candidates,
+                                      thumbnail_dir=thumb_dir)
     else:
         vision = analyze_cover(pdf_path, api_key, endpoint, model,
                                verbose=verbose, n_pages=n_pages,
-                               n_candidates=n_candidates)
+                               n_candidates=n_candidates,
+                               thumbnail_dir=thumb_dir)
 
     if vision.get('error') == 'extraction':
         result['status'] = 'erreur_extraction'
@@ -357,15 +378,28 @@ def save_mapper_results(mapper, profile, logs_dir):
 
 
 def make_llm_rename_callback(api_key, endpoint, model, verbose=False, n_pages=1,
-                             vision_cache_path=None):
-    # type: (str, str, str, bool, int, str | None) -> object
-    """Crée un callback LLM Vision pour le renommage (passe par le cache si fourni)."""
+                             vision_cache_path=None,
+                             thumbnails_base_dir=None):
+    # type: (str, str, str, bool, int, str | None, str | None) -> object
+    """Crée un callback LLM Vision pour le renommage (passe par le cache si fourni).
+
+    Si `thumbnails_base_dir` est fourni, capitalise sur l'extraction du
+    LLM pour pré-remplir le cache thumbnail du dashboard (gratuit).
+    """
     def callback(pdf_path):
         # type: (str) -> dict
+        thumb_dir = None
+        if thumbnails_base_dir:
+            from lib.thumbnail import compute_content_key
+            ck = compute_content_key(pdf_path)
+            if ck:
+                thumb_dir = os.path.join(thumbnails_base_dir, ck)
         if vision_cache_path:
             return analyze_cover_cached(pdf_path, vision_cache_path,
                                         api_key, endpoint, model,
-                                        verbose=verbose, n_pages=n_pages)
+                                        verbose=verbose, n_pages=n_pages,
+                                        thumbnail_dir=thumb_dir)
         return analyze_cover(pdf_path, api_key, endpoint, model,
-                             verbose=verbose, n_pages=n_pages)
+                             verbose=verbose, n_pages=n_pages,
+                             thumbnail_dir=thumb_dir)
     return callback

--- a/commands/process.py
+++ b/commands/process.py
@@ -73,10 +73,12 @@ def cmd_process(args, profile) -> None:
                 log.error("❌ --llm nécessite une clé API. export SILICONFLOW_API_KEY=votre-clé")
                 sys.exit(1)
             vision_cache_path = os.path.join(profile.cache_dir, 'vision_cache.json')
+            thumbnails_base_dir = os.path.join(profile.cache_dir, 'thumbnails')
             llm_callback = make_llm_rename_callback(
                 api_key, profile.llm_endpoint, profile.llm_model,
                 verbose=args.verbose, n_pages=n_pages,
-                vision_cache_path=vision_cache_path)
+                vision_cache_path=vision_cache_path,
+                thumbnails_base_dir=thumbnails_base_dir)
 
         report_path = renamer.scan(
             source, enable_online=enable_online, enable_pdf=enable_pdf,

--- a/commands/rename.py
+++ b/commands/rename.py
@@ -33,10 +33,12 @@ def cmd_rename(args, profile) -> None:
             sys.exit(1)
         n_pages = getattr(args, 'pages', 1)
         vision_cache_path = os.path.join(profile.cache_dir, 'vision_cache.json')
+        thumbnails_base_dir = os.path.join(profile.cache_dir, 'thumbnails')
         llm_callback = make_llm_rename_callback(
             api_key, profile.llm_endpoint, profile.llm_model,
             verbose=args.verbose, n_pages=n_pages,
-            vision_cache_path=vision_cache_path)
+            vision_cache_path=vision_cache_path,
+            thumbnails_base_dir=thumbnails_base_dir)
 
     max_files = getattr(args, 'max', 0)
     force = getattr(args, 'force', False)

--- a/commands/thumbnails.py
+++ b/commands/thumbnails.py
@@ -1,0 +1,144 @@
+"""Sous-commande thumbnails — backfill du cache thumbnail du dashboard.
+
+Itère sur tous les PDF/ePub d'un profil et pré-remplit le cache des
+miniatures (cover de page 1) utilisé par le viewer du dashboard. Sans
+ça, le dashboard génère les thumbnails à la demande au premier clic
+sur un fichier — coût ~3-5 s par fichier sur SSD externe.
+
+La clé du cache est ``MD5(head bytes du fichier)`` (alignée sur
+``lib.thumbnail.compute_content_key``), donc le cache **survit aux
+renommages** : si tu renommes un fichier plus tard, le thumbnail
+reste valide tant que le contenu n'a pas bougé.
+
+Usage::
+
+    ./klodo.sh thumbnails                  # dry-run (compte ce qu'il faut faire)
+    ./klodo.sh thumbnails --execute        # génère vraiment
+    ./klodo.sh thumbnails --execute --max 100  # limiter pour tester
+    ./klodo.sh thumbnails --execute --force    # régénère même les caches existants
+"""
+
+import os
+import sys
+import time
+from pathlib import Path
+
+from lib.logger import get_logger
+from lib.thumbnail import compute_content_key, generate_thumbnail
+
+log = get_logger()
+
+
+_SUPPORTED_EXTS = (".pdf", ".epub")
+
+
+def _enumerate_files(target: Path) -> list[Path]:
+    """Walk the target, return every PDF/ePub. Skips dotfiles + dotdirs
+    + the .trash/ folder (which is by definition out of scope)."""
+    out: list[Path] = []
+    for root, dirs, files in os.walk(str(target)):
+        dirs[:] = [d for d in dirs if not d.startswith(".")]
+        for f in files:
+            if f.startswith(".") or not f.lower().endswith(_SUPPORTED_EXTS):
+                continue
+            out.append(Path(root) / f)
+    return out
+
+
+def cmd_thumbnails(args, profile) -> None:
+    """Pré-remplit le cache thumbnail du dashboard pour tous les fichiers
+    du profil. Lance ``./klodo.sh thumbnails --execute``."""
+    target = Path(profile.target)
+    if not target.exists():
+        log.error("❌ Target introuvable : %s", target)
+        sys.exit(1)
+
+    cache_root = Path(profile.cache_dir) / "thumbnails"
+    cache_root.mkdir(parents=True, exist_ok=True)
+
+    execute = getattr(args, "execute", False)
+    force = getattr(args, "force", False)
+    max_files = int(getattr(args, "max", 0) or 0)
+
+    log.info("📸 Backfill thumbnail cache pour profil « %s »", profile.name)
+    log.info("   target = %s", target)
+    log.info("   cache  = %s", cache_root)
+    if not execute:
+        log.info("   mode   = DRY-RUN (ajouter --execute pour générer)")
+
+    files = _enumerate_files(target)
+    if max_files > 0:
+        files = files[:max_files]
+        log.info("   limite = %d fichiers (--max)", max_files)
+    log.info("   scope  = %d fichiers PDF/ePub trouvés\n", len(files))
+
+    # Pre-pass: count what would be done (cheap; just file.exists() per cache dir)
+    to_generate: list[tuple[Path, Path]] = []     # (source, cache_dir)
+    already_cached = 0
+    unreadable = 0
+    for src in files:
+        key = compute_content_key(src)
+        if not key:
+            unreadable += 1
+            continue
+        dest_dir = cache_root / key
+        page1 = dest_dir / "1.jpg"
+        if page1.exists() and not force:
+            already_cached += 1
+            continue
+        to_generate.append((src, dest_dir))
+
+    log.info("📊 État actuel :")
+    log.info("   déjà en cache : %d", already_cached)
+    log.info("   à générer     : %d", len(to_generate))
+    if unreadable:
+        log.info("   illisibles    : %d (skipped)", unreadable)
+    log.info("")
+
+    if not to_generate:
+        log.info("✅ Rien à faire. Cache déjà complet.")
+        return
+
+    if not execute:
+        log.info("🚦 Dry-run terminé. Ajoute --execute pour générer.")
+        # Show a small sample so the user sees what would happen
+        log.info("\nÉchantillon (5 premiers) :")
+        for src, dest in to_generate[:5]:
+            log.info("   %s → %s/1.jpg",
+                      src.name[:60], dest.name)
+        return
+
+    # Generation. Single-threaded by design — generate_thumbnail uses
+    # poppler which is already pretty fast (~30-80 ms per PDF page at
+    # 150 dpi). Parallel speedup would be modest and complicate the
+    # progress display.
+    log.info("⚙ Génération en cours…\n")
+    t0 = time.perf_counter()
+    n_done = 0
+    n_failed = 0
+    progress_interval = max(1, len(to_generate) // 50)  # ~50 progress ticks total
+    for i, (src, dest_dir) in enumerate(to_generate, start=1):
+        try:
+            dest_dir.mkdir(parents=True, exist_ok=True)
+            n = generate_thumbnail(src, dest_dir, n_pages=1, start_page=1)
+            if n > 0:
+                n_done += 1
+            else:
+                n_failed += 1
+        except Exception as exc:  # pragma: no cover — defensive
+            log.warning("  ⚠ %s : %s", src.name, exc)
+            n_failed += 1
+        if i % progress_interval == 0 or i == len(to_generate):
+            pct = 100 * i / len(to_generate)
+            elapsed = time.perf_counter() - t0
+            rate = i / elapsed if elapsed > 0 else 0
+            eta = (len(to_generate) - i) / rate if rate > 0 else 0
+            log.info("   [%4d/%4d] %5.1f%% · %.1f f/s · ETA %.0fs",
+                      i, len(to_generate), pct, rate, eta)
+
+    elapsed = time.perf_counter() - t0
+    log.info("\n✅ Terminé en %.1fs", elapsed)
+    log.info("   générés : %d", n_done)
+    if n_failed:
+        log.info("   échoués : %d", n_failed)
+    log.info("   moyenne : %.1f f/s", n_done / elapsed if elapsed > 0 else 0)

--- a/dashboard/taxonomy.py
+++ b/dashboard/taxonomy.py
@@ -23,7 +23,6 @@ a baseline_run) to block writes.
 
 from __future__ import annotations
 
-import hashlib
 import json
 import os
 import re
@@ -1231,10 +1230,22 @@ def _rename_diagnostic_for(
 # ─── Thumbnails (cover + multipage lazy) ──────────────────────────────────
 
 
-def _thumbnail_cache_dir(profile: str, rel_path: str) -> Path:
-    """Cache thumbnails at profile/.cache/thumbnails/<hash16>/."""
-    h = hashlib.sha1(rel_path.encode("utf-8")).hexdigest()[:16]
-    d = _profile_dir(profile) / ".cache" / "thumbnails" / h
+def _thumbnail_cache_dir(profile: str, abs_path: Path | str) -> Path | None:
+    """Cache thumbnails at ``profile/.cache/thumbnails/<content_key>/``.
+
+    ``content_key`` is derived from the file's head bytes (see
+    ``lib.thumbnail.compute_content_key``), NOT from its rel_path —
+    so a rename or a move doesn't invalidate the cached image.
+
+    Returns ``None`` if the file can't be hashed (caller should
+    surface "fichier introuvable" / "indisponible" rather than try to
+    generate into a meaningless dir).
+    """
+    from lib.thumbnail import compute_content_key
+    key = compute_content_key(abs_path)
+    if not key:
+        return None
+    d = _profile_dir(profile) / ".cache" / "thumbnails" / key
     d.mkdir(parents=True, exist_ok=True)
     return d
 
@@ -1251,7 +1262,9 @@ def get_thumbnail(profile: str, rel_path: str, page: int) -> tuple[Path | None, 
     abs_path = target / rel_path
     if not abs_path.exists():
         return None, "fichier introuvable"
-    cache_dir = _thumbnail_cache_dir(profile, rel_path)
+    cache_dir = _thumbnail_cache_dir(profile, abs_path)
+    if cache_dir is None:
+        return None, "fichier illisible"
     img = cache_dir / f"{page}.jpg"
     if img.exists():
         return img, "image/jpeg"

--- a/klodo.py
+++ b/klodo.py
@@ -53,6 +53,7 @@ from commands import (
     cmd_refine,
     cmd_rename,
     cmd_suggest,
+    cmd_thumbnails,
 )
 from lib.exceptions import ConfigError
 from lib.logger import get_logger, setup_logger
@@ -216,6 +217,17 @@ def _build_parser():
     p_dashboard.add_argument('--port', type=int, default=8080,
                              help='Port (défaut: 8080)')
 
+    # ── thumbnails ── (backfill du cache thumbnail du dashboard)
+    p_thumb = subparsers.add_parser(
+        'thumbnails', parents=[common],
+        help='Pré-remplir le cache thumbnail du dashboard pour tous les '
+             'fichiers du profil (évite la génération à la demande au '
+             'premier clic dans le viewer).')
+    p_thumb.add_argument('--max', type=int, default=0,
+                         help='Limiter le nombre de fichiers traités (0 = tous)')
+    p_thumb.add_argument('--force', action='store_true',
+                         help='Re-générer même les thumbnails déjà en cache')
+
     return parser
 
 
@@ -266,6 +278,7 @@ def main():
         'suggest': cmd_suggest,
         'clean': cmd_clean,
         'detect': cmd_detect,
+        'thumbnails': cmd_thumbnails,
     }
     handler = dispatch.get(args.command)
     if handler:

--- a/lib/thumbnail.py
+++ b/lib/thumbnail.py
@@ -9,6 +9,7 @@ Le cache est stocké dans `{INBOX}/.thumbnail-cache/{stem}.jpg`.
 
 from __future__ import annotations
 
+import hashlib
 import io
 import xml.etree.ElementTree as ET
 import zipfile
@@ -26,6 +27,33 @@ THUMBNAIL_HEIGHT = 550
 THUMBNAIL_QUALITY = 80
 PLACEHOLDER_BG = (26, 29, 36)        # #1a1d24 — gris foncé du dark theme
 PLACEHOLDER_FG = (220, 220, 220)     # blanc cassé
+
+# Number of bytes hashed to compute the content key. Same as
+# lib.vision_cache so the two caches are conceptually aligned (file
+# identity is "first 8 KiB of bytes"). Identical content under a
+# different rel_path → same key → cache hit (survives renames).
+_HEAD_BYTES = 8192
+
+
+def compute_content_key(file_path: str | Path, length: int = 16) -> str | None:
+    """Stable thumbnail cache key derived from the file's head bytes.
+
+    Returns the first ``length`` hex chars of ``md5(first 8 KiB)``, or
+    ``None`` if the file can't be read. Pure content-based so:
+      - A rename does NOT invalidate the cache (rel_path-independent).
+      - Two identical files under different paths share one thumbnail.
+
+    Used by the dashboard's thumbnail cache directory layout
+    ``profile/.cache/thumbnails/<key>/{1..n}.jpg``.
+    """
+    try:
+        with open(file_path, "rb") as f:
+            head = f.read(_HEAD_BYTES)
+    except OSError:
+        return None
+    if not head:
+        return None
+    return hashlib.md5(head).hexdigest()[:length]
 
 
 def generate_thumbnail(
@@ -69,6 +97,41 @@ def generate_thumbnail(
             return 1
         except Exception:
             return 0
+
+
+def save_pil_images_as_thumbnails(
+    images: list['Image.Image'],
+    doc_dir: Path,
+    overwrite: bool = False,
+) -> int:
+    """Persist a list of in-memory PIL images as ``doc_dir/{1..N}.jpg``.
+
+    Used by the LLM pipeline to "capitalize" on the cover extraction
+    it already does: after sending images to the LLM, save them to
+    the dashboard's thumbnail cache instead of throwing them away.
+
+    Saves at the same 400×550 resolution + JPEG quality as the
+    on-demand generator (``generate_thumbnail``), so the two paths
+    produce visually identical caches.
+
+    ``overwrite=False`` (default) skips pages whose file already
+    exists — cheap idempotent re-runs. Returns the number of images
+    actually written.
+    """
+    if not images:
+        return 0
+    doc_dir.mkdir(parents=True, exist_ok=True)
+    n_written = 0
+    for i, img in enumerate(images, start=1):
+        dest = doc_dir / f"{i}.jpg"
+        if dest.exists() and not overwrite:
+            continue
+        try:
+            _resize_and_save(img, dest)
+            n_written += 1
+        except Exception as exc:  # pragma: no cover — defensive
+            log.warning(f"  ⚠ Erreur save thumbnail {dest.name}: {exc}")
+    return n_written
 
 
 def _generate_pdf_thumbnails(

--- a/lib/vision.py
+++ b/lib/vision.py
@@ -367,7 +367,8 @@ def analyze_cover(pdf_path: str, api_key: str = '', endpoint: str = '',
                   max_retries: int = 3,
                   n_pages: int = 1,
                   n_candidates: int = 0,
-                  client: 'LLMClient | None' = None) -> dict | None:
+                  client: 'LLMClient | None' = None,
+                  thumbnail_dir: 'os.PathLike | None' = None) -> dict | None:
     """
     Analyse complète d'une couverture de livre (une ou plusieurs pages).
 
@@ -414,6 +415,20 @@ def analyze_cover(pdf_path: str, api_key: str = '', endpoint: str = '',
             log.info("  ✗ Échec extraction image")
         return {'error': 'extraction'}
 
+    # Étape 1bis: si on a un thumbnail_dir fourni, capitalise sur
+    # l'extraction (déjà faite, gratuite) pour pré-remplir le cache
+    # thumbnail du dashboard. Idempotent — saute les pages déjà en
+    # cache. Pas d'erreur fatale si l'écriture échoue.
+    if thumbnail_dir is not None:
+        try:
+            from pathlib import Path as _Path
+
+            from lib.thumbnail import save_pil_images_as_thumbnails
+            save_pil_images_as_thumbnails(images, _Path(thumbnail_dir))
+        except Exception as exc:  # pragma: no cover — defensive
+            if verbose:
+                log.warning("  ⚠ Save thumbnails KO : {}".format(exc))
+
     if verbose:
         log.info("  → {} page(s) extraite(s)".format(len(images)))
 
@@ -454,7 +469,8 @@ def analyze_cover_cached(pdf_path: str, cache_path: 'str | os.PathLike',
                          max_retries: int = 3,
                          n_pages: int = 1,
                          n_candidates: int = 0,
-                         client: 'LLMClient | None' = None) -> dict | None:
+                         client: 'LLMClient | None' = None,
+                         thumbnail_dir: 'os.PathLike | None' = None) -> dict | None:
     """Version cachée de `analyze_cover()` — lookup JSON avant appel LLM.
 
     Cache hit → retourne le résultat direct (0 token, ~5 ms).
@@ -497,7 +513,8 @@ def analyze_cover_cached(pdf_path: str, cache_path: 'str | os.PathLike',
     result = analyze_cover(
         pdf_path, api_key=api_key, endpoint=endpoint, model=model,
         dpi=dpi, verbose=verbose, max_retries=max_retries,
-        n_pages=n_pages, n_candidates=n_candidates, client=client)
+        n_pages=n_pages, n_candidates=n_candidates, client=client,
+        thumbnail_dir=thumbnail_dir)
 
     if (
         key is not None

--- a/tests/auto/test_taxonomy.py
+++ b/tests/auto/test_taxonomy.py
@@ -2371,6 +2371,36 @@ class TestSoftDeleteBulkEndpoint(TaxonomyTestBase):
         self.assertEqual(r.status_code, 400)
 
 
+class TestThumbnailCacheKeyAlignment(TaxonomyTestBase):
+    """The thumbnail cache dir must be keyed by content (MD5 of head
+    bytes), not by rel_path — so a rename does NOT invalidate the
+    cached cover image. Same key as ``lib.thumbnail.compute_content_key``."""
+
+    def test_cache_dir_keyed_by_content(self):
+        # Two paths, same file content → same cache dir
+        from lib.thumbnail import compute_content_key
+        a = self.target / "01-SCIENCES/PHYSIQUE/mechanics.pdf"
+        b = self.target / "01-SCIENCES/MATHEMATIQUES/algebra.pdf"
+        same_bytes = b"%PDF-1.4 identical bytes for the test"
+        a.write_bytes(same_bytes)
+        b.write_bytes(same_bytes)
+        key_a = compute_content_key(a)
+        key_b = compute_content_key(b)
+        self.assertIsNotNone(key_a)
+        self.assertEqual(key_a, key_b)
+        # taxonomy._thumbnail_cache_dir uses the same key for both
+        dir_a = taxonomy._thumbnail_cache_dir(self.profile_name, a)
+        dir_b = taxonomy._thumbnail_cache_dir(self.profile_name, b)
+        self.assertEqual(dir_a, dir_b)
+
+    def test_cache_dir_returns_none_for_unreadable(self):
+        # Empty file (no head bytes) → no key → no cache dir
+        ghost = self.target / "ghost.pdf"
+        ghost.write_bytes(b"")
+        self.assertIsNone(
+            taxonomy._thumbnail_cache_dir(self.profile_name, ghost))
+
+
 class TestMoveFile(TaxonomyTestBase):
 
     def test_happy_path(self):

--- a/tests/auto/test_thumbnail.py
+++ b/tests/auto/test_thumbnail.py
@@ -17,10 +17,12 @@ from lib.thumbnail import (
     THUMBNAIL_WIDTH,
     _generate_placeholder_thumbnail,
     clear_cache,
+    compute_content_key,
     count_pages,
     generate_thumbnail,
     get_cache_stats,
     get_doc_dir,
+    save_pil_images_as_thumbnails,
 )
 
 
@@ -278,6 +280,101 @@ class TestCache(unittest.TestCase):
         stats = get_cache_stats(self.tmp / "missing")
         self.assertEqual(stats["count"], 0)
         self.assertEqual(stats["size_bytes"], 0)
+
+
+class TestComputeContentKey(unittest.TestCase):
+    """compute_content_key returns a stable MD5 of the file's head bytes,
+    independent of the file path."""
+
+    def setUp(self):
+        self.tmpdir = Path(tempfile.mkdtemp(prefix="klodo-thumb-key-"))
+
+    def tearDown(self):
+        shutil.rmtree(self.tmpdir, ignore_errors=True)
+
+    def test_returns_16_char_hex(self):
+        f = self.tmpdir / "foo.pdf"
+        f.write_bytes(b"%PDF-1.4 some content")
+        key = compute_content_key(f)
+        self.assertIsNotNone(key)
+        self.assertEqual(len(key), 16)
+        self.assertRegex(key, r"^[0-9a-f]{16}$")
+
+    def test_same_content_same_key_regardless_of_path(self):
+        # The whole point of this key: survives renames.
+        a = self.tmpdir / "original-name.pdf"
+        b = self.tmpdir / "renamed-totally-differently.pdf"
+        payload = b"%PDF-1.4 same bytes here"
+        a.write_bytes(payload)
+        b.write_bytes(payload)
+        self.assertEqual(compute_content_key(a), compute_content_key(b))
+
+    def test_different_content_different_key(self):
+        a = self.tmpdir / "a.pdf"
+        b = self.tmpdir / "b.pdf"
+        a.write_bytes(b"%PDF-1.4 first")
+        b.write_bytes(b"%PDF-1.4 second")
+        self.assertNotEqual(compute_content_key(a), compute_content_key(b))
+
+    def test_missing_file_returns_none(self):
+        self.assertIsNone(compute_content_key(self.tmpdir / "ghost.pdf"))
+
+    def test_empty_file_returns_none(self):
+        f = self.tmpdir / "empty.pdf"
+        f.write_bytes(b"")
+        self.assertIsNone(compute_content_key(f))
+
+
+class TestSavePilImagesAsThumbnails(unittest.TestCase):
+    """save_pil_images_as_thumbnails persists in-memory PIL images so the
+    LLM pipeline can capitalize on its cover extraction."""
+
+    def setUp(self):
+        self.tmpdir = Path(tempfile.mkdtemp(prefix="klodo-thumb-save-"))
+
+    def tearDown(self):
+        shutil.rmtree(self.tmpdir, ignore_errors=True)
+
+    def _img(self, color=(200, 50, 50)):
+        return Image.new("RGB", (800, 1200), color)
+
+    def test_writes_n_jpgs(self):
+        imgs = [self._img(), self._img(color=(50, 200, 50)),
+                self._img(color=(50, 50, 200))]
+        n = save_pil_images_as_thumbnails(imgs, self.tmpdir)
+        self.assertEqual(n, 3)
+        for i in (1, 2, 3):
+            f = self.tmpdir / f"{i}.jpg"
+            self.assertTrue(f.exists())
+            # All at the standard thumbnail size
+            with Image.open(f) as out:
+                self.assertLessEqual(out.width, THUMBNAIL_WIDTH)
+                self.assertLessEqual(out.height, THUMBNAIL_HEIGHT)
+
+    def test_idempotent_skips_existing(self):
+        imgs = [self._img()]
+        save_pil_images_as_thumbnails(imgs, self.tmpdir)
+        # Second call should skip (overwrite=False is the default)
+        n = save_pil_images_as_thumbnails(imgs, self.tmpdir)
+        self.assertEqual(n, 0)
+
+    def test_overwrite_true_rewrites(self):
+        imgs = [self._img()]
+        save_pil_images_as_thumbnails(imgs, self.tmpdir)
+        n = save_pil_images_as_thumbnails(imgs, self.tmpdir, overwrite=True)
+        self.assertEqual(n, 1)
+
+    def test_empty_list_no_op(self):
+        n = save_pil_images_as_thumbnails([], self.tmpdir)
+        self.assertEqual(n, 0)
+
+    def test_creates_doc_dir_if_missing(self):
+        nested = self.tmpdir / "deeply" / "nested" / "newdir"
+        self.assertFalse(nested.exists())
+        n = save_pil_images_as_thumbnails([self._img()], nested)
+        self.assertEqual(n, 1)
+        self.assertTrue(nested.exists())
+        self.assertTrue((nested / "1.jpg").exists())
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Description

Trois changements coordonnés pour arrêter de dupliquer le travail d'extraction de cover entre le pipeline LLM et le viewer du dashboard.

### C — Cache thumbnail content-keyed (survit aux renames)

`dashboard/taxonomy._thumbnail_cache_dir` était keyé par `SHA1(rel_path)[:16]`. Chaque rename invalidait → regénération. Maintenant **keyé par MD5(file head bytes)** via `lib.thumbnail.compute_content_key`. Même idée que `vision_cache` : le cache suit le fichier, pas son emplacement.

### A — Hook pipeline qui save les thumbnails gratuitement

`lib.vision.analyze_cover` accepte maintenant un param optionnel `thumbnail_dir`. Après extraction des pages pour le LLM (l'étape coûteuse), si fourni, les images PIL sont dumpées sur disque comme JPEG 400×550 via le nouveau helper `lib.thumbnail.save_pil_images_as_thumbnails`. Idempotent.

Branché dans `process_single_file` + `make_llm_rename_callback`, et les 3 callers (classify / rename / process) passent `thumbnails_base_dir = profile.cache_dir/"thumbnails"`. Tout futur `klodo.sh classify|rename|process` peuplera silencieusement le cache thumbnail du dashboard.

### B — Commande CLI pour le backlog existant (18k fichiers)

`./klodo.sh thumbnails [--execute] [--max N] [--force]` :
- Dry-run par défaut (compte ce qu'il y a à faire)
- `--execute` génère vraiment, avec progress bar + ETA
- `--max N` pour tester
- `--force` régénère même les caches existants

Estimation : **~15-20 min** pour 18k fichiers (juste poppler à 150 dpi, pas d'appel LLM).

## Tests (11 new)

- `test_thumbnail.TestComputeContentKey` × 5 — clé 16-char hex stable, indépendante du path, change avec le contenu, None sur fichier vide/manquant.
- `test_thumbnail.TestSavePilImagesAsThumbnails` × 5 — N images, idempotent, overwrite, no-op, création parent dir.
- `test_taxonomy.TestThumbnailCacheKeyAlignment` × 2 — alignement de la clé entre dashboard et lib.

**Smoke test** dry-run de la CLI sur le profil réel : 5/5 fichiers détectés, clés content-based affichées.

**809/809** tests verts. Lint clean.

## Pour ton existant

Après merge, lance une fois :
```bash
./klodo.sh thumbnails --profile default --execute
```
~15-20 min, plus jamais besoin d'attendre l'extraction au clic dans le dashboard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)