### PR TITLE
docs: update for trigger N3, dashboard taxonomy/rename + agent refonte spec

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@
 
 **Klodo** est un outil CLI qui organise automatiquement de grandes bibliothèques de fichiers PDF. Il combine un modèle de vision (LLM Vision) pour identifier les livres par leur couverture, un système de classification hybride à 4 niveaux, et un mécanisme d'auto-apprentissage qui s'améliore à chaque utilisation.
 
-Déposez vos PDF, lancez une commande, récupérez une bibliothèque classée.
+Déposez vos PDF, lancez une commande, récupérez une bibliothèque classée. Affinez ensuite à la main via le **dashboard FastAPI** (sous-onglets Mappings / Catégories / Rename, drag-drop, audit + undo, multi-select bulk).
 
 <p align="center">
   <img src="docs/diagrams/pipeline-principal.svg" alt="Pipeline principal" width="700">
@@ -101,6 +101,9 @@ uv sync
 | `rename` | Renommage intelligent (ISBN, métadonnées, LLM Vision) | [renommage.md](docs/renommage.md) |
 | `refine` | Raffinement récursif des sous-catégories | [raffinement.md](docs/raffinement.md) |
 | `suggest` | Review des suggestions de nouveaux dossiers | [classification.md](docs/classification.md#niveau-4--suggestions) |
+| `thumbnails` | Backfill du cache thumbnail du dashboard (idempotent, resumable) | [architecture.md](docs/architecture.md) |
+| `detect` | Détecter un pattern de nommage via LLM depuis un échantillon | [renommage.md](docs/renommage.md) |
+| `dashboard` | Lancer le dashboard FastAPI (port 8080 par défaut) | [functional-testing-and-dashboard.md](docs/functional-testing-and-dashboard.md) |
 | `clean` | Nettoyer le cache du profil (progress, isbn, logs, all) | — |
 | `profiles` | Lister les profils disponibles | [profils.md](docs/profils.md) |
 | `init` | Créer un nouveau profil | [profils.md](docs/profils.md#créer-un-profil) |

--- a/commands/CLAUDE.md
+++ b/commands/CLAUDE.md
@@ -10,6 +10,7 @@ Point d'entrée unique : [../klodo.py](../klodo.py) avec sous-commandes argparse
 - **[process.py](process.py)** — `cmd_process` (pipeline complet, import direct `lib.renamer`)
 - **[misc.py](misc.py)** — `cmd_profiles`, `cmd_init`, `cmd_suggest`, `cmd_clean`
 - **[detect.py](detect.py)** — `cmd_detect` : sélection interactive ou par `--files`/`--dir`, appelle `lib.pattern_detector.detect_pattern()`, affiche le résultat et peut injecter dans `profile.yaml` (préserve les commentaires) avec `--execute`
+- **[thumbnails.py](thumbnails.py)** — `cmd_thumbnails` : backfill du cache thumbnail du dashboard. Itère sur tous les PDF/ePub du profil, calcule la clé content-based (MD5 head bytes), génère les pages manquantes via `lib.thumbnail.generate_thumbnail` (idempotent — skip si déjà en cache). Options `--pages N` (1-5), `--max M`, `--force`. Affiche progress + ETA + cost estimate
 
 ## Flags importants
 - `--execute` : appliquer les changements (sinon dry-run). **Ne jamais lancer `--execute` sans review du rapport.**

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -124,6 +124,43 @@ Charge et valide les fichiers YAML d'un profil. Supporte les valeurs par défaut
 
 Sanitize des noms de fichiers, génération de rapports CSV, résumés console, et fonctions de renommage partagées.
 
+### `rename_template.py` — Moteur de template (audit dashboard)
+
+Parser + renderer pour le pattern de renommage configurable (`{title}{ - author}` par défaut, blocs optionnels `{ - var }`, sanitization NFKC + chars FS-safe, troncature word-boundary). Utilisé par le sous-onglet **Rename** du dashboard pour proposer un nom suggéré à partir des metadata LLM.
+
+### `rename_journal.py` — Journal de renommages
+
+Persistance append-only JSONL des opérations de renommage (`profile/.cache/rename-journal.jsonl`). Gère `append_rename`, `undo_record` (avec guard case-insensitive APFS), `undo_batch` (records groupés par `batch_id` partagé). Les undos sont eux-mêmes journalisés sous `batch: "undo-<batch_id>"` pour audit trail complet.
+
+→ [Documentation complète](renommage.md#renommage-dashboard--audit-journal-undo)
+
+### `thumbnail.py` — Génération de miniatures (PDF + ePub)
+
+Génère les pages JPEG 400×550 pour le viewer du dashboard. **Cache content-keyed** : `profile/.cache/thumbnails/<MD5_head_bytes>[16]/{1..n}.jpg` — la clé survit aux renames. Idempotent au niveau page (skip si `N.jpg` existe). Helper `compute_content_key(path)` exposé pour aligner le pipeline LLM (qui peut sauver le thumbnail au passage via `save_pil_images_as_thumbnails`).
+
+CLI dédiée : `./klodo.sh thumbnails --execute [--pages N] [--max M] [--force]` pour backfill batch.
+
+## Dashboard FastAPI
+
+Le module `dashboard/` est une appli FastAPI + Jinja2 + HTMX qui sert d'IDE pour la bibliothèque (port 8080). Quatre couches :
+
+- **Routes** (`dashboard/app.py`) — 12+ pages : Overview, Tests, Rapports, Comparer, Métriques, Historique, Logs, Curation, Baseline, Taxonomie, Suggestions, Admin
+- **Couche données** (`dashboard/data.py`) — fusion YAML + JSON + DuckDB + CSV + helpers viewer
+- **Modules dédiés** :
+  - `taxonomy.py` — agrégation `tree.yaml + theme_mapping.yaml + vision_cache.json`, drag-drop, backup auto, lock concurrence, ops fichier (delete soft / move avec impact preview / bulk)
+  - `rename.py` — audit + apply + journal + undo (record/batch) + override + cache patch ciblé
+  - `categories.py` — CRUD sur `categories.yaml`, audit des dormants
+  - `baseline.py` — agrégation des disagreements d'un baseline_run
+- **Couche présentation** — Jinja2 templates dans `dashboard/templates/`, JS modulaires dans `dashboard/static/js/` (`taxonomy.js`, `taxonomy_rename.js`, `taxonomy_categories.js`, etc.), CSS dark theme dans `dashboard/static/style.css`
+
+Onglet **Taxonomie** (cockpit principal d'édition) : 3 sous-onglets
+
+1. **Mappings** — arbre des dossiers + viewer PDF + card LLM + treemap interactif + drag-drop thème → dossier + ops fichier (delete / move avec impact preview classify_combined)
+2. **Catégories** — CRUD de `categories.yaml` (groupes + entrées + mots-clés) + audit des dormants
+3. **Rename** — audit divergence nom-actuel vs nom-suggéré + bulk rename + override + 📜 historique avec undo
+
+→ [Documentation complète du dashboard](functional-testing-and-dashboard.md)
+
 ## Flux de données
 
 <p align="center">

--- a/docs/classification.md
+++ b/docs/classification.md
@@ -99,7 +99,7 @@ L'option `--pages N` envoie les N premières pages au lieu de la seule couvertur
 
 **Module** : `lib/vision.py` — Fonctions : `extract_cover_image()`, `image_to_base64()`, `call_vision_api()`, `analyze_cover()`.
 
-## Niveau 1 : Theme Mapping
+## Niveau 1 : Theme Mapping (+ trigger conditionnel N3)
 
 Recherche directe du thème dans un dictionnaire de 355+ entrées (`theme_mapping.yaml`).
 
@@ -113,6 +113,37 @@ Islamic Finance: 05-RELIGIONS/ISLAM
 ```
 
 C'est le chemin le plus rapide : une simple lookup dans un dictionnaire. Aucun appel API, aucun calcul. Résout ~80% des fichiers au premier passage.
+
+### Trigger conditionnel N3 sur catch-all
+
+Le mapping résout parfois sur un **dossier catch-all** : `02-INFORMATIQUE/03-Langages-Programmation/Autres`, `05-RELIGIONS/AUTRES-RELIGIONS`, `01-SCIENCES/MATHEMATIQUES/08-Mathematiques-Generales`, etc. C'est l'aveu éditorial que `theme_mapping.yaml` n'a pas plus précis pour ce thème — alors qu'un sous-dossier sœur plus spécifique existe dans `tree.yaml`.
+
+Pour ces ~12% des fichiers, le système appelle conditionnellement le **LLM Mapper (Niveau 3)** pour challenger N1, **sans toucher aux 88% restants** (qui sortent du Niveau 1 propres et gratuits).
+
+Garde-fous (cf. `lib.classifier._challenge_generic_fallback`) :
+
+- **Même section top-level** : refus des swaps inter-sections (ceux-là sont de vrais désaccords, traités ailleurs)
+- **Cible non catch-all elle-même** : pas de swap inutile vers un autre `/Autres`
+- **Profondeur ≥ N1** : N3 ne peut pas promouvoir vers un ancêtre générique
+
+Exemples mesurés empiriquement (audit 100 fichiers, seed=42) :
+
+| N1 (catch-all) | N3 (trigger fired) |
+|---|---|
+| `/Langages-Programmation/Autres` | `/Langages-Programmation/Java` (Java I/O) |
+| `/Langages-Programmation/Autres` | `/Langages-Programmation/C-Cpp-CSharp` (Exceptional C++) |
+| `/Langages-Programmation/Autres` | `/Systemes-OS/Linux-Unix` (Advanced UNIX Programming) |
+
+**Coût / bénéfice mesuré** :
+
+- Trigger fire sur **12%** des fichiers (les catch-all)
+- Upgrade effectif sur **6%** des fichiers (50% taux de succès sur les catch-all)
+- Coût LLM additionnel : **~+12%** vs cascade pure
+- **5/6 upgrades objectivement meilleurs** (revue manuelle des 6 cas)
+
+L'alternative envisagée (parallélisation systématique N1+N2+N3 sur 100% des fichiers) aurait coûté ×5 pour ~3% de gain marginal — non rentable. Le trigger ciblé est le bon compromis.
+
+Le résultat retourne sous le label **`LLM (theme→N3-refined)`** dans le CSV de classification pour distinguer les cas où le trigger a tiré.
 
 ## Niveau 2 : Keyword Matcher
 

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -100,11 +100,16 @@ class TestMaFeature(unittest.TestCase):
 Voici des pistes pour contribuer :
 
 - **Nouveaux providers LLM** — Support OpenAI, Anthropic, Mistral, Google
-- **Interface web** — Dashboard pour visualiser et reviewer les suggestions
 - **Détection de langue** — Identifier automatiquement la langue du PDF
 - **Index SQLite** — Base de données légère pour recherche rapide
-- **Couvertures** — Extraction et stockage des thumbnails pour aperçu visuel
 - **Prompts templatisés** — Permettre de surcharger les prompts LLM par profil
+- **Agents IA** — Cf. [refonte-agent-spec.md](refonte-agent-spec.md) pour le premier agent envisagé (refonte de taxonomy en 3 phases : diagnostic → proposition → dialog), puis onboarding nouveau profil et curation interactive
+
+Idées déjà livrées (à titre de référence) :
+
+- ✅ **Interface web** — dashboard FastAPI + HTMX (Taxonomie, Rename, Curation, etc.)
+- ✅ **Couvertures** — `lib/thumbnail.py` + cache content-keyed unifié + CLI `./klodo.sh thumbnails`
+- ✅ **Audit de renommages + undo** — journal append-only JSONL avec batch + override par contenu
 
 ## Structure des rapports
 

--- a/docs/functional-testing-and-dashboard.md
+++ b/docs/functional-testing-and-dashboard.md
@@ -287,6 +287,53 @@ L'onglet **Curation** (`/viewer`) permet de constituer des jeux de tests sur mes
 
 **Mockup statique** : `/viewer-mockup` reste accessible comme reference visuelle (bandeau "Mockup non fonctionnel").
 
+### Onglet Taxonomie — cockpit d'édition
+
+L'onglet **Taxonomie** est l'IDE de la bibliothèque. 3 sous-onglets, profil sélectionnable via dropdown, lock concurrence (`.taxonomy.lock`) + backup auto avant chaque write (rotation 20).
+
+**Sous-onglet Mappings** — vue 3 colonnes :
+
+- Col 1 (arbre) : `tree.yaml` + comptes fichiers par dossier, lazy load 50 fichiers/page, drag-drop de dossiers, search par nom de dossier. Checkbox hover-revealed sur chaque ligne fichier + bouton 🗑 inline → multi-select bulk + soft-delete vers `<target>/.trash/<ts>/`
+- Col 2 (centre) : viewer PDF multi-pages + card "Analyse LLM" (titre, auteur, langue, themes détectés, prédiction classify_by_theme) + treemap interactif 1-niveau avec drill-down + sous-bloc "Renommage" (cross-link vers sous-onglet Rename) + actions fichier (🗑 Supprimer, ➡ Déplacer vers… avec impact preview)
+- Col 3 (thèmes) : top "Thèmes mappés" du dossier sélectionné + bottom "Thèmes LLM" filtrable (recherche, orphelins uniquement) avec drag-drop thème → dossier
+
+Ops fichier dans Mappings :
+
+- **🗑 Supprimer** : soft delete vers `<target>/.trash/<YYYYMMDD-HHMMSS>/` + journal `file-trash-journal.jsonl`. Réversible via Finder. Refus de re-trash.
+- **➡ Déplacer** : popover autocomplete sur l'arborescence + **impact preview** via `classify_combined` — si la dest ne matche pas le predicted_folder, l'UI avertit que le fichier sera proposé pour retour au prochain reclassify (le bon endroit pour rendre un déplacement permanent reste le mapping de thème, pas le move manuel)
+- **Bulk delete** : sticky bar en bas de col 1 quand ≥1 fichier coché, single batch_id partagé pour grouper
+
+Endpoints clés :
+
+| Méthode | Route | Rôle |
+|---|---|---|
+| `POST` | `/api/taxonomy/file/delete` | Soft delete vers `.trash/` |
+| `GET` | `/api/taxonomy/file/move-impact` | Preview impact avant déplacement |
+| `POST` | `/api/taxonomy/file/move` | Move + cache invalidation |
+| `POST` | `/api/taxonomy/file/delete-bulk` | Soft delete batch (best-effort) |
+| `POST` | `/api/taxonomy/mapping` | Ajouter un mapping thème → dossier |
+| `POST` | `/api/taxonomy/folder` | Créer un sous-dossier |
+| `GET` | `/api/taxonomy/reclassify/dryrun` | Aperçu de ce que reclassify bougerait |
+
+**Sous-onglet Catégories** — 3 phases livrées :
+
+- **Phase A (read-only)** : navigation dans `categories.yaml`, groupes → entrées → mots-clés
+- **Phase B (CRUD)** : ajout / édition / suppression d'entrées et de mots-clés, drag-drop entre entrées
+- **Phase C (audit dormants)** : repère les entrées qui n'ont matché aucun fichier dans le dernier baseline_run
+
+**Sous-onglet Rename** — feature audit complet :
+
+- **Col 1** : liste filtrable des candidats (placeholder / divergent / minor_case / ok), search bar par nom, multi-select checkboxes + bulkbar sticky (Renommer suggestion / ✓ Marquer OK / Tout désélectionner)
+- **Col 2** : viewer multi-pages + card LLM + cross-link cliquable depuis le sous-onglet Mappings (`tax-navigate-file` event)
+- **Col 3** : nom suggéré éditable + bouton Renommer + confirm modal
+- **Modale 📜 Renommages** (sub-badge ⚠ count session-active sur le bouton) : 2 onglets *Tous* (record-by-record) et *Par lot* (groupé par batch_id) + bouton ↶ Annuler par ligne ou batch entier
+- **Override** : "Marquer comme OK" persisté dans `rename-overrides.json` keyé par cache_key MD5 — survit aux renames
+- **🔄 Rescan** : invalidation du cache audit + scan complet (utile après ajout manuel ou cycle `klodo.sh rename`)
+
+Performance : le cache audit (rebuild ~5s pour 18k fichiers) est patché en place après chaque rename (<50ms) → UI quasi-instantanée.
+
+→ Voir [renommage.md](renommage.md#renommage-dashboard--audit-journal-undo) pour le détail du journal + undo + override.
+
 ### Onglet Logs — viewer des rapports utilisateur
 
 L'onglet **Logs** (`/logs`) affiche les rapports CSV utilisateur dans `logs/` (rapport_rename, rapport_classify, rapport_process, refine). Filtre par type, recherche par nom, tri colonnes, pagination 50 lignes/page. Path traversal protege via `_is_safe_file_path()`.

--- a/docs/refonte-agent-spec.md
+++ b/docs/refonte-agent-spec.md
@@ -1,0 +1,392 @@
+# Spec — Agent IA « Refonte de taxonomie »
+
+[← Retour au README](../README.md) · [Architecture](architecture.md) · [Classification](classification.md)
+
+> **Statut** : spec en cours de validation · décomposition en 3 phases shippables (A → B → C).
+> **Audience** : devs Klodo + futurs contributeurs sur la couche agent.
+
+---
+
+## Pourquoi un agent
+
+Klodo dispose aujourd'hui d'une cascade de classification **déterministe et rapide** (cf. [classification.md](classification.md)). Elle résout ~99 % des fichiers correctement après auto-apprentissage. Ce n'est PAS ce qu'on cherche à remplacer.
+
+Ce qu'on cherche à résoudre : trois usages **haut-niveau, créatifs, conversationnels** où la cascade actuelle est inadaptée parce qu'ils demandent du raisonnement multi-étapes avec mémoire et itération :
+
+1. **Refonte de taxonomie** (cette spec) — *"regarde ma biblio existante, propose-moi une arborescence améliorée."*
+2. **Onboarding nouveau profil** (spec à venir) — *"j'ai un dossier de 500 PDF inconnus, bootstrap un profil propre."*
+3. **Curation interactive** (spec à venir) — *"aide-moi à reviewer ces 200 fichiers non classifiés un par un."*
+
+Les trois agents partagent **les mêmes outils sous-jacents** (theme_mapping, classify_combined, vision_cache, tree.yaml, categories.yaml). Construire l'agent refonte en premier produit ~80 % du scaffolding pour les deux autres.
+
+## Hors scope (explicitement)
+
+- **Classification de masse fichier-par-fichier** — la cascade actuelle est ×30-100 plus rapide et économique. Aucun agent ne fera mieux.
+- **Remplacement du pipeline** — l'agent **utilise** les briques existantes via outils ; il ne les réécrit pas.
+- **Modification automatique sans validation humaine** — chaque mutation passe par une étape "review + accept" explicite.
+
+## Architecture cible
+
+```text
+┌──────────────────────────────────────────────────────────────────┐
+│                    Refonte Agent (LangGraph)                     │
+│                                                                  │
+│   ┌────────────┐    ┌────────────┐    ┌────────────┐             │
+│   │ Phase A    │ →  │ Phase B    │ →  │ Phase C    │             │
+│   │ Diagnostic │    │ Proposition│    │ Dialog     │             │
+│   └────────────┘    └────────────┘    └────────────┘             │
+│        ↓ read-only      ↓ read+yaml      ↓ conversational        │
+└──────────────────────────────────────────────────────────────────┘
+        ↓ shared tools (read/write)
+┌──────────────────────────────────────────────────────────────────┐
+│  lib.classifier.classify_combined  (sans LLM Mapper en lecture)  │
+│  dashboard.taxonomy.build_snapshot                               │
+│  dashboard.reclassify.reclassify_dryrun                          │
+│  lib.rename_journal     (journal des actions agent)              │
+│  profile/.cache/*       (snapshots, backups, taxonomy.lock)      │
+└──────────────────────────────────────────────────────────────────┘
+```
+
+L'agent vit dans `agents/` (nouveau module Python). Frontend : nouvel onglet **Refonte** dans Taxonomie + endpoints `/api/agent/refonte/*`.
+
+---
+
+## Phase A — Diagnostic (read-only)
+
+### Objectif
+
+L'agent analyse la taxonomy existante d'un profil et produit un **rapport** lisible d'anomalies. **Aucune mutation YAML.** L'utilisateur lit, comprend, valide la pertinence avant d'autoriser la suite.
+
+### Ce que l'agent diagnostique
+
+- **Dossiers sous-utilisés** (< 5 fichiers) → candidats à fusion
+- **Dossiers sur-utilisés** (> 200 fichiers) → candidats à scission
+- **Thèmes ambigus** (mappés vers plusieurs sections incompatibles)
+- **Doublons sémantiques** (`/AI` et `/Machine-Learning` côte à côte)
+- **Sections déséquilibrées** (profondeur 1 vs 4 niveaux dans la même section)
+- **Catch-all qui débordent** (où `/Autres` collecte > 30 fichiers — signal qu'un sous-dossier manque)
+- **Couverture vision_cache** (% de fichiers avec metadata exploitable, par section)
+- **Auto-learning theme_mapping** (combien d'entrées apprises vs curées manuellement)
+
+### Sortie
+
+Rapport markdown structuré dans `profile/.cache/refonte/diagnostic-<ts>.md` :
+
+```markdown
+# Diagnostic taxonomy — profil `default` — 2026-05-24
+
+## Stats globales
+- 18 425 fichiers · 88 dossiers · profondeur moy. 2.7
+- Couverture LLM : 99 % (18 237 / 18 425)
+
+## Anomalies détectées (par priorité)
+### Sous-utilisés (8 dossiers)
+- `/01-SCIENCES/EPISTEMOLOGIE` (3 fichiers) — fusion avec `/04-SHS/PHILOSOPHIE` ?
+- ...
+
+### Catch-all qui débordent (2 candidats)
+- `/02-INFORMATIQUE/03-Langages/Autres` (47 fichiers) — vu ~10 Java + 8 C++ + 5 Go isolés
+- ...
+
+### Doublons sémantiques (1)
+- `/02-INFORMATIQUE/05-IA-ML/Machine-Learning` et `/02-INFORMATIQUE/05-IA-ML/Deep-Learning` — chevauchement de 60 % des thèmes mappés
+```
+
+### Outils nécessaires (read-only)
+
+| Outil | Source | Rôle |
+|---|---|---|
+| `list_folders(profile)` | `tree.yaml` | Énumération |
+| `count_files_per_folder(profile)` | `os.walk(target)` | Stats utilisation |
+| `read_theme_mapping(profile)` | `theme_mapping.yaml` | Thèmes mappés |
+| `read_categories(profile)` | `categories.yaml` | Mots-clés |
+| `list_themes_per_folder(profile)` | `vision_cache.json` | Thèmes LLM observés |
+| `compute_folder_overlap(folder_a, folder_b)` | combinaison | Détection doublons |
+
+### Endpoint
+
+`POST /api/agent/refonte/diagnostic` body `{profile}` → kick-off async. `GET /api/agent/refonte/diagnostic/<run_id>` → status (pending/running/done) + lien vers le rapport.
+
+### Garde-fous Phase A
+
+- Lecture seule absolue (aucune écriture sur les YAML / FS).
+- Idempotent : 2 runs sur le même état produisent le même rapport.
+- Stockage du rapport hors git (`.cache/`) — pas de pollution.
+- Coût LLM borné : ≤ 5 appels (l'agent peut résumer mais ne fait pas un appel par fichier).
+
+---
+
+## Phase B — Proposition (read + nouveau YAML séparé)
+
+### Objectif
+
+À partir du diagnostic, l'agent **propose une nouvelle taxonomy** sous forme d'un fichier `tree-proposed.yaml` + `theme_mapping-proposed.yaml` séparés. L'utilisateur peut **comparer** (diff visuel) et **simuler l'impact** via `reclassify_dryrun` avant de décider quoi que ce soit.
+
+### Ce que l'agent produit
+
+1. **`tree-proposed.yaml`** — arborescence proposée
+2. **`theme_mapping-proposed.yaml`** — mapping enrichi pour matcher la nouvelle arborescence
+3. **`refonte-rationale.md`** — explication par changement (créations, fusions, renommages, scissions)
+4. **`reclassify-projection.csv`** — pour chaque fichier de la biblio actuelle, où il irait avec la nouvelle taxonomy
+
+### Format `refonte-rationale.md`
+
+```markdown
+## Changements proposés
+
+### CRÉATIONS (3)
+- `/02-INFORMATIQUE/03-Langages/Java` — récupère 14 fichiers Java actuellement dans /Autres
+- `/02-INFORMATIQUE/03-Langages/C-Cpp` — récupère 8 fichiers C++
+- ...
+
+### FUSIONS (1)
+- `/04-SHS/PHILOSOPHIE` + `/01-SCIENCES/EPISTEMOLOGIE` → `/04-SHS/PHILOSOPHIE-EPISTEMOLOGIE`
+  Raison : 3 fichiers chacun, themes très proches (philosophie de la science)
+
+### RENOMMAGES (0)
+
+### MAPPINGS AJOUTÉS (12)
+- `Java I/O` → `/02-INFORMATIQUE/03-Langages/Java`
+- ...
+```
+
+### Comparaison + simulation
+
+L'UI affiche :
+
+- **Diff visuel** entre `tree.yaml` actuel et `tree-proposed.yaml` (ajouts vert, suppressions rouge, fusions orange)
+- **Histogramme avant/après** : nombre de fichiers par dossier
+- **Reclassify projection** : combien de fichiers bougent, combien restent, combien vont vers les nouveaux dossiers
+
+### Itération
+
+L'utilisateur peut demander : *"j'aime A mais pas la fusion B"*. L'agent regenère une proposition révisée. Conservation de l'historique des propositions (versionnage interne `.cache/refonte/proposals/v1/`, `v2/`, etc.).
+
+### Garde-fous Phase B
+
+- **Aucune mutation des YAML de production** — tout reste dans `.cache/refonte/proposals/<run_id>/`
+- **Lock concurrence** : `taxonomy.lock` empêche un baseline_run pendant la génération
+- **Reclassify projection en dry-run uniquement** — pas de move FS
+- Coût LLM borné : ≤ 30 appels (raisonnement + itérations)
+
+---
+
+## Phase C — Dialog (conversational + commits)
+
+### Objectif
+
+Conversation continue où l'agent peut **appliquer les changements** validés sur les YAML de production. Chaque mutation passe par une étape "preview + confirm". L'agent peut aussi proposer des **micro-actions** de manière interactive (renommer une section, absorber un sous-dossier, etc.).
+
+### Exemples de tour de conversation
+
+> **User** — Crée la section `/02-INFORMATIQUE/03-Langages/Rust`
+> **Agent** — Voilà la proposition de mutation :
+>   - `tree.yaml` : ajout de la ligne `02-INFORMATIQUE/03-Langages/Rust`
+>   - `theme_mapping.yaml` : ajout de `Rust: 02-INFORMATIQUE/03-Langages/Rust`
+>   - 3 fichiers candidats pour migrer ici (cf. preview ↓)
+>   Confirmer ? [Apply / Skip / Modify]
+
+> **User** — Apply
+> **Agent** — Backup créé (`taxonomy-backups/2026-05-24-14h30/`). Mutation appliquée. Reclassify dry-run lancé en arrière-plan.
+
+### Tools mutables (read + write)
+
+| Outil | Effet |
+|---|---|
+| `add_folder(path)` | Ajoute dans `tree.yaml` + crée le dossier physique |
+| `merge_folders(src_paths, dest_path)` | Renomme + déplace fichiers + supprime sources |
+| `rename_folder(old, new)` | Renomme physique + tree.yaml + remappe les thèmes |
+| `add_theme_mapping(theme, path)` | Ajoute dans `theme_mapping.yaml` |
+| `bulk_move_files(rel_paths, dest_folder)` | Wrap de `taxonomy.move_file` (impact preview obligatoire) |
+
+### Journal agent
+
+Toutes les actions sont écrites dans `profile/.cache/refonte/agent-journal.jsonl` (même pattern que `rename-journal.jsonl`). Chaque entrée :
+
+- `ts`, `tool_called`, `args`, `result`, `human_validated: true/false`
+- Permet undo, audit, et bootstrap d'un futur "rejouer la session sur un autre profil"
+
+### Garde-fous Phase C
+
+- **Backup automatique** avant chaque mutation (rotation 50)
+- **Confirmation humaine obligatoire** par mutation (pas de mode auto)
+- **Lock concurrence** `taxonomy.lock` actif pendant l'exécution
+- **Limitation des appels LLM par tour** (≤ 5 par message utilisateur)
+- **Rollback en 1 clic** depuis le dashboard (réutilise les backups existants)
+
+---
+
+## Plan de développement
+
+### Vue d'ensemble
+
+| Phase | Durée estimée | Livrables |
+|---|---|---|
+| **A — Diagnostic** | ~10-15 j-h | endpoint + agent LangGraph + 6 outils read-only + rapport markdown + UI minimal |
+| **B — Proposition** | ~10-15 j-h | YAML séparés + diff visuel + reclassify projection + itération + UI complète |
+| **C — Dialog** | ~15-20 j-h | conversation continue + 5 outils mutables + journal + backup + rollback |
+
+**Total : ~35-50 j-h** sur ~6-8 semaines avec validation à chaque palier.
+
+### Phase A — Tasks détaillées
+
+**A.1 — Scaffolding LangGraph** *(2-3 j)*
+
+- [ ] Nouveau module `agents/` avec `agents/refonte/` (séparé de `lib/` pour clarté)
+- [ ] Dépendance `langgraph` ajoutée à `pyproject.toml`
+- [ ] Pattern de construction d'agent (ToolNode, conditional edges, state schema)
+- [ ] Tests unitaires de base (mock LLM, vérifier le graphe se construit)
+- [ ] Décision : modèle LLM par défaut pour l'agent (probablement Sonnet via Anthropic — Qwen3-VL est trop limité pour le raisonnement structuré)
+
+**A.2 — Tools read-only** *(3-4 j)*
+
+- [ ] `list_folders(profile)` — wraps `taxonomy._load_tree`
+- [ ] `count_files_per_folder(profile)` — wraps `taxonomy._scan_folder_counts`
+- [ ] `read_theme_mapping(profile)` — wraps `taxonomy._load_mapping`
+- [ ] `list_themes_per_folder(profile, folder)` — agrégation par folder à partir de `vision_cache.json`
+- [ ] `compute_folder_overlap(folder_a, folder_b)` — Jaccard sur les thèmes mappés
+- [ ] `get_classifier_breakdown(profile)` — % via N1 / N2 / N3 / FAILED sur le dernier reclassify
+- [ ] Tests unitaires pour chaque tool (isolation, données mockées)
+
+**A.3 — Agent diagnostic** *(2-3 j)*
+
+- [ ] State schema : profile, current_step, accumulated_findings
+- [ ] Prompt système : *"tu es un assistant qui analyse la taxonomy d'une biblio Klodo et identifie les anomalies"*
+- [ ] Graphe : `start → list_anomalies → categorize → write_report → end`
+- [ ] Détection systématique des 7 catégories d'anomalies listées plus haut
+- [ ] Budget LLM borné à 5 appels max par run
+- [ ] Sortie : markdown structuré + JSON parsable
+
+**A.4 — Endpoint + UI** *(3-4 j)*
+
+- [ ] `POST /api/agent/refonte/diagnostic` (kick async)
+- [ ] `GET /api/agent/refonte/diagnostic/<run_id>` (status + résultat)
+- [ ] Nouvel onglet **Refonte** dans Taxonomie (col 1 statut runs, col 2 rapport courant)
+- [ ] Stream du markdown via SSE pendant la génération
+- [ ] Tests endpoint + smoke test E2E
+
+**A.5 — Validation + ship** *(1-2 j)*
+
+- [ ] Smoke run sur profil `default` (18k fichiers) — coût estimé : <$1
+- [ ] Review du rapport produit avec l'utilisateur
+- [ ] Itérations sur les prompts si besoin
+- [ ] PR vers `develop`
+
+### Phase B — Tasks détaillées
+
+**B.1 — Tools de proposition** *(2-3 j)*
+
+- [ ] `propose_tree_change(action, args)` — produit un YAML diffable, ne touche pas la prod
+- [ ] `simulate_reclassify(proposed_tree, proposed_mapping)` — wraps `reclassify_dryrun` sur les YAML proposés
+- [ ] `compute_diff(current, proposed)` — diff structuré pour l'UI
+- [ ] `version_proposal(run_id, version, payload)` — versioning dans `.cache/refonte/proposals/`
+
+**B.2 — Agent proposition** *(3-4 j)*
+
+- [ ] Reprend le state de la Phase A (diagnostic en entrée)
+- [ ] Graphe : `read_diagnostic → propose_creations → propose_merges → propose_renamings → validate_consistency → write_proposal`
+- [ ] Validation interne : cohérence du nouveau tree (pas de cycles, pas de mappings vers des folders inexistants)
+- [ ] Génération du `rationale.md`
+- [ ] Budget LLM : ≤ 30 appels (raisonnement + plusieurs itérations possibles)
+
+**B.3 — UI diff + simulation** *(4-5 j)*
+
+- [ ] Diff visuel tree.yaml ↔ tree-proposed.yaml (ajouts/suppressions/renommages colorés)
+- [ ] Histogramme avant/après (nb fichiers par dossier)
+- [ ] Table de projection reclassify (rel_path | from | to | confidence)
+- [ ] Bouton "Itérer" : input texte pour demander des ajustements
+- [ ] Stockage des versions visibles dans une dropdown (v1, v2, v3...)
+
+**B.4 — Tests + ship** *(1-2 j)*
+
+- [ ] Tests unitaires sur tools de proposition
+- [ ] Smoke run sur profil `default` post-diagnostic
+- [ ] Review humaine de 2-3 propositions
+- [ ] PR vers `develop`
+
+### Phase C — Tasks détaillées
+
+**C.1 — Tools mutables** *(3-4 j)*
+
+- [ ] `add_folder(profile, path)` — wraps `taxonomy.create_folder` + backup
+- [ ] `merge_folders(profile, src_paths, dest_path)` — orchestration : créer dest, move files, drop src
+- [ ] `rename_folder(profile, old, new)` — wraps `taxonomy.rename_folder` + remap des thèmes affectés
+- [ ] `add_theme_mapping(profile, theme, path)` — wraps `taxonomy.upsert_mapping`
+- [ ] `bulk_move_files(profile, rel_paths, dest_folder)` — wraps `taxonomy.move_file` en boucle, impact preview obligatoire avant commit
+- [ ] Tests pour chaque outil + tests d'intégration sur les enchaînements
+
+**C.2 — Agent conversationnel** *(4-5 j)*
+
+- [ ] Mémoire conversationnelle (LangGraph checkpointer + persistance JSON)
+- [ ] Graphe : `parse_user_intent → propose_mutation → preview → wait_confirmation → execute_or_skip`
+- [ ] Génération de preview pour chaque mutation avant exécution
+- [ ] Streaming des réponses (SSE)
+- [ ] Budget par tour : ≤ 5 appels LLM, mutation ≤ 1 par tour
+
+**C.3 — Journal + backup + rollback** *(3-4 j)*
+
+- [ ] `agent-journal.jsonl` append-only (même pattern que rename-journal)
+- [ ] Backup auto avant chaque mutation (rotation 50)
+- [ ] Endpoint `POST /api/agent/refonte/rollback` (revert à un snapshot)
+- [ ] UI : timeline des actions + bouton rollback par action
+
+**C.4 — UI chat + ship** *(4-5 j)*
+
+- [ ] Onglet **Refonte** finalisé : col 1 historique runs, col 2 chat, col 3 timeline mutations
+- [ ] Markdown rendering dans la conversation
+- [ ] Boutons d'action (Apply / Skip / Modify) inline dans les messages
+- [ ] Tests E2E
+- [ ] PR vers `develop`
+
+## Tests et validation
+
+| Phase | Tests unitaires | Tests d'intégration | Validation manuelle |
+|---|---|---|---|
+| A | Tools read-only + agent state | Endpoint + UI rendering | Diagnostic sur profil `default` |
+| B | Tools propose + validate | Proposal → simulate → diff | Comparer 2 versions de propositions |
+| C | Tools mutables + journal | Conversation E2E | Sessions de 30 min sur profil `test` |
+
+## Métriques de succès
+
+**Phase A**
+
+- Rapport diagnostic produit en < 60 s pour 18k fichiers
+- 0 false positive sur les anomalies déclarées (validation humaine sur les 10 premières)
+- Coût < $0.50 par run
+
+**Phase B**
+
+- Proposition cohérente (pas de cycles, pas de mappings cassés) : 100 % par construction
+- Itérations utiles : au moins 50 % des propositions itérées améliorent la précédente (mesuré sur 10 sessions test)
+- Coût < $2 par proposition
+
+**Phase C**
+
+- 0 corruption YAML observée sur 100 mutations
+- Rollback fonctionnel en < 10 s
+- Coût < $0.20 par tour de conversation
+
+## Risques identifiés + mitigations
+
+| Risque | Probabilité | Impact | Mitigation |
+|---|---|---|---|
+| Context LLM saturé sur 18k fichiers + 88 dossiers | élevée | majeur | Pré-agrégation (n'envoie pas la liste brute mais des stats résumées) + summarization récursive |
+| Hallucinations sur la proposition | moyenne | majeur | Validation structurelle obligatoire (cycles, mappings cassés) + diff visuel + revue humaine systématique |
+| Coût LLM dérape (le user explore beaucoup) | moyenne | mineur | Budget appel/tour hard-codé + compteur visible UI + warning > $1/session |
+| Rollback YAML race-condition avec un classify en cours | faible | critique | Lock `taxonomy.lock` partagé (existe déjà) + refus de rollback si lock acquis |
+| Agent répond bullshit poliment (mode complaisance) | élevée | majeur | Prompt système strict : *"si tu n'as pas les données, dis 'je ne sais pas' — interdiction de spéculer"* + tests adversariaux |
+
+## Frameworks alternatifs considérés
+
+- **LangGraph** (choix) — graph-based, state explicite, parfait pour des workflows multi-étapes avec branchements conditionnels. Stable, documenté, intégration LangSmith pour le debug.
+- **CrewAI** — orienté multi-agent collaboratif. Overkill pour cette première version (un seul agent suffit).
+- **OpenAI Assistants API** — vendor lock-in, pas de support multi-provider clean. Mauvais fit avec notre stack SiliconFlow + Anthropic.
+- **Pure prompt chains** (sans framework) — viable pour Phase A, devient ingérable en Phase C avec mémoire conversationnelle + tool calling.
+
+## Glossaire technique
+
+- **Tool** — fonction Python exposée à l'agent. L'agent peut décider de l'appeler en fournissant des arguments. La sortie revient au LLM comme contexte.
+- **State** — dictionnaire partagé entre les nodes du graphe (LangGraph state schema).
+- **Node** — une étape du workflow (souvent : un appel LLM + une décision de routing).
+- **Checkpoint** — sauvegarde de l'état d'une conversation pour reprise (persistance JSON).
+- **Dry-run** — exécution simulée sans effet de bord (ex: `reclassify_dryrun`).

--- a/docs/renommage.md
+++ b/docs/renommage.md
@@ -150,6 +150,61 @@ Module : `lib/pattern_detector.py`. Commande : `commands/detect.py`.
 
 Les résultats de recherche ISBN sont stockés dans `profiles/<nom>/.cache/isbn_cache.json`. Ce cache accélère les prochains runs et réduit les appels réseau. Il contient ~3400 entrées après le traitement initial de la bibliothèque. Nettoyable via `./klodo.sh clean isbn --execute`.
 
+## Renommage dashboard — audit, journal, undo
+
+En complément du pipeline CLI ci-dessus, le dashboard expose une **feature audit de renommages** dans le sous-onglet **Rename** de la Taxonomie. Indépendante du pipeline classify : permet de renommer des fichiers déjà classifiés dont le nom diverge du titre extrait par LLM Vision.
+
+### Pipeline audit
+
+À partir de `vision_cache.json` (titre + auteur extraits par LLM), le système calcule pour chaque fichier :
+
+1. Un **nom suggéré** via un template configurable (par défaut `{title}{ - author}`) avec sanitization NFKC + filesystem-safe (`/` → `-`, `:` → `—`, chars interdits drop)
+2. Une **similarité Jaccard 3-grams** entre nom actuel et nom suggéré
+3. Une **catégorie** : `placeholder` (pattern "Title Author"), `divergent` (sim < 0.4), `minor_case` (0.4 ≤ sim < 0.7), `ok` (sim ≥ 0.7)
+
+L'utilisateur peut renommer **unitairement** ou **en bulk**, ou marquer manuellement un fichier comme **OK** (override) — dans tous les cas, chaque opération est journalisée.
+
+### Le journal — `rename-journal.jsonl`
+
+Append-only JSONL stocké dans `profiles/<p>/.cache/rename-journal.jsonl`. Chaque entrée :
+
+```json
+{"ts": "2026-05-17T19:09:06", "old": "/abs/Title Author.pdf",
+ "new": "/abs/Real Title - Real Author.pdf",
+ "batch": "20260517-190906-c94aee"}
+```
+
+- `batch` est partagé par tous les renames d'un même bulk (auto-undo batch en un clic)
+- Les undos sont eux-mêmes journalisés sous `batch: "undo-<original_batch_id>"` → audit trail complet, append-only par construction
+- `is_undone` calculé positionnellement (un record est annulé ssi un record d'undo plus récent dans le journal a son `old` = ce record's `new`) — pas d'ambiguïté sur les chemins qui se répètent au fil du temps
+
+### UI
+
+- **Sous-onglet Rename** : col 1 liste filtrable + multi-select bulk, col 2 viewer + LLM card avec sous-bloc Rename (cross-link Mappings ↔ Rename via `tax-navigate-file` event), col 3 input éditable + bouton Renommer + confirm modal
+- **Modale 📜 Renommages** (compteur + sub-badge ⚠ session-active) : 2 onglets (Tous / Par lot) avec bouton ↶ Annuler par ligne ou par batch entier
+- **Override** : bouton "Marquer comme OK" persisté dans `rename-overrides.json` keyé par cache_key MD5 — **survit aux renames** (sur le contenu, pas sur le path)
+- **Session log** (col 1, persistance `sessionStorage`) : trace en mémoire des actions du tab courant + bouton ↶ inline
+- **Search bar** col 1 + bulkbar sticky (Renommer suggestion / Marquer OK / Tout désélectionner)
+- **🔄 Rescan** : invalidation du cache audit + scan complet (utile après ajout manuel ou nouveau cycle `klodo.sh rename`)
+
+### Endpoints API
+
+| Méthode | Route | Rôle |
+|---|---|---|
+| `GET` | `/api/rename/audit?profile=&force=` | Charger l'audit (force = bypass cache) |
+| `POST` | `/api/rename/file` | Renommer un fichier (commit + journal) |
+| `POST` | `/api/rename/bulk` | Renommer N fichiers en batch (shared batch_id) |
+| `GET` | `/api/rename/journal?profile=&limit=` | Historique du profil (newest first) |
+| `POST` | `/api/rename/undo/record` | Annuler un rename individuel (match ts+old+new) |
+| `POST` | `/api/rename/undo/batch` | Annuler tout un batch en une opération |
+| `POST` | `/api/rename/override` | Marquer N fichiers comme OK (ou clear) |
+
+### Performance — cache patch ciblé
+
+Avant : chaque rename invalidait tout l'audit cache (`~5s` de rescan os.walk + ThreadPoolExecutor sur 18k fichiers). Aujourd'hui : **patch ciblé en place** (`<50ms`) — drop de l'entrée concernée + re-audit du seul fichier + tri unique en fin de batch. Fallback automatique sur full-rebuild si le patch ne peut pas s'appliquer (profil mal configuré, fichier disparu, bucket non-candidat).
+
 ## Module
 
-**Fichiers** : `lib/renamer.py` (moteur), `lib/vision.py` (LLM Vision), `lib/wordcheck.py` (validation dictionnaire), `lib/utils.py` (sanitize).
+**Fichiers** : `lib/renamer.py` (moteur CLI), `lib/rename_template.py` (parser de template + sanitization), `lib/rename_journal.py` (journal append-only + undo), `lib/vision.py` (LLM Vision), `lib/wordcheck.py` (validation dictionnaire), `lib/utils.py` (sanitize).
+
+**Dashboard** : `dashboard/rename.py` (audit + apply + journal viewing + override + bulk + cache patch), templates `dashboard/templates/taxonomy.html` (sous-onglet + modale), JS `dashboard/static/js/taxonomy_rename.js`.

--- a/lib/CLAUDE.md
+++ b/lib/CLAUDE.md
@@ -22,10 +22,17 @@ LLM Vision (thème, titre) → 1. Theme Mapping (355+ entrées, gratuit)
 - **`KeywordClassifier.classify()`** retourne `list[tuple[str, float, str]]`
 
 ## Renommage
-- **[renamer.py](renamer.py)** — Moteur : ISBN, PDF, LLM Vision
+- **[renamer.py](renamer.py)** — Moteur CLI : ISBN, PDF, LLM Vision
 - **`GENERIC_TITLES`** : liste des titres placeholder rejetés (dans renamer.py)
 - **`is_name_clean()`** et **`_is_good_title()`** utilisent [wordcheck.py](wordcheck.py)
 - **`is_name_clean(filename, name_patterns=None)`** accepte une liste de regex venant de `profile.yaml` (`rename.name_patterns`). Si configurés, le fichier doit matcher au moins un pattern **après** le wordcheck. Les regex invalides du profil sont silencieusement ignorées (try/except `re.error`)
+
+### Audit & journal (dashboard Rename)
+- **[rename_template.py](rename_template.py)** — Parser + renderer du template `{title}{ - author}` (blocs optionnels, sanitization NFKC + chars FS-safe, troncature word-boundary, fallback)
+- **[rename_journal.py](rename_journal.py)** — JSONL append-only `profile/.cache/rename-journal.jsonl`. Helpers : `append_rename`, `list_renames`, `list_batches`, `undo_record` (avec guard case-insensitive APFS via `samefile()`), `undo_batch` (groupé par `batch_id` partagé)
+- Les undos sont eux-mêmes journalisés sous `batch: "undo-<batch_id>"` → audit trail complet, append-only par construction
+- L'overrides utilisateur `rename-overrides.json` est keyé par cache_key MD5 (head bytes du fichier) → **survit aux renames**
+- Cf. [dashboard/rename.py](../dashboard/rename.py) pour le wrapper FastAPI (audit + commit + cache patch ciblé)
 
 ## Pattern detector — détection automatique de patterns de nommage
 - **[pattern_detector.py](pattern_detector.py)** — `detect_pattern(filenames, ...)` envoie un échantillon de noms à un LLM qui retourne une regex + description + confiance
@@ -33,12 +40,14 @@ LLM Vision (thème, titre) → 1. Theme Mapping (355+ entrées, gratuit)
 - Validation : `re.compile()` avant de retourner, gère les fences markdown dans la réponse JSON
 - Utilisé par la sous-commande `./klodo.sh detect --files ... --execute` (cf. `commands/detect.py`) qui injecte le pattern validé dans `profile.yaml` en préservant les commentaires
 
-## Thumbnail (pour le dashboard Curation)
-- **[thumbnail.py](thumbnail.py)** — `generate_thumbnail(source, doc_dir, n_pages=1, start_page=1)` produit `doc_dir/{1..n}.jpg` (400×550 JPEG)
-- **Structure du cache** : sous-dossier par document — `.thumbnail-cache/{stem}/{1..n}.jpg`
+## Thumbnail (cache unifié dashboard + LLM pipeline)
+- **[thumbnail.py](thumbnail.py)** — `generate_thumbnail(source, doc_dir, n_pages=1, start_page=1)` produit `doc_dir/{1..n}.jpg` (400×550 JPEG). **Idempotent au niveau page** : skip si `N.jpg` existe (resumable runs + upgrades incrémentaux `--pages 1` → `--pages 5`)
+- **`compute_content_key(path)`** — clé content-based (MD5 des head bytes [16 chars]). Utilisée par le dashboard pour son cache `profile/.cache/thumbnails/<content_key>/{1..n}.jpg` — **survit aux renames** (clé liée au contenu, pas au rel_path)
+- **`save_pil_images_as_thumbnails(images, doc_dir, overwrite=False)`** — exposé pour le pipeline LLM : après `extract_cover_image()` dans `analyze_cover()`, les PIL images peuvent être dumpées vers le cache thumbnail au lieu d'être jetées. Capitalise sur l'extraction gratuite.
 - **Helpers** : `count_pages(cache_dir, stem)`, `clear_cache(cache_dir)` (gère legacy + sous-dossiers), `get_cache_stats(cache_dir)`
-- **Formats** : PDF (via `lib/vision.py:extract_cover_image`) + ePub (zipfile + parsing manifest OPF) + placeholder pour le reste
+- **Formats** : PDF (via `lib/pdf_cover.get_cover_image(page_indices=...)` pour batch ciblé Poppler) + ePub (zipfile + parsing manifest OPF) + placeholder pour le reste
 - **ePub start_page > 1** : retourne 0 (pas d'extraction de pages internes)
+- **CLI dédiée** : `./klodo.sh thumbnails --execute --pages N` pour backfill batch (cf. `commands/thumbnails.py`)
 
 ## Wordcheck — validation noms par dictionnaire
 


### PR DESCRIPTION
## Summary

- Mise à jour de la doc pour refléter l'architecture et les features livrées depuis la dernière passe (trigger N3 sur catch-all, dashboard Rename, dashboard Taxonomie, cache thumbnail unifié, etc.)
- Nouveau : `docs/refonte-agent-spec.md` — spec complète du premier agent IA Klodo (refonte de taxonomie) en 3 phases A/B/C avec découpage des tâches et plan de dev

## Détail des changements

### Docs publiques
- `docs/classification.md` — nouvelle section "Trigger conditionnel N3 sur catch-all" (PR #147) avec gardes et résultats empiriques (PR #148)
- `docs/renommage.md` — nouvelle section dashboard Rename (audit + journal + undo)
- `docs/architecture.md` — modules `rename_template`, `rename_journal`, `thumbnail` + section "Dashboard FastAPI"
- `docs/functional-testing-and-dashboard.md` — onglets Taxonomie + Rename ajoutés
- `README.md` — commandes `thumbnails` / `detect` / `dashboard` + mention dashboard dans présentation
- `docs/contributing.md` — retire les couvertures (livrées), ajoute pointeur vers la spec agents IA

### Docs internes (CLAUDE.md)
- `lib/CLAUDE.md` — sous-sections audit/journal Rename + thumbnail unifié (compute_content_key, save_pil_images_as_thumbnails)
- `commands/CLAUDE.md` — ligne thumbnails

### Nouveau : spec agent refonte
- `docs/refonte-agent-spec.md` (392 lignes) — premier agent IA Klodo :
  - 3 phases shippables : A (Diagnostic, read-only) → B (Proposition, side YAMLs) → C (Dialog, mutations)
  - ~35-50 j-h sur 6-8 semaines
  - Framework LangGraph (justifié vs CrewAI / OpenAI Assistants)
  - Découpage des tâches A.1-A.5 / B.1-B.4 / C.1-C.4
  - Tables outils par phase, table risques + mitigations

## Test plan

- [x] Lecture des liens internes (relatifs)
- [x] Vérif que README pointe bien sur les pages docs/ qui existent
- [ ] Pas de tests auto ni de lint (changements 100% docs/Markdown)

🤖 Generated with [Claude Code](https://claude.com/claude-code)