### PR TITLE
docs(diagrams): mise à jour pour refléter la nouvelle architecture

### DIFF
--- a/docs/diagrams/agent-refonte-phases.svg
+++ b/docs/diagrams/agent-refonte-phases.svg
@@ -1,0 +1,130 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 620" font-family="Segoe Print, Comic Sans MS, cursive" font-size="13">
+  <defs>
+    <filter id="h" x="-2%" y="-2%" width="104%" height="104%">
+      <feTurbulence type="fractalNoise" baseFrequency="0.03" numOctaves="3" seed="21"/>
+      <feDisplacementMap in="SourceGraphic" scale="1.2"/>
+    </filter>
+    <marker id="arrow" viewBox="0 0 10 10" refX="8" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M 0 0 L 10 5 L 0 10 z" fill="#6b7280"/>
+    </marker>
+    <marker id="arrowPurple" viewBox="0 0 10 10" refX="8" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M 0 0 L 10 5 L 0 10 z" fill="#8b5cf6"/>
+    </marker>
+  </defs>
+
+  <g filter="url(#h)">
+    <!-- Title -->
+    <text x="500" y="30" text-anchor="middle" font-size="16" font-weight="bold" fill="#5b21b6">🤖 Agent IA Refonte — 3 phases shippables</text>
+    <text x="500" y="50" text-anchor="middle" font-size="11" fill="#7c3aed" font-style="italic">orchestration LangGraph · ~35-50 j-h · 6-8 semaines</text>
+
+    <!-- ── Phase A : Diagnostic (read-only) ── -->
+    <rect x="30" y="80" width="290" height="350" rx="14" fill="#dbeafe" stroke="#3b82f6" stroke-width="2.5"/>
+    <text x="175" y="106" text-anchor="middle" font-size="15" font-weight="bold" fill="#1e40af">Phase A — Diagnostic</text>
+    <text x="175" y="124" text-anchor="middle" font-size="11" fill="#3b82f6" font-style="italic">read-only · ~10-15 j-h</text>
+
+    <!-- A inputs -->
+    <text x="50" y="148" font-size="10" font-style="italic" fill="#1e40af">Inputs</text>
+    <rect x="45" y="155" width="260" height="22" rx="4" fill="#ffffff" stroke="#3b82f6" stroke-width="1"/>
+    <text x="175" y="170" text-anchor="middle" font-size="10" fill="#1e40af">tree.yaml + theme_mapping.yaml + biblio FS</text>
+
+    <!-- A tools -->
+    <text x="50" y="200" font-size="10" font-style="italic" fill="#1e40af">Tools (read-only)</text>
+    <rect x="45" y="207" width="125" height="22" rx="4" fill="#ffffff" stroke="#3b82f6" stroke-width="1"/>
+    <text x="107" y="222" text-anchor="middle" font-size="10" fill="#1e40af">list_tree()</text>
+    <rect x="180" y="207" width="125" height="22" rx="4" fill="#ffffff" stroke="#3b82f6" stroke-width="1"/>
+    <text x="242" y="222" text-anchor="middle" font-size="10" fill="#1e40af">count_files()</text>
+
+    <rect x="45" y="234" width="260" height="22" rx="4" fill="#ffffff" stroke="#3b82f6" stroke-width="1"/>
+    <text x="175" y="249" text-anchor="middle" font-size="10" fill="#1e40af">sample_theme_mapping(theme, n=5)</text>
+
+    <rect x="45" y="261" width="260" height="22" rx="4" fill="#ffffff" stroke="#3b82f6" stroke-width="1"/>
+    <text x="175" y="276" text-anchor="middle" font-size="10" fill="#1e40af">read_catch_all_distribution()</text>
+
+    <!-- A tasks -->
+    <text x="50" y="306" font-size="10" font-style="italic" fill="#1e40af">Tâches</text>
+    <text x="55" y="322" font-size="10" fill="#1e40af">• A.1 — Bootstrap LangGraph + state</text>
+    <text x="55" y="338" font-size="10" fill="#1e40af">• A.2 — Outils read-only (5)</text>
+    <text x="55" y="354" font-size="10" fill="#1e40af">• A.3 — Prompt diagnostic</text>
+    <text x="55" y="370" font-size="10" fill="#1e40af">• A.4 — Rapport markdown</text>
+    <text x="55" y="386" font-size="10" fill="#1e40af">• A.5 — Tests + smoke run</text>
+
+    <!-- A output -->
+    <rect x="45" y="400" width="260" height="22" rx="4" fill="#d1fae5" stroke="#22c55e" stroke-width="1.5"/>
+    <text x="175" y="415" text-anchor="middle" font-size="10" font-weight="bold" fill="#166534">📄 diagnostic-&lt;date&gt;.md</text>
+
+    <!-- ── Phase B : Proposition (side YAMLs) ── -->
+    <rect x="355" y="80" width="290" height="350" rx="14" fill="#ede9fe" stroke="#8b5cf6" stroke-width="2.5"/>
+    <text x="500" y="106" text-anchor="middle" font-size="15" font-weight="bold" fill="#5b21b6">Phase B — Proposition</text>
+    <text x="500" y="124" text-anchor="middle" font-size="11" fill="#7c3aed" font-style="italic">side YAMLs · ~10-15 j-h</text>
+
+    <text x="375" y="148" font-size="10" font-style="italic" fill="#5b21b6">Inputs</text>
+    <rect x="370" y="155" width="260" height="22" rx="4" fill="#ffffff" stroke="#8b5cf6" stroke-width="1"/>
+    <text x="500" y="170" text-anchor="middle" font-size="10" fill="#5b21b6">Phase A + objectifs user</text>
+
+    <text x="375" y="200" font-size="10" font-style="italic" fill="#5b21b6">Tools (read + propose)</text>
+    <rect x="370" y="207" width="260" height="22" rx="4" fill="#ffffff" stroke="#8b5cf6" stroke-width="1"/>
+    <text x="500" y="222" text-anchor="middle" font-size="10" fill="#5b21b6">tous les A.* + propose_changes()</text>
+
+    <rect x="370" y="234" width="260" height="22" rx="4" fill="#ffffff" stroke="#8b5cf6" stroke-width="1"/>
+    <text x="500" y="249" text-anchor="middle" font-size="10" fill="#5b21b6">simulate_reclassify(--dry-run)</text>
+
+    <rect x="370" y="261" width="260" height="22" rx="4" fill="#ffffff" stroke="#8b5cf6" stroke-width="1"/>
+    <text x="500" y="276" text-anchor="middle" font-size="10" fill="#5b21b6">compute_impact(propositions)</text>
+
+    <text x="375" y="306" font-size="10" font-style="italic" fill="#5b21b6">Tâches</text>
+    <text x="380" y="322" font-size="10" fill="#5b21b6">• B.1 — propose_changes → side YAMLs</text>
+    <text x="380" y="338" font-size="10" fill="#5b21b6">• B.2 — Simulateur dry-run</text>
+    <text x="380" y="354" font-size="10" fill="#5b21b6">• B.3 — Tableau d'impact</text>
+    <text x="380" y="370" font-size="10" fill="#5b21b6">• B.4 — Tests + smoke run</text>
+
+    <rect x="370" y="400" width="260" height="22" rx="4" fill="#d1fae5" stroke="#22c55e" stroke-width="1.5"/>
+    <text x="500" y="415" text-anchor="middle" font-size="10" font-weight="bold" fill="#166534">📄 tree-proposed + mapping-proposed</text>
+
+    <!-- ── Phase C : Dialog (mutations) ── -->
+    <rect x="680" y="80" width="290" height="350" rx="14" fill="#fce7f3" stroke="#ec4899" stroke-width="2.5"/>
+    <text x="825" y="106" text-anchor="middle" font-size="15" font-weight="bold" fill="#9d174d">Phase C — Dialog</text>
+    <text x="825" y="124" text-anchor="middle" font-size="11" fill="#ec4899" font-style="italic">mutations · ~15-20 j-h</text>
+
+    <text x="700" y="148" font-size="10" font-style="italic" fill="#9d174d">Inputs</text>
+    <rect x="695" y="155" width="260" height="22" rx="4" fill="#ffffff" stroke="#ec4899" stroke-width="1"/>
+    <text x="825" y="170" text-anchor="middle" font-size="10" fill="#9d174d">Phase B + validation interactive</text>
+
+    <text x="700" y="200" font-size="10" font-style="italic" fill="#9d174d">Tools (mutables, locked)</text>
+    <rect x="695" y="207" width="260" height="22" rx="4" fill="#ffffff" stroke="#ec4899" stroke-width="1"/>
+    <text x="825" y="222" text-anchor="middle" font-size="10" fill="#9d174d">tous les B.* + apply_changes()</text>
+
+    <rect x="695" y="234" width="260" height="22" rx="4" fill="#ffffff" stroke="#ec4899" stroke-width="1"/>
+    <text x="825" y="249" text-anchor="middle" font-size="10" fill="#9d174d">rename_folder + remap_theme</text>
+
+    <rect x="695" y="261" width="260" height="22" rx="4" fill="#ffffff" stroke="#ec4899" stroke-width="1"/>
+    <text x="825" y="276" text-anchor="middle" font-size="10" fill="#9d174d">🔒 taxonomy.lock (concurrence)</text>
+
+    <text x="700" y="306" font-size="10" font-style="italic" fill="#9d174d">Tâches</text>
+    <text x="705" y="322" font-size="10" fill="#9d174d">• C.1 — apply_changes (atomique)</text>
+    <text x="705" y="338" font-size="10" fill="#9d174d">• C.2 — Journal agent (JSONL)</text>
+    <text x="705" y="354" font-size="10" fill="#9d174d">• C.3 — UI dialog dashboard</text>
+    <text x="705" y="370" font-size="10" fill="#9d174d">• C.4 — Rollback + tests E2E</text>
+
+    <rect x="695" y="400" width="260" height="22" rx="4" fill="#d1fae5" stroke="#22c55e" stroke-width="1.5"/>
+    <text x="825" y="415" text-anchor="middle" font-size="10" font-weight="bold" fill="#166534">📄 YAMLs mutés + agent-journal.jsonl</text>
+
+    <!-- Arrows between phases -->
+    <line x1="320" y1="255" x2="353" y2="255" stroke="#8b5cf6" stroke-width="2" marker-end="url(#arrowPurple)"/>
+    <text x="337" y="248" font-size="9" text-anchor="middle" fill="#7c3aed" font-style="italic">A → B</text>
+
+    <line x1="645" y1="255" x2="678" y2="255" stroke="#ec4899" stroke-width="2" marker-end="url(#arrow)"/>
+    <text x="662" y="248" font-size="9" text-anchor="middle" fill="#9d174d" font-style="italic">B → C</text>
+
+    <!-- Bottom : framework + risks -->
+    <rect x="30" y="455" width="940" height="80" rx="12" fill="#fef9c3" stroke="#ca8a04" stroke-width="2"/>
+    <text x="500" y="478" text-anchor="middle" font-size="13" font-weight="bold" fill="#854d0e">Framework &amp; garde-fous</text>
+    <text x="50" y="500" font-size="11" fill="#a16207">• LangGraph : orchestration + state typé + interruption/resume</text>
+    <text x="50" y="516" font-size="11" fill="#a16207">• Coût LLM contenu : budget par phase + checkpointing + cache prompt</text>
+    <text x="500" y="500" font-size="11" fill="#a16207">• Phase A jamais bloquante (read-only, peut tourner en CI)</text>
+    <text x="500" y="516" font-size="11" fill="#a16207">• Phase C : tout passe par apply_changes() + journal append-only</text>
+
+    <!-- Timeline -->
+    <text x="500" y="565" text-anchor="middle" font-size="11" fill="#9ca3af" font-style="italic">Chaque phase est shippable seule — Phase A déjà livrable en sprint 1, valide l'archi avant d'engager B/C</text>
+    <text x="500" y="585" text-anchor="middle" font-size="10" fill="#9ca3af" font-style="italic">Cf. docs/refonte-agent-spec.md pour le détail des tâches A.1-A.5 / B.1-B.4 / C.1-C.4</text>
+  </g>
+</svg>

--- a/docs/diagrams/architecture-modules.svg
+++ b/docs/diagrams/architecture-modules.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 780 460" font-family="Segoe Print, Comic Sans MS, cursive" font-size="12">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 880 560" font-family="Segoe Print, Comic Sans MS, cursive" font-size="12">
   <defs>
     <filter id="h" x="-2%" y="-2%" width="104%" height="104%">
       <feTurbulence type="fractalNoise" baseFrequency="0.03" numOctaves="3" seed="13"/>
@@ -10,94 +10,158 @@
   </defs>
   <g filter="url(#h)">
     <!-- CLI layer -->
-    <rect x="250" y="10" width="280" height="55" rx="12" fill="#dbeafe" stroke="#3b82f6" stroke-width="2"/>
-    <text x="390" y="33" text-anchor="middle" font-size="14" font-weight="bold" fill="#1e40af">klodo.py — Point d'entrée CLI</text>
-    <text x="390" y="52" text-anchor="middle" font-size="11" fill="#3b82f6">Parser argparse + sous-commandes</text>
+    <rect x="300" y="10" width="280" height="55" rx="12" fill="#dbeafe" stroke="#3b82f6" stroke-width="2"/>
+    <text x="440" y="33" text-anchor="middle" font-size="14" font-weight="bold" fill="#1e40af">klodo.py — Point d'entrée CLI</text>
+    <text x="440" y="52" text-anchor="middle" font-size="11" fill="#3b82f6">Parser argparse + sous-commandes</text>
 
-    <!-- Arrows from CLI to lib modules -->
-    <line x1="390" y1="65" x2="390" y2="105" stroke="#6b7280" stroke-width="1.5" marker-end="url(#arrow)"/>
+    <!-- Arrow CLI → lib -->
+    <line x1="440" y1="65" x2="440" y2="105" stroke="#6b7280" stroke-width="1.5" marker-end="url(#arrow)"/>
 
     <!-- LIB layer -->
-    <rect x="30" y="110" width="720" height="170" rx="14" fill="#ede9fe" stroke="#8b5cf6" stroke-width="2"/>
-    <text x="390" y="132" text-anchor="middle" font-size="14" font-weight="bold" fill="#5b21b6">lib/ — Modules métier</text>
+    <rect x="30" y="110" width="820" height="240" rx="14" fill="#ede9fe" stroke="#8b5cf6" stroke-width="2"/>
+    <text x="440" y="132" text-anchor="middle" font-size="14" font-weight="bold" fill="#5b21b6">lib/ — Modules métier</text>
 
-    <!-- Module boxes -->
-    <rect x="50" y="145" width="115" height="50" rx="8" fill="#ffffff" stroke="#8b5cf6" stroke-width="1.5"/>
-    <text x="107" y="167" text-anchor="middle" font-size="12" font-weight="bold" fill="#5b21b6">vision.py</text>
-    <text x="107" y="183" text-anchor="middle" font-size="10" fill="#7c3aed">LLM Vision</text>
+    <!-- Row 1 : pipeline classification -->
+    <text x="60" y="155" font-size="10" font-style="italic" fill="#7c3aed">Classification</text>
 
-    <rect x="180" y="145" width="115" height="50" rx="8" fill="#ffffff" stroke="#8b5cf6" stroke-width="1.5"/>
-    <text x="237" y="167" text-anchor="middle" font-size="12" font-weight="bold" fill="#5b21b6">classifier.py</text>
-    <text x="237" y="183" text-anchor="middle" font-size="10" fill="#7c3aed">Classification</text>
+    <rect x="50" y="160" width="115" height="48" rx="8" fill="#ffffff" stroke="#8b5cf6" stroke-width="1.5"/>
+    <text x="107" y="180" text-anchor="middle" font-size="12" font-weight="bold" fill="#5b21b6">vision.py</text>
+    <text x="107" y="196" text-anchor="middle" font-size="10" fill="#7c3aed">LLM Vision</text>
 
-    <rect x="310" y="145" width="115" height="50" rx="8" fill="#ffffff" stroke="#8b5cf6" stroke-width="1.5"/>
-    <text x="367" y="167" text-anchor="middle" font-size="12" font-weight="bold" fill="#5b21b6">llm_mapper.py</text>
-    <text x="367" y="183" text-anchor="middle" font-size="10" fill="#7c3aed">Résolution thèmes</text>
+    <rect x="180" y="160" width="115" height="48" rx="8" fill="#ffffff" stroke="#8b5cf6" stroke-width="1.5"/>
+    <text x="237" y="180" text-anchor="middle" font-size="12" font-weight="bold" fill="#5b21b6">classifier.py</text>
+    <text x="237" y="196" text-anchor="middle" font-size="10" fill="#7c3aed">Cascade 4 niveaux</text>
 
-    <rect x="440" y="145" width="115" height="50" rx="8" fill="#ffffff" stroke="#8b5cf6" stroke-width="1.5"/>
-    <text x="497" y="167" text-anchor="middle" font-size="12" font-weight="bold" fill="#5b21b6">refiner.py</text>
-    <text x="497" y="183" text-anchor="middle" font-size="10" fill="#7c3aed">Raffinement</text>
+    <rect x="310" y="160" width="115" height="48" rx="8" fill="#ffffff" stroke="#8b5cf6" stroke-width="1.5"/>
+    <text x="367" y="180" text-anchor="middle" font-size="12" font-weight="bold" fill="#5b21b6">llm_mapper.py</text>
+    <text x="367" y="196" text-anchor="middle" font-size="10" fill="#7c3aed">Résolution thèmes</text>
 
-    <rect x="570" y="145" width="80" height="50" rx="8" fill="#ffffff" stroke="#8b5cf6" stroke-width="1.5"/>
-    <text x="610" y="167" text-anchor="middle" font-size="12" font-weight="bold" fill="#5b21b6">utils.py</text>
-    <text x="610" y="183" text-anchor="middle" font-size="10" fill="#7c3aed">Rapports</text>
+    <rect x="440" y="160" width="115" height="48" rx="8" fill="#ffffff" stroke="#8b5cf6" stroke-width="1.5"/>
+    <text x="497" y="180" text-anchor="middle" font-size="12" font-weight="bold" fill="#5b21b6">refiner.py</text>
+    <text x="497" y="196" text-anchor="middle" font-size="10" fill="#7c3aed">Raffinement</text>
 
-    <rect x="665" y="145" width="75" height="50" rx="8" fill="#ffffff" stroke="#8b5cf6" stroke-width="1.5"/>
-    <text x="702" y="167" text-anchor="middle" font-size="12" font-weight="bold" fill="#5b21b6">profile.py</text>
-    <text x="702" y="183" text-anchor="middle" font-size="10" fill="#7c3aed">Profils</text>
+    <rect x="570" y="160" width="125" height="48" rx="8" fill="#ffffff" stroke="#8b5cf6" stroke-width="1.5"/>
+    <text x="632" y="180" text-anchor="middle" font-size="12" font-weight="bold" fill="#5b21b6">pattern_detector.py</text>
+    <text x="632" y="196" text-anchor="middle" font-size="10" fill="#7c3aed">Détection patterns</text>
 
-    <!-- Second row of lib -->
-    <rect x="50" y="210" width="115" height="50" rx="8" fill="#ffffff" stroke="#8b5cf6" stroke-width="1.5"/>
-    <text x="107" y="232" text-anchor="middle" font-size="12" font-weight="bold" fill="#5b21b6">wordcheck.py</text>
-    <text x="107" y="248" text-anchor="middle" font-size="10" fill="#7c3aed">Validation noms</text>
+    <rect x="710" y="160" width="125" height="48" rx="8" fill="#ffffff" stroke="#8b5cf6" stroke-width="1.5"/>
+    <text x="772" y="180" text-anchor="middle" font-size="12" font-weight="bold" fill="#5b21b6">vision_cache.py</text>
+    <text x="772" y="196" text-anchor="middle" font-size="10" fill="#7c3aed">Cache LLM</text>
 
-    <rect x="180" y="210" width="115" height="50" rx="8" fill="#ffffff" stroke="#8b5cf6" stroke-width="1.5"/>
-    <text x="237" y="232" text-anchor="middle" font-size="12" font-weight="bold" fill="#5b21b6">checkpoint.py</text>
-    <text x="237" y="248" text-anchor="middle" font-size="10" fill="#7c3aed">Reprise</text>
+    <!-- Row 2 : rename pipeline -->
+    <text x="60" y="225" font-size="10" font-style="italic" fill="#7c3aed">Renommage</text>
 
-    <rect x="310" y="210" width="115" height="50" rx="8" fill="#ffffff" stroke="#8b5cf6" stroke-width="1.5"/>
-    <text x="367" y="232" text-anchor="middle" font-size="12" font-weight="bold" fill="#5b21b6">logger.py</text>
-    <text x="367" y="248" text-anchor="middle" font-size="10" fill="#7c3aed">Logging</text>
+    <rect x="50" y="230" width="115" height="48" rx="8" fill="#ffffff" stroke="#ec4899" stroke-width="1.5"/>
+    <text x="107" y="250" text-anchor="middle" font-size="12" font-weight="bold" fill="#9d174d">renamer.py</text>
+    <text x="107" y="266" text-anchor="middle" font-size="10" fill="#ec4899">Moteur cascade</text>
 
-    <!-- External modules -->
-    <rect x="30" y="310" width="300" height="65" rx="12" fill="#fef3c7" stroke="#f59e0b" stroke-width="2"/>
-    <text x="180" y="332" text-anchor="middle" font-size="14" font-weight="bold" fill="#92400e">Moteurs hérités</text>
+    <rect x="180" y="230" width="115" height="48" rx="8" fill="#ffffff" stroke="#ec4899" stroke-width="1.5"/>
+    <text x="237" y="250" text-anchor="middle" font-size="12" font-weight="bold" fill="#9d174d">rename_template</text>
+    <text x="237" y="266" text-anchor="middle" font-size="10" fill="#ec4899">Render {title}{ - auth}</text>
 
-    <rect x="45" y="340" width="130" height="28" rx="6" fill="#ffffff" stroke="#f59e0b" stroke-width="1.5"/>
-    <text x="110" y="359" text-anchor="middle" font-size="11" fill="#92400e">klodo_renamer.py</text>
+    <rect x="310" y="230" width="115" height="48" rx="8" fill="#ffffff" stroke="#ec4899" stroke-width="1.5"/>
+    <text x="367" y="250" text-anchor="middle" font-size="12" font-weight="bold" fill="#9d174d">rename_journal</text>
+    <text x="367" y="266" text-anchor="middle" font-size="10" fill="#ec4899">JSONL append-only</text>
 
-    <rect x="190" y="340" width="130" height="28" rx="6" fill="#ffffff" stroke="#f59e0b" stroke-width="1.5"/>
-    <text x="255" y="359" text-anchor="middle" font-size="11" fill="#92400e">klodo_organizer.py</text>
+    <rect x="440" y="230" width="115" height="48" rx="8" fill="#ffffff" stroke="#ec4899" stroke-width="1.5"/>
+    <text x="497" y="250" text-anchor="middle" font-size="12" font-weight="bold" fill="#9d174d">wordcheck.py</text>
+    <text x="497" y="266" text-anchor="middle" font-size="10" fill="#ec4899">Validation noms</text>
 
-    <!-- Arrows from classifier to organizer -->
-    <line x1="237" y1="195" x2="255" y2="340" stroke="#f59e0b" stroke-width="1.2" marker-end="url(#arrow)" stroke-dasharray="4,3"/>
+    <rect x="570" y="230" width="125" height="48" rx="8" fill="#ffffff" stroke="#8b5cf6" stroke-width="1.5"/>
+    <text x="632" y="250" text-anchor="middle" font-size="12" font-weight="bold" fill="#5b21b6">thumbnail.py</text>
+    <text x="632" y="266" text-anchor="middle" font-size="10" fill="#7c3aed">Cache content-keyed</text>
+
+    <rect x="710" y="230" width="125" height="48" rx="8" fill="#ffffff" stroke="#8b5cf6" stroke-width="1.5"/>
+    <text x="772" y="250" text-anchor="middle" font-size="12" font-weight="bold" fill="#5b21b6">pdf_cover.py</text>
+    <text x="772" y="266" text-anchor="middle" font-size="10" fill="#7c3aed">Extraction couverture</text>
+
+    <!-- Row 3 : infra -->
+    <text x="60" y="295" font-size="10" font-style="italic" fill="#7c3aed">Infrastructure</text>
+
+    <rect x="50" y="300" width="115" height="40" rx="8" fill="#ffffff" stroke="#8b5cf6" stroke-width="1.5"/>
+    <text x="107" y="318" text-anchor="middle" font-size="12" font-weight="bold" fill="#5b21b6">profile.py</text>
+    <text x="107" y="332" text-anchor="middle" font-size="10" fill="#7c3aed">Profils YAML</text>
+
+    <rect x="180" y="300" width="115" height="40" rx="8" fill="#ffffff" stroke="#8b5cf6" stroke-width="1.5"/>
+    <text x="237" y="318" text-anchor="middle" font-size="12" font-weight="bold" fill="#5b21b6">checkpoint.py</text>
+    <text x="237" y="332" text-anchor="middle" font-size="10" fill="#7c3aed">Reprise</text>
+
+    <rect x="310" y="300" width="115" height="40" rx="8" fill="#ffffff" stroke="#8b5cf6" stroke-width="1.5"/>
+    <text x="367" y="318" text-anchor="middle" font-size="12" font-weight="bold" fill="#5b21b6">llm_client.py</text>
+    <text x="367" y="332" text-anchor="middle" font-size="10" fill="#7c3aed">HTTP session</text>
+
+    <rect x="440" y="300" width="115" height="40" rx="8" fill="#ffffff" stroke="#8b5cf6" stroke-width="1.5"/>
+    <text x="497" y="318" text-anchor="middle" font-size="12" font-weight="bold" fill="#5b21b6">constants.py</text>
+    <text x="497" y="332" text-anchor="middle" font-size="10" fill="#7c3aed">Seuils, timeouts</text>
+
+    <rect x="570" y="300" width="125" height="40" rx="8" fill="#ffffff" stroke="#8b5cf6" stroke-width="1.5"/>
+    <text x="632" y="318" text-anchor="middle" font-size="12" font-weight="bold" fill="#5b21b6">exceptions.py</text>
+    <text x="632" y="332" text-anchor="middle" font-size="10" fill="#7c3aed">Hiérarchie KlodoError</text>
+
+    <rect x="710" y="300" width="125" height="40" rx="8" fill="#ffffff" stroke="#8b5cf6" stroke-width="1.5"/>
+    <text x="772" y="318" text-anchor="middle" font-size="12" font-weight="bold" fill="#5b21b6">utils.py</text>
+    <text x="772" y="332" text-anchor="middle" font-size="10" fill="#7c3aed">sanitize + rapports</text>
+
+    <!-- Dashboard -->
+    <rect x="30" y="365" width="380" height="100" rx="12" fill="#fce7f3" stroke="#ec4899" stroke-width="2"/>
+    <text x="220" y="387" text-anchor="middle" font-size="14" font-weight="bold" fill="#9d174d">dashboard/ — FastAPI + HTMX + DuckDB</text>
+
+    <rect x="45" y="397" width="110" height="28" rx="6" fill="#ffffff" stroke="#ec4899" stroke-width="1.5"/>
+    <text x="100" y="416" text-anchor="middle" font-size="10" fill="#9d174d">taxonomy.py</text>
+
+    <rect x="165" y="397" width="110" height="28" rx="6" fill="#ffffff" stroke="#ec4899" stroke-width="1.5"/>
+    <text x="220" y="416" text-anchor="middle" font-size="10" fill="#9d174d">rename.py</text>
+
+    <rect x="285" y="397" width="110" height="28" rx="6" fill="#ffffff" stroke="#ec4899" stroke-width="1.5"/>
+    <text x="340" y="416" text-anchor="middle" font-size="10" fill="#9d174d">curation.py</text>
+
+    <rect x="45" y="430" width="110" height="28" rx="6" fill="#ffffff" stroke="#ec4899" stroke-width="1.5"/>
+    <text x="100" y="449" text-anchor="middle" font-size="10" fill="#9d174d">data.py (DuckDB)</text>
+
+    <rect x="165" y="430" width="110" height="28" rx="6" fill="#ffffff" stroke="#ec4899" stroke-width="1.5"/>
+    <text x="220" y="449" text-anchor="middle" font-size="10" fill="#9d174d">logs.py (SSE)</text>
+
+    <rect x="285" y="430" width="110" height="28" rx="6" fill="#ffffff" stroke="#ec4899" stroke-width="1.5"/>
+    <text x="340" y="449" text-anchor="middle" font-size="10" fill="#9d174d">templates/ + static/</text>
 
     <!-- Profiles -->
-    <rect x="410" y="310" width="340" height="130" rx="12" fill="#d1fae5" stroke="#22c55e" stroke-width="2"/>
-    <text x="580" y="332" text-anchor="middle" font-size="14" font-weight="bold" fill="#166534">profiles/default/</text>
+    <rect x="430" y="365" width="420" height="180" rx="12" fill="#d1fae5" stroke="#22c55e" stroke-width="2"/>
+    <text x="640" y="387" text-anchor="middle" font-size="14" font-weight="bold" fill="#166534">profiles/&lt;name&gt;/</text>
 
-    <rect x="425" y="345" width="100" height="25" rx="6" fill="#ffffff" stroke="#22c55e" stroke-width="1.5"/>
-    <text x="475" y="363" text-anchor="middle" font-size="10" fill="#166534">profile.yaml</text>
+    <text x="450" y="406" font-size="10" font-style="italic" fill="#15803d">Config</text>
+    <rect x="445" y="412" width="120" height="25" rx="6" fill="#ffffff" stroke="#22c55e" stroke-width="1.5"/>
+    <text x="505" y="430" text-anchor="middle" font-size="10" fill="#166534">profile.yaml</text>
 
-    <rect x="540" y="345" width="85" height="25" rx="6" fill="#ffffff" stroke="#22c55e" stroke-width="1.5"/>
-    <text x="582" y="363" text-anchor="middle" font-size="10" fill="#166534">tree.yaml</text>
+    <rect x="575" y="412" width="120" height="25" rx="6" fill="#ffffff" stroke="#22c55e" stroke-width="1.5"/>
+    <text x="635" y="430" text-anchor="middle" font-size="10" fill="#166534">tree.yaml</text>
 
-    <rect x="640" y="345" width="100" height="25" rx="6" fill="#ffffff" stroke="#22c55e" stroke-width="1.5"/>
-    <text x="690" y="363" text-anchor="middle" font-size="10" fill="#166534">theme_mapping</text>
+    <rect x="705" y="412" width="135" height="25" rx="6" fill="#ffffff" stroke="#22c55e" stroke-width="1.5"/>
+    <text x="772" y="430" text-anchor="middle" font-size="10" fill="#166534">theme_mapping.yaml</text>
 
-    <rect x="425" y="380" width="110" height="25" rx="6" fill="#ffffff" stroke="#22c55e" stroke-width="1.5"/>
-    <text x="480" y="398" text-anchor="middle" font-size="10" fill="#166534">categories.yaml</text>
+    <rect x="445" y="445" width="120" height="25" rx="6" fill="#ffffff" stroke="#22c55e" stroke-width="1.5"/>
+    <text x="505" y="463" text-anchor="middle" font-size="10" fill="#166534">categories.yaml</text>
 
-    <rect x="550" y="380" width="110" height="25" rx="6" fill="#ffffff" stroke="#22c55e" stroke-width="1.5"/>
-    <text x="605" y="398" text-anchor="middle" font-size="10" fill="#166534">refinement.yaml</text>
+    <rect x="575" y="445" width="120" height="25" rx="6" fill="#ffffff" stroke="#22c55e" stroke-width="1.5"/>
+    <text x="635" y="463" text-anchor="middle" font-size="10" fill="#166534">refinement.yaml</text>
 
-    <!-- Arrows from profile.py to profiles -->
-    <line x1="702" y1="195" x2="580" y2="310" stroke="#22c55e" stroke-width="1.2" marker-end="url(#arrow)" stroke-dasharray="4,3"/>
+    <text x="450" y="492" font-size="10" font-style="italic" fill="#15803d">.cache/ (runtime)</text>
+    <rect x="445" y="498" width="125" height="25" rx="6" fill="#ffffff" stroke="#22c55e" stroke-width="1.5"/>
+    <text x="507" y="516" text-anchor="middle" font-size="10" fill="#166534">vision_cache.json</text>
 
-    <!-- Arrows from classifier to theme_mapping -->
-    <line x1="367" y1="195" x2="580" y2="345" stroke="#22c55e" stroke-width="1" marker-end="url(#arrow)" stroke-dasharray="4,3"/>
+    <rect x="580" y="498" width="125" height="25" rx="6" fill="#ffffff" stroke="#22c55e" stroke-width="1.5"/>
+    <text x="642" y="516" text-anchor="middle" font-size="10" fill="#166534">rename-journal.jsonl</text>
 
-    <!-- Arrows from refiner to refinement -->
-    <line x1="497" y1="195" x2="605" y2="380" stroke="#22c55e" stroke-width="1" marker-end="url(#arrow)" stroke-dasharray="4,3"/>
+    <rect x="715" y="498" width="125" height="25" rx="6" fill="#ffffff" stroke="#22c55e" stroke-width="1.5"/>
+    <text x="777" y="516" text-anchor="middle" font-size="10" fill="#166534">thumbnails/&lt;key&gt;/</text>
+
+    <!-- Connections lib → profiles (dashed) -->
+    <line x1="237" y1="278" x2="640" y2="365" stroke="#22c55e" stroke-width="1" marker-end="url(#arrow)" stroke-dasharray="4,3"/>
+    <line x1="367" y1="278" x2="640" y2="365" stroke="#22c55e" stroke-width="1" marker-end="url(#arrow)" stroke-dasharray="4,3"/>
+    <line x1="632" y1="278" x2="780" y2="498" stroke="#22c55e" stroke-width="1" marker-end="url(#arrow)" stroke-dasharray="4,3"/>
+    <line x1="367" y1="278" x2="640" y2="498" stroke="#22c55e" stroke-width="1" marker-end="url(#arrow)" stroke-dasharray="4,3"/>
+
+    <!-- Dashboard → lib (uses) -->
+    <line x1="220" y1="365" x2="237" y2="278" stroke="#ec4899" stroke-width="1.2" marker-end="url(#arrow)" stroke-dasharray="4,3"/>
+    <line x1="100" y1="365" x2="237" y2="208" stroke="#ec4899" stroke-width="1" marker-end="url(#arrow)" stroke-dasharray="4,3"/>
   </g>
 </svg>

--- a/docs/diagrams/cascade-classification.svg
+++ b/docs/diagrams/cascade-classification.svg
@@ -39,6 +39,14 @@
     <text x="500" y="192" text-anchor="middle" font-size="13" font-weight="bold" fill="#1e40af">1. Theme Mapping</text>
     <text x="500" y="208" text-anchor="middle" font-size="11" fill="#3b82f6">classify_by_theme() — instantané, gratuit</text>
 
+    <!-- Trigger conditionnel : si N1 atterrit sur /Autres → challenge N3 -->
+    <path d="M 630 215 Q 735 285 630 355" stroke="#f97316" stroke-width="1.8" fill="none"
+          stroke-dasharray="5,3" marker-end="url(#arrowOrange)"/>
+    <text x="715" y="238" font-size="10" fill="#c2410c" font-style="italic" text-anchor="middle">catch-all</text>
+    <text x="715" y="251" font-size="10" fill="#c2410c" font-style="italic" text-anchor="middle">→ challenge N3</text>
+    <text x="715" y="328" font-size="10" fill="#c2410c" font-style="italic" text-anchor="middle">~12% fichiers</text>
+    <text x="715" y="341" font-size="10" fill="#c2410c" font-style="italic" text-anchor="middle">6% upgradés</text>
+
     <!-- YAML file box LEFT: theme_mapping.yaml -->
     <rect x="60" y="170" width="220" height="50" rx="8" fill="#fef9c3" stroke="#ca8a04" stroke-width="2"/>
     <text x="170" y="190" text-anchor="middle" font-size="12" font-weight="bold" fill="#854d0e">📋 theme_mapping.yaml</text>

--- a/docs/diagrams/pipeline-renommage.svg
+++ b/docs/diagrams/pipeline-renommage.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 680 540" font-family="Segoe Print, Comic Sans MS, cursive" font-size="13">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 920 620" font-family="Segoe Print, Comic Sans MS, cursive" font-size="13">
   <defs>
     <filter id="h" x="-2%" y="-2%" width="104%" height="104%">
       <feTurbulence type="fractalNoise" baseFrequency="0.03" numOctaves="3" seed="9"/>
@@ -9,6 +9,9 @@
     </marker>
     <marker id="arrowGreen" viewBox="0 0 10 10" refX="8" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
       <path d="M 0 0 L 10 5 L 0 10 z" fill="#22c55e"/>
+    </marker>
+    <marker id="arrowPink" viewBox="0 0 10 10" refX="8" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M 0 0 L 10 5 L 0 10 z" fill="#ec4899"/>
     </marker>
   </defs>
   <g filter="url(#h)">
@@ -79,4 +82,50 @@
 
   <!-- Label -->
   <text x="340" y="500" text-anchor="middle" font-size="11" fill="#9ca3af" font-style="italic">Cascade : chaque source est essayée si la précédente échoue</text>
+
+  <!-- ── Dashboard Rename : audit + journal + undo ── -->
+  <g filter="url(#h)">
+    <!-- rename_template.py : render entre la cascade et le résultat -->
+    <rect x="670" y="245" width="220" height="55" rx="10" fill="#ede9fe" stroke="#8b5cf6" stroke-width="2"/>
+    <text x="780" y="266" text-anchor="middle" font-size="12" font-weight="bold" fill="#5b21b6">rename_template.py</text>
+    <text x="780" y="282" text-anchor="middle" font-size="10" fill="#7c3aed">{title}{ - author}</text>
+    <text x="780" y="295" text-anchor="middle" font-size="10" fill="#7c3aed">NFKC + FS-safe + troncature</text>
+
+    <!-- Arrow from Result box (x=535-660, y=87-457) to template -->
+    <line x1="660" y1="272" x2="668" y2="272" stroke="#8b5cf6" stroke-width="1.5" marker-end="url(#arrow)"/>
+
+    <!-- rename-journal.jsonl -->
+    <rect x="670" y="320" width="220" height="55" rx="10" fill="#fce7f3" stroke="#ec4899" stroke-width="2"/>
+    <text x="780" y="341" text-anchor="middle" font-size="12" font-weight="bold" fill="#9d174d">rename-journal.jsonl</text>
+    <text x="780" y="357" text-anchor="middle" font-size="10" fill="#ec4899">append-only — batch_id</text>
+    <text x="780" y="370" text-anchor="middle" font-size="10" fill="#ec4899">old → new + timestamp</text>
+
+    <line x1="780" y1="300" x2="780" y2="318" stroke="#ec4899" stroke-width="1.5" marker-end="url(#arrowPink)"/>
+    <text x="800" y="312" font-size="10" fill="#ec4899" font-style="italic">log</text>
+
+    <!-- Dashboard Rename UI -->
+    <rect x="670" y="395" width="220" height="55" rx="10" fill="#fce7f3" stroke="#ec4899" stroke-width="2"/>
+    <text x="780" y="416" text-anchor="middle" font-size="12" font-weight="bold" fill="#9d174d">🎛 Dashboard Rename</text>
+    <text x="780" y="432" text-anchor="middle" font-size="10" fill="#ec4899">audit + commit ciblé</text>
+    <text x="780" y="445" text-anchor="middle" font-size="10" fill="#ec4899">undo single + batch</text>
+
+    <line x1="780" y1="375" x2="780" y2="393" stroke="#ec4899" stroke-width="1.5" marker-end="url(#arrowPink)"/>
+    <text x="795" y="387" font-size="10" fill="#ec4899" font-style="italic">lit</text>
+
+    <!-- undo loop : Dashboard → journal (append undo record) -->
+    <path d="M 670 415 Q 620 415 620 360 Q 620 340 668 340" stroke="#ec4899" stroke-width="1.2" fill="none"
+          stroke-dasharray="4,3" marker-end="url(#arrowPink)"/>
+    <text x="600" y="380" font-size="9" fill="#ec4899" font-style="italic" text-anchor="end">undo (append)</text>
+
+    <!-- rename-overrides.json (cache_key MD5) -->
+    <rect x="670" y="470" width="220" height="48" rx="10" fill="#fef9c3" stroke="#ca8a04" stroke-width="2"/>
+    <text x="780" y="490" text-anchor="middle" font-size="11" font-weight="bold" fill="#854d0e">rename-overrides.json</text>
+    <text x="780" y="506" text-anchor="middle" font-size="10" fill="#a16207">keyé MD5 head — survit aux renames</text>
+
+    <line x1="780" y1="450" x2="780" y2="468" stroke="#ca8a04" stroke-width="1.5" marker-end="url(#arrow)"/>
+
+    <!-- Section label -->
+    <text x="780" y="232" text-anchor="middle" font-size="11" font-weight="bold" fill="#9d174d">— Dashboard Rename —</text>
+    <text x="780" y="540" text-anchor="middle" font-size="10" fill="#9ca3af" font-style="italic">Audit · Journal append-only · Undo single/batch</text>
+  </g>
 </svg>

--- a/docs/refonte-agent-spec.md
+++ b/docs/refonte-agent-spec.md
@@ -27,6 +27,10 @@ Les trois agents partagent **les mêmes outils sous-jacents** (theme_mapping, cl
 
 ## Architecture cible
 
+<p align="center">
+  <img src="diagrams/agent-refonte-phases.svg" alt="Agent refonte — 3 phases" width="800">
+</p>
+
 ```text
 ┌──────────────────────────────────────────────────────────────────┐
 │                    Refonte Agent (LangGraph)                     │


### PR DESCRIPTION
## Summary

Suite à la passe doc texte (PR #149), mise à jour des diagrammes SVG associés pour rester cohérent avec ce qui est désormais documenté.

## Détail des changements

### Mis à jour
- **`cascade-classification.svg`** — arc orange N1 → N3 pour le trigger conditionnel sur catch-all (PR #147) + chiffres empiriques (12% fire, 6% upgrade)
- **`architecture-modules.svg`** — refonte du layout en 3 rangées thématiques (Classification / Renommage / Infrastructure). Ajoute renamer, rename_template, rename_journal, thumbnail, pattern_detector, vision_cache. Ajoute le bloc dashboard/ et .cache/ dans profiles/
- **`pipeline-renommage.svg`** — bloc latéral "Dashboard Rename" (rename_template → rename-journal.jsonl → UI undo + rename-overrides)

### Créé
- **`agent-refonte-phases.svg`** — diagramme des 3 phases A/B/C de la spec agent refonte avec inputs / tools / tâches / outputs par phase, framework + garde-fous. Inséré dans `docs/refonte-agent-spec.md`.

### Skipped (justifié)
- `flux-donnees.svg` — le cache thumbnail unifié est un effet de bord interne (vision et dashboard l'utilisent indépendamment), pas un flux temporel utilisateur. L'ajouter encombrerait le sequence diagram sans clarifier.

## Test plan

- [x] Rendu via `qlmanage -t` des 4 SVG : pas d'overlap, lisible
- [x] Vérif que les diagrammes existants sont toujours référencés correctement dans les .md
- [ ] Pas de tests auto ni de lint (changements 100% SVG/Markdown)

🤖 Generated with [Claude Code](https://claude.com/claude-code)