### PR TITLE
docs(agents): spec des agents Onboarding et Curation + diagrammes

### DIFF
--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -103,7 +103,10 @@ Voici des pistes pour contribuer :
 - **Détection de langue** — Identifier automatiquement la langue du PDF
 - **Index SQLite** — Base de données légère pour recherche rapide
 - **Prompts templatisés** — Permettre de surcharger les prompts LLM par profil
-- **Agents IA** — Cf. [refonte-agent-spec.md](refonte-agent-spec.md) pour le premier agent envisagé (refonte de taxonomy en 3 phases : diagnostic → proposition → dialog), puis onboarding nouveau profil et curation interactive
+- **Agents IA** — 3 agents IA spécifiés, à développer dans l'ordre :
+  1. [refonte-agent-spec.md](refonte-agent-spec.md) — refonte de taxonomy en 3 phases (diagnostic → proposition → dialog), ~35-50 j-h
+  2. [onboarding-agent-spec.md](onboarding-agent-spec.md) — bootstrap d'un nouveau profil depuis une inbox (discovery → proposition → bootstrap), ~28-42 j-h
+  3. [curation-agent-spec.md](curation-agent-spec.md) — constitution de sous-ensembles intelligents entre profils (analyze → select → apply), ~22-35 j-h
 
 Idées déjà livrées (à titre de référence) :
 

--- a/docs/curation-agent-spec.md
+++ b/docs/curation-agent-spec.md
@@ -1,0 +1,383 @@
+# Spec — Agent IA « Curation de profil »
+
+[← Retour au README](../README.md) · [Spec agent Refonte](refonte-agent-spec.md) · [Spec agent Onboarding](onboarding-agent-spec.md)
+
+> Troisième agent IA du projet Klodo. Aide à **constituer des sous-ensembles de fichiers** d'un profil source vers un profil cible, selon des critères sémantiques que l'agent comprend (échantillon représentatif, doublons, edge cases pour tests de régression, jeu stratifié, etc.).
+
+## Pourquoi un agent
+
+L'onglet **Curation** du dashboard existe déjà ([dashboard/curation.py](../dashboard/curation.py)) : double panneau qui permet de **sélectionner manuellement** des PDFs d'un profil source pour les copier dans un profil cible (typiquement `test`). C'est utile pour constituer des jeux de tests par picking visuel via les thumbnails.
+
+Limite actuelle : **tout est manuel**. Si l'utilisateur veut "20 fichiers représentatifs couvrant toutes les sections", "tous les fichiers qui ont fini dans `Autres`", ou "les 10 fichiers les plus litigieux selon le classifier", il doit le faire à la main.
+
+L'agent curation prend le relais sur les sélections intelligentes :
+- **Échantillons stratifiés** sémantiquement (pas juste random — distribution voulue, ex. 3 par section top-level)
+- **Détection de doublons** (mêmes contenus rangés sous deux noms / deux catégories)
+- **Edge cases** : fichiers où le classifier hésite (score faible, désaccord N1/N2/N3), fichiers en `Autres`, fichiers avec couverture cassée
+- **Régression test set** : constitution d'un jeu de tests stable pour valider que les changements de mapping ne dégradent pas la classif
+- **Conversation** pour ajuster les critères en cours de route ("ajoute-moi 5 PDFs supplémentaires en Programmation, et retire ceux que tu avais déjà mis qui sont des Cookbooks")
+
+## Hors scope (explicitement)
+
+- **Modification du profil source** — toutes les opérations sont read-only côté source
+- **Génération d'annotations / résumés** des fichiers — juste sélection + copie
+- **Curation cross-profils en bulk** — un profil source à la fois (pas de fan-out)
+- **Renommage ou re-classification** lors de la copie — c'est la responsabilité du profil cible
+- **Sélection sur PDFs non analysés par vision** — l'agent travaille sur des fichiers déjà passés par `analyze_cover` (sinon il n'a pas d'info sémantique)
+
+## Architecture cible
+
+<p align="center">
+  <img src="diagrams/agent-curation-phases.svg" alt="Agent curation — 3 phases" width="800">
+</p>
+
+```text
+┌──────────────────────────────────────────────────────────────────┐
+│              Curation Agent (LangGraph)                          │
+│                                                                  │
+│   ┌────────────┐    ┌────────────┐    ┌────────────┐             │
+│   │ Phase A    │ →  │ Phase B    │ →  │ Phase C    │             │
+│   │ Analyze    │    │ Select     │    │ Apply      │             │
+│   └────────────┘    └────────────┘    └────────────┘             │
+│        ↓ stats         ↓ candidate set  ↓ copy to target         │
+└──────────────────────────────────────────────────────────────────┘
+        ↓ shared
+┌──────────────────────────────────────────────────────────────────┐
+│  dashboard.curation        (helpers copie + thumbnails)          │
+│  dashboard.data            (DuckDB queries stats)                │
+│  lib.classifier            (score / desagreement detection)      │
+│  agents/                   (module Python partagé)               │
+└──────────────────────────────────────────────────────────────────┘
+```
+
+L'agent vit dans `agents/curation/` (sous-package du module `agents/`). Frontend : extension de l'onglet **Curation** existant + endpoints `/api/agent/curation/*`.
+
+---
+
+## Phase A — Analyze (read-only)
+
+### Objectif
+
+L'agent comprend le profil source avant toute sélection. Il produit des **stats** + **anomalies détectées** qui éclairent les choix de curation : si l'utilisateur demande "20 fichiers représentatifs", l'agent doit savoir s'il y a 88 sections ou 5, si la distribution est équilibrée ou déséquilibrée, où sont les zones d'ombre.
+
+### Ce que l'agent analyse
+
+- **Distribution** : nombre de fichiers par section top-level et par sous-dossier (réutilise `dashboard.data` DuckDB)
+- **Désaccords classifier** : fichiers où N1 (theme_mapping) et N2 (keyword) ou N3 (LLM) divergeraient s'ils étaient ré-évalués — détectés via le trigger N3 sur catch-all (PR #147) et d'éventuels désaccords inter-niveaux
+- **Doublons potentiels** : par hash MD5 head bytes (déjà calculé pour le cache thumbnail) + par similarité de titre (Levenshtein)
+- **Couvertures cassées** : fichiers où `vision_cache.json` retourne `theme=""` ou pas d'entrée du tout
+- **Anciens** : fichiers analysés avec une version de `PROMPT_VERSION` antérieure à la version courante — candidats à re-vision
+
+### Sortie
+
+`profile/<source>/.cache/curation/analysis-<date>.md` :
+
+```markdown
+# Curation Analysis — profil source `default` — 2026-05-25
+
+## Distribution
+- 19 259 fichiers répartis sur 88 dossiers / 5 sections top-level
+- Section dominante : `02-INFORMATIQUE` (8 240, 43%)
+- Section sous-utilisée : `04-ECONOMIE` (240, 1.2%)
+
+## Désaccords classifier (3.2% — 617 fichiers)
+- Catch-all hit par N1 mais N3 propose un dossier spécifique : 412 fichiers
+- N2 keyword override : 205 fichiers
+- (À examiner sur un cas avant régression test)
+
+## Doublons potentiels (78 paires, 156 fichiers)
+- 23 paires : même MD5, basenames différents (renames manqués)
+- 55 paires : titre similaire (Levenshtein < 4), MD5 différents (vraies variantes)
+
+## Couvertures cassées (8 fichiers)
+- 3 PDFs encryptés
+- 5 PDFs avec page de garde noire
+
+## Anciens (PROMPT_VERSION < courant : 142 fichiers)
+- Cycle 2 vs cycle 3 (avant fix parser 2026-05-04)
+```
+
+### Outils nécessaires (read-only)
+
+| Outil | Signature | Effet |
+|---|---|---|
+| `profile_stats` | `(profile) -> ProfileStats` | Distribution par section/dossier, réutilise queries DuckDB `dashboard.data` |
+| `find_classifier_disagreements` | `(profile) -> list[Disagreement]` | Compare N1/N2/N3 sur les fichiers déjà en cache vision |
+| `find_duplicates` | `(profile, method="md5"\|"title") -> list[DupeGroup]` | Groupes de fichiers candidats doublons |
+| `find_broken_covers` | `(profile) -> list[Path]` | Fichiers où vision_cache vide ou erreur |
+| `find_stale_vision` | `(profile, min_version) -> list[Path]` | Fichiers analysés sous PROMPT_VERSION ancien |
+
+### Endpoint
+
+`POST /api/agent/curation/analyze` body :
+```json
+{
+  "source_profile": "default",
+  "target_profile": "test",  // déclaré dès Phase A pour contexte
+  "criteria_hint": "représentatif global"  // optionnel — guide la profondeur d'analyse
+}
+```
+
+### Garde-fous Phase A
+
+- **Aucune écriture FS** côté Klodo — seul artefact : `analysis-<date>.md` dans `.cache/curation/`
+- **Cap durée** : si l'analyse dépasse 60s (gros profil), retourne un rapport partiel + propose de l'affiner
+- **Pas d'accès LLM** en Phase A par défaut (toutes les sources sont locales : DuckDB + vision_cache + MD5). Optionnel : embedding-based duplicate detection si l'utilisateur l'active explicitement (cost contrôlé)
+
+---
+
+## Phase B — Select (proposition de sélection)
+
+### Objectif
+
+À partir d'un critère donné par l'utilisateur en langage naturel, **proposer une liste de fichiers** (rel_paths) avec rationale par fichier. L'utilisateur valide / ajuste / re-prompt avant la copie.
+
+### Exemples de critères supportés
+
+| Critère utilisateur | Stratégie agent |
+|---|---|
+| "20 fichiers représentatifs de toute la biblio" | Échantillon stratifié par section top-level, poids ∝ √(taille_section) |
+| "5 fichiers par section" | Échantillon uniforme stratifié |
+| "tous les Autres de Programmation" | Filtre par dossier == catch-all |
+| "10 fichiers où le classifier hésite" | Top-10 des désaccords par score gap |
+| "les doublons MD5" | Tous les groupes MD5 (1 fichier par groupe = canonical) |
+| "10 couvertures à re-visionner" | Couvertures cassées + anciennes (jusqu'à 10) |
+| "jeu de régression : 50 fichiers stables, couvrant 10+ sections, sans doublons" | Composition : 50 fichiers, stratifié, exclure doublons MD5, score classifier > 0.6 |
+
+### Sortie
+
+Un fichier JSON dans `.cache/curation/<selection_id>/selection.json` :
+
+```json
+{
+  "selection_id": "sel-2026-05-25-1234",
+  "source_profile": "default",
+  "target_profile": "test",
+  "criteria": "20 fichiers représentatifs de toute la biblio",
+  "strategy": "stratified_topsection",
+  "count": 20,
+  "files": [
+    {
+      "rel_path": "02-INFORMATIQUE/03-Langages-Programmation/01-Python/Fluent Python.pdf",
+      "section": "02-INFORMATIQUE",
+      "rationale": "représentant de Programmation Python (cluster 12% biblio)",
+      "score_classifier": 0.92
+    },
+    ...
+  ],
+  "diagnostics": {
+    "sections_covered": 5,
+    "duplicates_excluded": 3,
+    "broken_covers_excluded": 0
+  }
+}
+```
+
+Plus un **markdown lisible** `selection.md` pour l'audit humain.
+
+### Outils Phase B (read + propose)
+
+| Outil | Signature | Effet |
+|---|---|---|
+| Tous ceux de Phase A | | (réutilisés pour cibler la sélection) |
+| `propose_selection` | `(profile, criteria, n) -> Selection` | LLM interprète le critère, choisit la stratégie, échantillonne |
+| `apply_strategy` | `(strategy, profile, n) -> list[Path]` | Stratégies déterministes : stratified, top_disagreement, duplicates_only, etc. |
+| `preview_target_impact` | `(selection, target_profile) -> ImpactReport` | Combien de fichiers déjà présents dans target, collisions, espace requis |
+| `refine_selection` | `(selection_id, adjustment) -> Selection` | Modifier une sélection existante ("ajoute 5 Python", "retire les Cookbooks") |
+
+### Itération conversationnelle
+
+```
+User: 20 fichiers représentatifs
+Agent: J'ai composé une sélection stratifiée :
+       - 02-INFORMATIQUE : 9 fichiers (43% biblio)
+       - 01-SCIENCES : 5
+       - 03-HISTOIRE : 3
+       - 05-RELIGIONS : 2
+       - 04-ECONOMIE : 1
+       Voir selection.md
+User: ajoute 3 Cookbooks
+Agent: ⚠ Aucun dossier "Cookbook" dans 02-INFORMATIQUE.
+       J'ai trouvé 4 fichiers avec "cookbook" dans le titre, dans /Python et /JavaScript.
+       Tu veux que j'en pioche 3 sur ces 4 ?
+User: oui
+Agent: ✓ Sélection mise à jour : 23 fichiers
+```
+
+### Garde-fous Phase B
+
+- **Aucune écriture sur target_profile** — uniquement `.cache/curation/<selection_id>/`
+- **Validation que tous les rel_paths existent réellement** dans le profil source avant de proposer
+- **Diff vs sélection précédente** affiché à chaque itération (added / removed)
+- **Limite n ≤ 200** par sélection (au-delà, l'agent demande s'il faut vraiment ou si c'est une erreur)
+- **Anti-hallucination LLM** : la liste finale est filtrée par `apply_strategy` qui ne retourne que des Paths réellement listés via DuckDB. Le LLM ne peut pas inventer un rel_path
+
+---
+
+## Phase C — Apply (copie vers target)
+
+### Objectif
+
+Copier physiquement la sélection vers le profil cible avec gestion des collisions et journalisation.
+
+### Exemples de tour de conversation
+
+```
+User: applique
+Agent: Je vais copier 23 fichiers (124 MB) vers profil 'test' :
+       - 21 nouveaux
+       - 2 collisions (basename existe déjà) → suffixe -2
+       Confirmer ?
+User: oui
+Agent: ✓ Copie terminée. 23 fichiers écrits.
+       Journal : profile/test/.cache/curation-journal.jsonl
+       Tu veux que je lance les tests fonctionnels sur 'test' ?
+```
+
+### Tools mutables (read + write)
+
+| Outil | Signature | Effet |
+|---|---|---|
+| Tous ceux de Phase B | | (l'agent peut affiner avant apply) |
+| `copy_to_target` | `(selection_id, target_profile, on_collision="suffix"\|"skip"\|"overwrite") -> CopyResult` | Copie physique. Réutilise les helpers de `dashboard.curation` |
+| `journal_curation` | `(selection_id, copy_result) -> JournalEntry` | Append à `profile/<target>/.cache/curation-journal.jsonl` |
+| `run_tests_on_target` | `(target_profile) -> TestResult` | (optionnel) Lance `tests/functional/runner.py --profile <target>` |
+
+### Journal agent
+
+```json
+{
+  "ts": "2026-05-25T14:30:00",
+  "agent": "curation",
+  "phase": "C",
+  "action": "copy_to_target",
+  "selection_id": "sel-2026-05-25-1234",
+  "source": "default",
+  "target": "test",
+  "criteria": "20 fichiers représentatifs de toute la biblio",
+  "files_copied": 21,
+  "collisions_resolved": 2,
+  "bytes_written": 130023424
+}
+```
+
+### Garde-fous Phase C
+
+- **Refus si target_profile == source_profile** (no-op et risqué)
+- **Refus si target_profile n'existe pas** — l'agent suggère onboarding-agent ou `./klodo.sh init`
+- **Dry-run par défaut** — l'agent affiche le plan d'abord, demande confirmation
+- **Atomicité par fichier** : chaque copie est atomique (`shutil.copy2 → tempfile → rename`), pas de partial state
+- **Journal append-only** — pas de mutation rétroactive
+- **Espace disque vérifié** avant la copie (`shutil.disk_usage`) — refus si insuffisant
+- **Pas de delete sur source** — Phase C ne supprime jamais rien
+
+---
+
+## Plan de développement
+
+### Vue d'ensemble
+
+| Phase | Effort estimé | Dépendances | Livrable |
+|---|---|---|---|
+| **A — Analyze** | ~6-10 j-h | Agent Refonte Phase A (module `agents/`) + dashboard.data DuckDB | Analyse + 5 outils read-only |
+| **B — Select** | ~10-15 j-h | Phase A + dashboard.curation helpers existants | Sélection conversationnelle + stratégies |
+| **C — Apply** | ~6-10 j-h | Phase B + `lib.rename_journal` pattern pour le journal | Copie atomique + journal |
+| **Total** | **~22-35 j-h** | Refonte A + dashboard Curation existant | Agent curation livrable en 4-5 semaines |
+
+L'agent curation est le **plus léger des trois** parce qu'il s'appuie sur l'infrastructure dashboard Curation déjà en place.
+
+### Phase A — Tasks détaillées
+
+- **A.1** — Sous-package `agents/curation/` + state typé `CurationState`
+- **A.2** — Outils read-only (5) : `profile_stats`, `find_classifier_disagreements`, `find_duplicates`, `find_broken_covers`, `find_stale_vision`. Réutilise queries DuckDB existantes
+- **A.3** — Détection de doublons : version "md5 head bytes" (déjà calculé pour thumbnail cache) et version "title Levenshtein"
+- **A.4** — Endpoint `POST /api/agent/curation/analyze` + format markdown standardisé
+- **A.5** — Tests : ~8 tests sur fixtures DuckDB synthétiques
+
+### Phase B — Tasks détaillées
+
+- **B.1** — Outil `propose_selection` : LLM interprète le critère NL → choisit une stratégie déterministe
+- **B.2** — Stratégies (`apply_strategy`) : `stratified_topsection`, `uniform_per_section`, `top_disagreement`, `duplicates_only`, `broken_covers`, `regression_set`, `from_folder`, `by_title_match`
+- **B.3** — Outil `preview_target_impact` : intersection avec target_profile, calcul collisions, espace requis
+- **B.4** — UI dashboard : extension de l'onglet Curation existant — chat panel à côté du double panneau actuel, sélection auto poppe les fichiers dans le panneau source
+- **B.5** — Itération : `refine_selection(adjustment)` qui parse les ajustements NL et compose avec `apply_strategy`
+- **B.6** — Tests : ~12 tests dont une suite de stratégies + edge cases (n=0, n=200, target inexistant, collisions)
+
+### Phase C — Tasks détaillées
+
+- **C.1** — Outil `copy_to_target` : wrap autour de `dashboard.curation` helpers existants + on_collision policy
+- **C.2** — Journal `curation-journal.jsonl` : format aligné avec rename_journal (append-only, batch_id)
+- **C.3** — UI : modale de confirmation avant copie (récap + estimation), barre de progression pendant
+- **C.4** — Tests E2E : crée 2 profils test, lance curation 10 fichiers de A vers B, vérifie présence + journal + idempotence
+
+---
+
+## Tests et validation
+
+### Tests unitaires (par tâche)
+
+- **Phase A** : ~8 tests (mocks DuckDB, fixtures profil synthétique)
+- **Phase B** : ~12 tests (stratégies, edge cases, refine_selection)
+- **Phase C** : ~8 tests (copie atomique, collision policies, refus self-target, journal)
+
+Cible : **~28 tests** ajoutés à `tests/auto/test_agent_curation.py`.
+
+### Tests fonctionnels
+
+- 1 série dans `tests/functional/tests.yaml` : "Curation agent end-to-end" :
+  1. Crée 2 profils test (sourceX, targetY) avec 30 fichiers chacun
+  2. Lance analyze sur sourceX
+  3. Vérifie que l'analyse retourne au moins 2 catégories
+  4. Lance select : "5 fichiers représentatifs"
+  5. Vérifie que la sélection contient 5 rel_paths existants
+  6. Lance apply
+  7. Vérifie 5 fichiers présents dans targetY + entrée dans curation-journal.jsonl
+
+### Métriques de succès
+
+| Métrique | Cible v1 |
+|---|---|
+| Sélection retournée en < 5 sec pour profils < 20k fichiers | ✓ |
+| Stratégies déterministes : 100% reproductibles (seed fixe → mêmes fichiers) | ✓ |
+| 0 hallucination de rel_path par le LLM | ✓ (filtrage Phase B) |
+| Apply atomique : 0 partial-copy en cas de crash mi-copie | ✓ |
+| Coût LLM par sélection ≤ $0.10 (interprétation NL + rationale) | ✓ |
+
+---
+
+## Risques identifiés + mitigations
+
+| Risque | Probabilité | Impact | Mitigation |
+|---|---|---|---|
+| LLM invente un rel_path → erreur lors de l'apply | Élevée (sans précaution) | Critique | Filtrage Phase B : la sélection finale n'est composée que de Paths issus de `apply_strategy` (DuckDB-backed) |
+| Stratégie mal choisie pour le critère NL | Moyenne | Mineur | L'agent affiche le nom de la stratégie + count + rationale. User peut re-prompt |
+| Critère ambigu (ex. "des trucs intéressants") | Élevée | Mineur | L'agent demande clarification au lieu d'inventer une stratégie |
+| Espace disque insuffisant côté target | Faible | Majeur | Check `shutil.disk_usage` avant apply, refus si < 1.2× taille sélection |
+| Collisions de basename non gérées | Faible | Mineur | `on_collision` explicite (default `suffix`) |
+| Pollution de target_profile avec des fichiers d'agent runs ratés | Moyenne | Mineur | `selection_id` dans le journal → bouton "undo selection" en C.4 (optionnel) |
+| Profil source modifié pendant la curation (run concurrent) | Faible | Moyen | Snapshot de la liste de fichiers en début de Phase B. Si un fichier a disparu au moment de l'apply → skip + journal |
+| Désaccord N1/N3 mal interprété comme "le classifier hésite" | Faible | Mineur | Doc explicite dans le rationale : "désaccord" = trigger N3 a fired, c'est un signal pas une certitude |
+
+---
+
+## Frameworks alternatifs considérés
+
+Mêmes considérations que pour les agents Refonte et Onboarding. **LangGraph** retenu pour cohérence avec les autres agents. Voir [refonte-agent-spec.md](refonte-agent-spec.md#frameworks-alternatifs-considérés).
+
+Note spécifique curation : la phase de sélection (B) est l'endroit où on aurait pu envisager d'utiliser un système plus simple (pas d'orchestration LangGraph, juste des outils Python). Choix de garder LangGraph pour :
+- Itération conversationnelle native (refine_selection en multi-tour)
+- Cohérence du state pattern entre les 3 agents
+- Pouvoir composer plus tard (refonte + curation, par exemple "régénère le jeu de tests après un changement de mapping")
+
+---
+
+## Glossaire technique
+
+| Terme | Définition |
+|---|---|
+| **selection_id** | UUID d'une session Phase B, sert de clé pour `.cache/curation/<id>/` |
+| **stratégie** | Algorithme déterministe de sélection (stratified, top_disagreement, etc.). Le LLM choisit la stratégie ; la stratégie produit la liste de paths |
+| **désaccord classifier** | Cas où N1, N2 ou N3 propose des dossiers différents — utile pour les jeux de régression |
+| **régression test set** | Sélection stable destinée à être ré-évaluée après chaque modif de mapping, pour détecter les drifts |
+| **on_collision policy** | Comportement quand un basename existe déjà côté target : `suffix` (default, ajoute -2/-3), `skip` (ne copie pas), `overwrite` (remplace) |
+| **canonical** | Dans un groupe de doublons, le fichier choisi comme représentant (ex. nom le plus propre) |

--- a/docs/diagrams/agent-curation-phases.svg
+++ b/docs/diagrams/agent-curation-phases.svg
@@ -1,0 +1,127 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 620" font-family="Segoe Print, Comic Sans MS, cursive" font-size="13">
+  <defs>
+    <filter id="h" x="-2%" y="-2%" width="104%" height="104%">
+      <feTurbulence type="fractalNoise" baseFrequency="0.03" numOctaves="3" seed="25"/>
+      <feDisplacementMap in="SourceGraphic" scale="1.2"/>
+    </filter>
+    <marker id="arrow" viewBox="0 0 10 10" refX="8" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M 0 0 L 10 5 L 0 10 z" fill="#6b7280"/>
+    </marker>
+    <marker id="arrowPurple" viewBox="0 0 10 10" refX="8" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M 0 0 L 10 5 L 0 10 z" fill="#8b5cf6"/>
+    </marker>
+  </defs>
+
+  <g filter="url(#h)">
+    <!-- Title -->
+    <text x="500" y="30" text-anchor="middle" font-size="16" font-weight="bold" fill="#166534">🤖 Agent IA Curation — 3 phases shippables</text>
+    <text x="500" y="50" text-anchor="middle" font-size="11" fill="#22c55e" font-style="italic">orchestration LangGraph · ~22-35 j-h · 4-5 semaines</text>
+
+    <!-- ── Phase A : Analyze ── -->
+    <rect x="30" y="80" width="290" height="350" rx="14" fill="#dbeafe" stroke="#3b82f6" stroke-width="2.5"/>
+    <text x="175" y="106" text-anchor="middle" font-size="15" font-weight="bold" fill="#1e40af">Phase A — Analyze</text>
+    <text x="175" y="124" text-anchor="middle" font-size="11" fill="#3b82f6" font-style="italic">read-only stats · ~6-10 j-h</text>
+
+    <text x="50" y="148" font-size="10" font-style="italic" fill="#1e40af">Inputs</text>
+    <rect x="45" y="155" width="260" height="22" rx="4" fill="#ffffff" stroke="#3b82f6" stroke-width="1"/>
+    <text x="175" y="170" text-anchor="middle" font-size="10" fill="#1e40af">source_profile + criteria_hint</text>
+
+    <text x="50" y="200" font-size="10" font-style="italic" fill="#1e40af">Tools (read-only)</text>
+    <rect x="45" y="207" width="260" height="22" rx="4" fill="#ffffff" stroke="#3b82f6" stroke-width="1"/>
+    <text x="175" y="222" text-anchor="middle" font-size="10" fill="#1e40af">profile_stats() — DuckDB</text>
+
+    <rect x="45" y="234" width="260" height="22" rx="4" fill="#ffffff" stroke="#3b82f6" stroke-width="1"/>
+    <text x="175" y="249" text-anchor="middle" font-size="10" fill="#1e40af">find_classifier_disagreements()</text>
+
+    <rect x="45" y="261" width="125" height="22" rx="4" fill="#ffffff" stroke="#3b82f6" stroke-width="1"/>
+    <text x="107" y="276" text-anchor="middle" font-size="10" fill="#1e40af">find_duplicates()</text>
+    <rect x="180" y="261" width="125" height="22" rx="4" fill="#ffffff" stroke="#3b82f6" stroke-width="1"/>
+    <text x="242" y="276" text-anchor="middle" font-size="10" fill="#1e40af">find_broken_covers()</text>
+
+    <text x="50" y="306" font-size="10" font-style="italic" fill="#1e40af">Tâches</text>
+    <text x="55" y="322" font-size="10" fill="#1e40af">• A.1 — Sous-package agents/curation/</text>
+    <text x="55" y="338" font-size="10" fill="#1e40af">• A.2 — 5 outils read-only</text>
+    <text x="55" y="354" font-size="10" fill="#1e40af">• A.3 — Doublons MD5 + title Levenshtein</text>
+    <text x="55" y="370" font-size="10" fill="#1e40af">• A.4 — Endpoint + format rapport</text>
+    <text x="55" y="386" font-size="10" fill="#1e40af">• A.5 — Tests fixtures DuckDB</text>
+
+    <rect x="45" y="400" width="260" height="22" rx="4" fill="#d1fae5" stroke="#22c55e" stroke-width="1.5"/>
+    <text x="175" y="415" text-anchor="middle" font-size="10" font-weight="bold" fill="#166534">📄 analysis-&lt;date&gt;.md</text>
+
+    <!-- ── Phase B : Select ── -->
+    <rect x="355" y="80" width="290" height="350" rx="14" fill="#ede9fe" stroke="#8b5cf6" stroke-width="2.5"/>
+    <text x="500" y="106" text-anchor="middle" font-size="15" font-weight="bold" fill="#5b21b6">Phase B — Select</text>
+    <text x="500" y="124" text-anchor="middle" font-size="11" fill="#7c3aed" font-style="italic">propose selection · ~10-15 j-h</text>
+
+    <text x="375" y="148" font-size="10" font-style="italic" fill="#5b21b6">Inputs</text>
+    <rect x="370" y="155" width="260" height="22" rx="4" fill="#ffffff" stroke="#8b5cf6" stroke-width="1"/>
+    <text x="500" y="170" text-anchor="middle" font-size="10" fill="#5b21b6">criteria NL + n (target count)</text>
+
+    <text x="375" y="200" font-size="10" font-style="italic" fill="#5b21b6">Tools (read + propose)</text>
+    <rect x="370" y="207" width="260" height="22" rx="4" fill="#ffffff" stroke="#8b5cf6" stroke-width="1"/>
+    <text x="500" y="222" text-anchor="middle" font-size="10" fill="#5b21b6">propose_selection(criteria, n)</text>
+
+    <rect x="370" y="234" width="260" height="22" rx="4" fill="#ffffff" stroke="#8b5cf6" stroke-width="1"/>
+    <text x="500" y="249" text-anchor="middle" font-size="10" fill="#5b21b6">apply_strategy() — 8 stratégies</text>
+
+    <rect x="370" y="261" width="260" height="22" rx="4" fill="#ffffff" stroke="#8b5cf6" stroke-width="1"/>
+    <text x="500" y="276" text-anchor="middle" font-size="10" fill="#5b21b6">refine_selection(adjustment)</text>
+
+    <text x="375" y="306" font-size="10" font-style="italic" fill="#5b21b6">Tâches</text>
+    <text x="380" y="322" font-size="10" fill="#5b21b6">• B.1 — propose_selection LLM → strategy</text>
+    <text x="380" y="338" font-size="10" fill="#5b21b6">• B.2 — 8 stratégies déterministes</text>
+    <text x="380" y="354" font-size="10" fill="#5b21b6">• B.3 — preview_target_impact</text>
+    <text x="380" y="370" font-size="10" fill="#5b21b6">• B.4 — UI chat dans onglet Curation</text>
+    <text x="380" y="386" font-size="10" fill="#5b21b6">• B.5/B.6 — Itération + tests</text>
+
+    <rect x="370" y="400" width="260" height="22" rx="4" fill="#d1fae5" stroke="#22c55e" stroke-width="1.5"/>
+    <text x="500" y="415" text-anchor="middle" font-size="10" font-weight="bold" fill="#166534">📄 selection.json + selection.md</text>
+
+    <!-- ── Phase C : Apply ── -->
+    <rect x="680" y="80" width="290" height="350" rx="14" fill="#fce7f3" stroke="#ec4899" stroke-width="2.5"/>
+    <text x="825" y="106" text-anchor="middle" font-size="15" font-weight="bold" fill="#9d174d">Phase C — Apply</text>
+    <text x="825" y="124" text-anchor="middle" font-size="11" fill="#ec4899" font-style="italic">copy + journal · ~6-10 j-h</text>
+
+    <text x="700" y="148" font-size="10" font-style="italic" fill="#9d174d">Inputs</text>
+    <rect x="695" y="155" width="260" height="22" rx="4" fill="#ffffff" stroke="#ec4899" stroke-width="1"/>
+    <text x="825" y="170" text-anchor="middle" font-size="10" fill="#9d174d">selection_id + target_profile</text>
+
+    <text x="700" y="200" font-size="10" font-style="italic" fill="#9d174d">Tools (mutables)</text>
+    <rect x="695" y="207" width="260" height="22" rx="4" fill="#ffffff" stroke="#ec4899" stroke-width="1"/>
+    <text x="825" y="222" text-anchor="middle" font-size="10" fill="#9d174d">copy_to_target(on_collision=...)</text>
+
+    <rect x="695" y="234" width="260" height="22" rx="4" fill="#ffffff" stroke="#ec4899" stroke-width="1"/>
+    <text x="825" y="249" text-anchor="middle" font-size="10" fill="#9d174d">journal_curation() — JSONL</text>
+
+    <rect x="695" y="261" width="260" height="22" rx="4" fill="#ffffff" stroke="#ec4899" stroke-width="1"/>
+    <text x="825" y="276" text-anchor="middle" font-size="10" fill="#9d174d">run_tests_on_target() (optionnel)</text>
+
+    <text x="700" y="306" font-size="10" font-style="italic" fill="#9d174d">Tâches</text>
+    <text x="705" y="322" font-size="10" fill="#9d174d">• C.1 — copy_to_target atomique</text>
+    <text x="705" y="338" font-size="10" fill="#9d174d">• C.2 — curation-journal.jsonl</text>
+    <text x="705" y="354" font-size="10" fill="#9d174d">• C.3 — UI modale + progress</text>
+    <text x="705" y="370" font-size="10" fill="#9d174d">• C.4 — Tests E2E source→target</text>
+
+    <rect x="695" y="400" width="260" height="22" rx="4" fill="#d1fae5" stroke="#22c55e" stroke-width="1.5"/>
+    <text x="825" y="415" text-anchor="middle" font-size="10" font-weight="bold" fill="#166534">📄 target/&lt;files&gt; + journal</text>
+
+    <!-- Arrows between phases -->
+    <line x1="320" y1="255" x2="353" y2="255" stroke="#8b5cf6" stroke-width="2" marker-end="url(#arrowPurple)"/>
+    <text x="337" y="248" font-size="9" text-anchor="middle" fill="#7c3aed" font-style="italic">A → B</text>
+
+    <line x1="645" y1="255" x2="678" y2="255" stroke="#ec4899" stroke-width="2" marker-end="url(#arrow)"/>
+    <text x="662" y="248" font-size="9" text-anchor="middle" fill="#9d174d" font-style="italic">B → C</text>
+
+    <!-- Bottom : specificities -->
+    <rect x="30" y="455" width="940" height="80" rx="12" fill="#fef9c3" stroke="#ca8a04" stroke-width="2"/>
+    <text x="500" y="478" text-anchor="middle" font-size="13" font-weight="bold" fill="#854d0e">Spécificités curation</text>
+    <text x="50" y="500" font-size="11" fill="#a16207">• Anti-hallucination LLM : la sélection finale n'est composée que de Paths réels (DuckDB-backed)</text>
+    <text x="50" y="516" font-size="11" fill="#a16207">• Le LLM choisit la stratégie, la stratégie déterministe produit la liste</text>
+    <text x="500" y="500" font-size="11" fill="#a16207">• Stratégies reproductibles : seed fixe → mêmes fichiers</text>
+    <text x="500" y="516" font-size="11" fill="#a16207">• L'agent le + léger des 3 (s'appuie sur dashboard.curation existant)</text>
+
+    <!-- Timeline -->
+    <text x="500" y="565" text-anchor="middle" font-size="11" fill="#9ca3af" font-style="italic">Dépendances : Refonte Phase A (module agents/) + onglet Curation existant + DuckDB dashboard.data</text>
+    <text x="500" y="585" text-anchor="middle" font-size="10" fill="#9ca3af" font-style="italic">Cf. docs/curation-agent-spec.md pour le détail des tâches A.1-A.5 / B.1-B.6 / C.1-C.4</text>
+  </g>
+</svg>

--- a/docs/diagrams/agent-onboarding-phases.svg
+++ b/docs/diagrams/agent-onboarding-phases.svg
@@ -1,0 +1,128 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 620" font-family="Segoe Print, Comic Sans MS, cursive" font-size="13">
+  <defs>
+    <filter id="h" x="-2%" y="-2%" width="104%" height="104%">
+      <feTurbulence type="fractalNoise" baseFrequency="0.03" numOctaves="3" seed="23"/>
+      <feDisplacementMap in="SourceGraphic" scale="1.2"/>
+    </filter>
+    <marker id="arrow" viewBox="0 0 10 10" refX="8" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M 0 0 L 10 5 L 0 10 z" fill="#6b7280"/>
+    </marker>
+    <marker id="arrowPurple" viewBox="0 0 10 10" refX="8" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M 0 0 L 10 5 L 0 10 z" fill="#8b5cf6"/>
+    </marker>
+  </defs>
+
+  <g filter="url(#h)">
+    <!-- Title -->
+    <text x="500" y="30" text-anchor="middle" font-size="16" font-weight="bold" fill="#1e40af">🤖 Agent IA Onboarding — 3 phases shippables</text>
+    <text x="500" y="50" text-anchor="middle" font-size="11" fill="#3b82f6" font-style="italic">orchestration LangGraph · ~28-42 j-h · 4-6 semaines</text>
+
+    <!-- ── Phase A : Discovery (read-only inbox) ── -->
+    <rect x="30" y="80" width="290" height="350" rx="14" fill="#dbeafe" stroke="#3b82f6" stroke-width="2.5"/>
+    <text x="175" y="106" text-anchor="middle" font-size="15" font-weight="bold" fill="#1e40af">Phase A — Discovery</text>
+    <text x="175" y="124" text-anchor="middle" font-size="11" fill="#3b82f6" font-style="italic">read inbox · ~8-12 j-h</text>
+
+    <text x="50" y="148" font-size="10" font-style="italic" fill="#1e40af">Inputs</text>
+    <rect x="45" y="155" width="260" height="22" rx="4" fill="#ffffff" stroke="#3b82f6" stroke-width="1"/>
+    <text x="175" y="170" text-anchor="middle" font-size="10" fill="#1e40af">inbox path + sample_size (50)</text>
+
+    <text x="50" y="200" font-size="10" font-style="italic" fill="#1e40af">Tools (read-only)</text>
+    <rect x="45" y="207" width="125" height="22" rx="4" fill="#ffffff" stroke="#3b82f6" stroke-width="1"/>
+    <text x="107" y="222" text-anchor="middle" font-size="10" fill="#1e40af">scan_inbox()</text>
+    <rect x="180" y="207" width="125" height="22" rx="4" fill="#ffffff" stroke="#3b82f6" stroke-width="1"/>
+    <text x="242" y="222" text-anchor="middle" font-size="10" fill="#1e40af">sample_stratified()</text>
+
+    <rect x="45" y="234" width="260" height="22" rx="4" fill="#ffffff" stroke="#3b82f6" stroke-width="1"/>
+    <text x="175" y="249" text-anchor="middle" font-size="10" fill="#1e40af">analyze_sample() → LLM Vision</text>
+
+    <rect x="45" y="261" width="125" height="22" rx="4" fill="#ffffff" stroke="#3b82f6" stroke-width="1"/>
+    <text x="107" y="276" text-anchor="middle" font-size="10" fill="#1e40af">cluster_themes()</text>
+    <rect x="180" y="261" width="125" height="22" rx="4" fill="#ffffff" stroke="#3b82f6" stroke-width="1"/>
+    <text x="242" y="276" text-anchor="middle" font-size="10" fill="#1e40af">detect_existing_tree()</text>
+
+    <text x="50" y="306" font-size="10" font-style="italic" fill="#1e40af">Tâches</text>
+    <text x="55" y="322" font-size="10" fill="#1e40af">• A.1 — Sous-package agents/onboarding/</text>
+    <text x="55" y="338" font-size="10" fill="#1e40af">• A.2 — 5 outils read-only + tests</text>
+    <text x="55" y="354" font-size="10" fill="#1e40af">• A.3 — Prompt + format rapport</text>
+    <text x="55" y="370" font-size="10" fill="#1e40af">• A.4 — Endpoint + page dashboard</text>
+    <text x="55" y="386" font-size="10" fill="#1e40af">• A.5 — Smoke run 50 PDFs</text>
+
+    <rect x="45" y="400" width="260" height="22" rx="4" fill="#d1fae5" stroke="#22c55e" stroke-width="1.5"/>
+    <text x="175" y="415" text-anchor="middle" font-size="10" font-weight="bold" fill="#166534">📄 discovery-&lt;date&gt;.md (clusters)</text>
+
+    <!-- ── Phase B : Proposition (side YAMLs) ── -->
+    <rect x="355" y="80" width="290" height="350" rx="14" fill="#ede9fe" stroke="#8b5cf6" stroke-width="2.5"/>
+    <text x="500" y="106" text-anchor="middle" font-size="15" font-weight="bold" fill="#5b21b6">Phase B — Proposition</text>
+    <text x="500" y="124" text-anchor="middle" font-size="11" fill="#7c3aed" font-style="italic">side YAMLs · ~10-15 j-h</text>
+
+    <text x="375" y="148" font-size="10" font-style="italic" fill="#5b21b6">Inputs</text>
+    <rect x="370" y="155" width="260" height="22" rx="4" fill="#ffffff" stroke="#8b5cf6" stroke-width="1"/>
+    <text x="500" y="170" text-anchor="middle" font-size="10" fill="#5b21b6">Phase A + objectifs structurels user</text>
+
+    <text x="375" y="200" font-size="10" font-style="italic" fill="#5b21b6">Tools (propose)</text>
+    <rect x="370" y="207" width="260" height="22" rx="4" fill="#ffffff" stroke="#8b5cf6" stroke-width="1"/>
+    <text x="500" y="222" text-anchor="middle" font-size="10" fill="#5b21b6">A.* + propose_tree()</text>
+
+    <rect x="370" y="234" width="260" height="22" rx="4" fill="#ffffff" stroke="#8b5cf6" stroke-width="1"/>
+    <text x="500" y="249" text-anchor="middle" font-size="10" fill="#5b21b6">propose_theme_mapping()</text>
+
+    <rect x="370" y="261" width="260" height="22" rx="4" fill="#ffffff" stroke="#8b5cf6" stroke-width="1"/>
+    <text x="500" y="276" text-anchor="middle" font-size="10" fill="#5b21b6">simulate_classify(--dry-run)</text>
+
+    <text x="375" y="306" font-size="10" font-style="italic" fill="#5b21b6">Tâches</text>
+    <text x="380" y="322" font-size="10" fill="#5b21b6">• B.1 — propose_tree + mapping</text>
+    <text x="380" y="338" font-size="10" fill="#5b21b6">• B.2 — Format onboarding-rationale.md</text>
+    <text x="380" y="354" font-size="10" fill="#5b21b6">• B.3 — UI visualiseur YAMLs</text>
+    <text x="380" y="370" font-size="10" fill="#5b21b6">• B.4 — Dialog itératif (chat)</text>
+
+    <rect x="370" y="400" width="260" height="22" rx="4" fill="#d1fae5" stroke="#22c55e" stroke-width="1.5"/>
+    <text x="500" y="415" text-anchor="middle" font-size="10" font-weight="bold" fill="#166534">📄 tree + mapping + categories proposed</text>
+
+    <!-- ── Phase C : Bootstrap (création profil) ── -->
+    <rect x="680" y="80" width="290" height="350" rx="14" fill="#fce7f3" stroke="#ec4899" stroke-width="2.5"/>
+    <text x="825" y="106" text-anchor="middle" font-size="15" font-weight="bold" fill="#9d174d">Phase C — Bootstrap</text>
+    <text x="825" y="124" text-anchor="middle" font-size="11" fill="#ec4899" font-style="italic">création profil · ~10-15 j-h</text>
+
+    <text x="700" y="148" font-size="10" font-style="italic" fill="#9d174d">Inputs</text>
+    <rect x="695" y="155" width="260" height="22" rx="4" fill="#ffffff" stroke="#ec4899" stroke-width="1"/>
+    <text x="825" y="170" text-anchor="middle" font-size="10" fill="#9d174d">YAMLs proposed validés</text>
+
+    <text x="700" y="200" font-size="10" font-style="italic" fill="#9d174d">Tools (mutables)</text>
+    <rect x="695" y="207" width="260" height="22" rx="4" fill="#ffffff" stroke="#ec4899" stroke-width="1"/>
+    <text x="825" y="222" text-anchor="middle" font-size="10" fill="#9d174d">create_profile(name, target, yamls)</text>
+
+    <rect x="695" y="234" width="260" height="22" rx="4" fill="#ffffff" stroke="#ec4899" stroke-width="1"/>
+    <text x="825" y="249" text-anchor="middle" font-size="10" fill="#9d174d">🔒 profiles-create.lock</text>
+
+    <rect x="695" y="261" width="260" height="22" rx="4" fill="#ffffff" stroke="#ec4899" stroke-width="1"/>
+    <text x="825" y="276" text-anchor="middle" font-size="10" fill="#9d174d">run_classify_dryrun()</text>
+
+    <text x="700" y="306" font-size="10" font-style="italic" fill="#9d174d">Tâches</text>
+    <text x="705" y="322" font-size="10" fill="#9d174d">• C.1 — create_profile atomique</text>
+    <text x="705" y="338" font-size="10" fill="#9d174d">• C.2 — Journal agent (JSONL)</text>
+    <text x="705" y="354" font-size="10" fill="#9d174d">• C.3 — UI récap + confirm modale</text>
+    <text x="705" y="370" font-size="10" fill="#9d174d">• C.4 — Tests E2E + smoke process</text>
+
+    <rect x="695" y="400" width="260" height="22" rx="4" fill="#d1fae5" stroke="#22c55e" stroke-width="1.5"/>
+    <text x="825" y="415" text-anchor="middle" font-size="10" font-weight="bold" fill="#166534">📄 profiles/&lt;name&gt;/ + agent-journal</text>
+
+    <!-- Arrows between phases -->
+    <line x1="320" y1="255" x2="353" y2="255" stroke="#8b5cf6" stroke-width="2" marker-end="url(#arrowPurple)"/>
+    <text x="337" y="248" font-size="9" text-anchor="middle" fill="#7c3aed" font-style="italic">A → B</text>
+
+    <line x1="645" y1="255" x2="678" y2="255" stroke="#ec4899" stroke-width="2" marker-end="url(#arrow)"/>
+    <text x="662" y="248" font-size="9" text-anchor="middle" fill="#9d174d" font-style="italic">B → C</text>
+
+    <!-- Bottom : framework + risks -->
+    <rect x="30" y="455" width="940" height="80" rx="12" fill="#fef9c3" stroke="#ca8a04" stroke-width="2"/>
+    <text x="500" y="478" text-anchor="middle" font-size="13" font-weight="bold" fill="#854d0e">Spécificités onboarding</text>
+    <text x="50" y="500" font-size="11" fill="#a16207">• Cap dur budget LLM : 200 fichiers max (~$5) — l'inbox peut être énorme</text>
+    <text x="50" y="516" font-size="11" fill="#a16207">• Détection de pré-orga existante → reverse-engineer ou repartir à plat</text>
+    <text x="500" y="500" font-size="11" fill="#a16207">• Aucune classif réelle, pas de rename — ça reste de la responsabilité du process</text>
+    <text x="500" y="516" font-size="11" fill="#a16207">• Le profil créé est immédiatement utilisable par ./klodo.sh process</text>
+
+    <!-- Timeline -->
+    <text x="500" y="565" text-anchor="middle" font-size="11" fill="#9ca3af" font-style="italic">Dépendance : module agents/ créé par Phase A de Refonte (LangGraph state pattern)</text>
+    <text x="500" y="585" text-anchor="middle" font-size="10" fill="#9ca3af" font-style="italic">Cf. docs/onboarding-agent-spec.md pour le détail des tâches A.1-A.5 / B.1-B.4 / C.1-C.4</text>
+  </g>
+</svg>

--- a/docs/onboarding-agent-spec.md
+++ b/docs/onboarding-agent-spec.md
@@ -1,0 +1,380 @@
+# Spec — Agent IA « Onboarding nouveau profil »
+
+[← Retour au README](../README.md) · [Spec agent Refonte](refonte-agent-spec.md) · [Spec agent Curation](curation-agent-spec.md)
+
+> Second agent IA du projet Klodo. Lit ce qui se trouve dans un dossier "inbox" et propose une **taxonomie de départ** (tree.yaml + theme_mapping.yaml + categories.yaml) adaptée au contenu réel, plutôt que de forcer l'utilisateur à tout écrire à la main.
+
+## Pourquoi un agent
+
+Aujourd'hui, créer un profil = `./klodo.sh init <nom> --target /path` puis **éditer 3 YAMLs à la main** avant de pouvoir classer quoi que ce soit. Problème chicken-and-egg : on ne sait pas écrire un bon `theme_mapping.yaml` avant de connaître les thèmes qui vont sortir du vision LLM sur le corpus.
+
+L'agent onboarding casse ce blocage : il **échantillonne** le contenu, **groupe** les thèmes par cluster sémantique, et **propose** une taxonomie de départ que l'utilisateur valide ou ajuste. Le profil ainsi créé est immédiatement utilisable par `./klodo.sh process`.
+
+Ce qu'un agent apporte (vs. script déterministe) :
+- **Compréhension sémantique des clusters** : "Programmation Java", "Programmation Python", "Frameworks JS" → cluster `02-INFORMATIQUE/03-Langages-Programmation/` avec sous-dossiers, pas un fourre-tout
+- **Conversation pour les choix structurels** : "tu préfères grouper par langage ou par paradigme ?"
+- **Détection de profil pré-organisé** : si le dossier source contient déjà une structure (`Sciences/`, `Programmation/`), l'agent propose de la reverse-engineer plutôt que de reconstruire
+
+## Hors scope (explicitement)
+
+- **Renommage des fichiers** — l'agent ne touche pas aux noms (c'est `./klodo.sh rename` après création du profil)
+- **Classification réelle** — l'agent ne déplace pas les PDFs. Il crée le profil. La classification se fait après via `./klodo.sh process`
+- **Auto-discover continu** — one-shot pour le bootstrap. Pour enrichir la taxonomie après coup → agent Refonte
+- **Génération de prompts custom** — utilise les prompts vision standards de Klodo
+- **Multi-profils en parallèle** — un onboarding = un profil à la fois (pas de bulk)
+
+## Architecture cible
+
+<p align="center">
+  <img src="diagrams/agent-onboarding-phases.svg" alt="Agent onboarding — 3 phases" width="800">
+</p>
+
+```text
+┌──────────────────────────────────────────────────────────────────┐
+│              Onboarding Agent (LangGraph)                        │
+│                                                                  │
+│   ┌────────────┐    ┌────────────┐    ┌────────────┐             │
+│   │ Phase A    │ →  │ Phase B    │ →  │ Phase C    │             │
+│   │ Discovery  │    │ Proposition│    │ Bootstrap  │             │
+│   └────────────┘    └────────────┘    └────────────┘             │
+│        ↓ read inbox     ↓ side YAMLs    ↓ create profile         │
+└──────────────────────────────────────────────────────────────────┘
+        ↓ shared with Refonte agent (read tools)
+┌──────────────────────────────────────────────────────────────────┐
+│  lib.vision.analyze_cover      (échantillon LLM Vision)          │
+│  lib.classifier (read-only)    (validation des propositions)     │
+│  lib.profile.create_profile    (mutation finale)                 │
+│  agents/                       (module Python partagé)           │
+└──────────────────────────────────────────────────────────────────┘
+```
+
+L'agent vit dans `agents/onboarding/` (sous-package du module `agents/` créé par Refonte). Frontend : nouvel onglet **Onboarding** dans le dashboard + endpoints `/api/agent/onboarding/*`.
+
+---
+
+## Phase A — Discovery (read-only)
+
+### Objectif
+
+L'agent observe l'inbox sans rien modifier. Il échantillonne intelligemment, identifie les clusters de contenu et produit un **rapport de découverte** que l'utilisateur lit pour comprendre ce que Klodo a vu dans son corpus avant d'engager la suite.
+
+### Ce que l'agent discovere
+
+- **Volume + format** : nombre de fichiers, répartition PDF/ePub/autres
+- **Pré-organisation existante** : structure de dossiers détectée dans l'inbox (s'il y en a une)
+- **Échantillon stratifié** : N fichiers (default N=50, configurable jusqu'à 200) répartis sur l'arborescence existante ou aléatoirement si flat
+- **Thèmes bruts** : appel LLM Vision sur l'échantillon, agrégation des `theme` et `themes[]`
+- **Clusters proposés** : regroupement des thèmes par proximité sémantique (similarité d'embeddings ou règles déterministes)
+- **Cas non couverts** : fichiers où le LLM retourne `theme=""` ou couverture non extractible — signalés
+
+### Sortie
+
+Un fichier markdown auto-généré : `profile/<name>/.cache/discovery-<date>.md`
+
+```markdown
+# Discovery — inbox `/Volumes/ExtSSD/MyBooks` — 2026-05-25
+
+## Volume
+- 1 247 fichiers (1 198 PDF · 49 ePub)
+- Taille moyenne : 8 MB · range [40 KB → 220 MB]
+
+## Pré-organisation détectée
+✅ L'inbox a déjà une structure :
+  - `Books/Programming/` (412 files)
+  - `Books/Science/` (218 files)
+  - `Books/History/` (87 files)
+  - `Books/Misc/` (530 files)
+
+Recommandation : reverse-engineer la structure existante + analyse de `Misc/` pour proposer des sous-dossiers.
+
+## Échantillon analysé (50 fichiers)
+- Stratifié sur les 4 dossiers principaux
+- Coût LLM : $0.74 · durée : 4 min
+
+## Clusters détectés
+1. **Langages de programmation** (412 fichiers, 33%)
+   - Java (~120) · Python (~90) · JavaScript (~70) · C/C++ (~50) · Autres (~80)
+2. **Sciences exactes** (218 fichiers, 17%)
+   - Mathématiques (~80) · Physique (~70) · Chimie (~30) · Biologie (~38)
+3. **Histoire** (87 fichiers, 7%)
+   - XXe siècle (~40) · Antiquité (~25) · Médiéval (~22)
+4. **Religion / Spiritualité** (62 fichiers, 5%, inferred from Misc)
+5. **Économie / Finance** (48 fichiers, 4%, inferred from Misc)
+6. **Cas non couverts** : 8 fichiers (LLM theme vide ou couverture illisible)
+```
+
+### Outils nécessaires (read-only)
+
+| Outil | Signature | Effet |
+|---|---|---|
+| `scan_inbox` | `(path) -> InboxStats` | Compte fichiers, formats, structure de dossiers |
+| `sample_stratified` | `(inbox, n=50, strategy="balanced") -> list[Path]` | Échantillonnage proportionnel à l'arbo, ou aléatoire si flat |
+| `analyze_sample` | `(paths) -> list[VisionResult]` | Appelle `lib.vision.analyze_cover` sur chaque, retourne titre+thème+themes |
+| `cluster_themes` | `(vision_results) -> list[ThemeCluster]` | Regroupe par proximité — règles + embeddings optionnels |
+| `detect_existing_tree` | `(inbox) -> TreeStructure \| None` | Inspecte la profondeur/régularité de l'arbo. Retourne None si flat |
+
+### Endpoint
+
+`POST /api/agent/onboarding/discovery` body :
+```json
+{
+  "inbox_path": "/Volumes/ExtSSD/MyBooks",
+  "profile_name": "perso-2026",  // pré-réservé, profil pas encore créé
+  "sample_size": 50
+}
+```
+Retourne le rapport markdown + un `discovery_id` pour la Phase B.
+
+### Garde-fous Phase A
+
+- **Aucune écriture FS** côté Klodo. La seule "écriture" est le rapport markdown dans `.cache/onboarding/<discovery_id>/`
+- **Cap budget LLM** : par défaut, $5 max par discovery (200 fichiers × $0.025). Au-delà, l'agent s'arrête et demande confirmation
+- **Aucun accès à la biblio classifiée existante** d'autres profils (sauf si l'utilisateur l'autorise pour s'inspirer)
+- **Pas de download** : tous les outils opèrent sur le FS local
+
+---
+
+## Phase B — Proposition (side YAMLs)
+
+### Objectif
+
+À partir du rapport Phase A + des objectifs structurels de l'utilisateur (conversation), produire 3 YAMLs **proposés**, sans toucher au système. L'utilisateur les visualise, simule la classif, ajuste.
+
+### Ce que l'agent produit
+
+3 fichiers dans `profile/<name>/.cache/onboarding/<discovery_id>/proposed/` :
+- `tree-proposed.yaml` — arborescence cible (sections top-level + sous-dossiers)
+- `theme-mapping-proposed.yaml` — mapping thème → dossier basé sur les clusters Phase A
+- `categories-proposed.yaml` — mots-clés par dossier (fallback KeywordClassifier)
+
+Plus :
+- `onboarding-rationale.md` — décisions structurelles (pourquoi 4 sections top-level, pourquoi tel cluster va dans tel dossier)
+
+### Format `onboarding-rationale.md`
+
+```markdown
+# Onboarding — profil `perso-2026` — 2026-05-25
+
+## Structure top-level proposée (5 sections)
+
+1. **01-INFORMATIQUE** (33%, 412 files)
+2. **02-SCIENCES** (17%, 218 files)
+3. **03-HISTOIRE** (7%, 87 files)
+4. **04-RELIGIONS** (5%, 62 files)
+5. **05-AUTRES** (38%, 468 files non clusterisés)
+
+Rationale : sections top-level basées sur les 5 clusters dominants. Le dossier 05-AUTRES capture le résiduel — il sera affiné via l'agent Refonte après quelques runs de classify.
+
+## Sous-arbo détaillée
+
+```yaml
+01-INFORMATIQUE:
+  01-Langages-Programmation:
+    01-Java: {}
+    02-Python: {}
+    03-JavaScript: {}
+    04-C-Cpp: {}
+    Autres: {}
+  02-Frameworks: {}
+  03-Bases-Donnees: {}
+```
+
+## Theme mapping initial (32 entrées)
+
+```yaml
+"java programming": 01-INFORMATIQUE/01-Langages-Programmation/01-Java
+"python programming": 01-INFORMATIQUE/01-Langages-Programmation/02-Python
+...
+```
+
+## Simulation dry-run
+
+Si on lance `./klodo.sh process /Volumes/ExtSSD/MyBooks` avec ces YAMLs :
+- ~78% des fichiers iraient dans une catégorie spécifique (pas dans Autres)
+- ~22% iraient dans le bucket `Autres` (à raffiner)
+- 8 fichiers non identifiables (cf. Phase A)
+```
+
+### Outils Phase B (read + propose)
+
+| Outil | Signature | Effet |
+|---|---|---|
+| Tous ceux de Phase A | | (réutilisés pour itération) |
+| `propose_tree` | `(clusters, depth=2) -> TreeYaml` | Génère tree.yaml depuis les clusters |
+| `propose_theme_mapping` | `(vision_results, tree) -> ThemeMappingYaml` | Mappe chaque thème détecté vers un dossier de tree |
+| `propose_categories` | `(clusters, vision_titles) -> CategoriesYaml` | Extrait mots-clés représentatifs par cluster |
+| `simulate_classify` | `(inbox, proposed_yamls) -> ClassifySimulation` | Dry-run de classify avec les YAMLs proposés, retourne distribution + cas catch-all |
+| `inspire_from_profile` | `(other_profile_name) -> TreePattern` | (optionnel) Lit un profil existant pour s'inspirer des conventions |
+
+### Itération
+
+L'agent dialogue : "Voici 5 sections top-level. Tu veux fusionner Religion et Spiritualité ? Tu préfères grouper par langage ou par paradigme dans Programmation ?"
+
+Chaque ajustement re-génère les YAMLs proposés et la simulation. Le rationale est mis à jour pour tracer les décisions.
+
+### Garde-fous Phase B
+
+- **Aucune mutation hors `.cache/onboarding/<discovery_id>/`** — le dossier `profile/<name>/` réel n'existe pas encore
+- **Simulation requise avant Phase C** : l'agent refuse d'entrer en Phase C si la dernière `simulate_classify` montre > 50% catch-all ou < 100 fichiers classés
+- **Pas d'écriture de mappings hallucinés** : chaque entrée `theme_mapping-proposed.yaml` doit provenir d'un `theme` réellement observé en Phase A
+- **Snapshot avant Phase C** : copie des proposed YAMLs sous `.cache/onboarding/<discovery_id>/snapshot-before-bootstrap.tar` pour audit
+
+---
+
+## Phase C — Bootstrap (création du profil)
+
+### Objectif
+
+Créer **le profil pour de vrai** sur le FS Klodo : `profiles/<name>/profile.yaml`, `tree.yaml`, `theme_mapping.yaml`, `categories.yaml` à partir des YAMLs proposés validés. Optionnellement, lance un premier classify pour amorcer l'auto-apprentissage.
+
+### Exemples de tour de conversation
+
+```
+User: lance le bootstrap
+Agent: Je vais créer le profil 'perso-2026' avec :
+       - target : /Volumes/ExtSSD/MyBooks
+       - 5 sections, 32 mappings, ~50 mots-clés categories
+       - LLM : SiliconFlow (défaut)
+       Confirmer ?
+User: oui
+Agent: ✓ Profil créé. Je peux lancer un dry-run de process maintenant ?
+User: vas-y
+Agent: [Lance ./klodo.sh process /Volumes/ExtSSD/MyBooks --dry-run]
+       → 974/1247 classés (78%)
+       → 265 dans Autres (à raffiner)
+       → 8 erreurs (couverture illisible)
+       Tu veux que je relance avec --execute ?
+User: pas encore, je veux d'abord regarder les 265 Autres
+```
+
+### Tools mutables (read + write)
+
+| Outil | Signature | Effet |
+|---|---|---|
+| Tous ceux de Phase B | | (l'agent peut re-itérer si l'utilisateur ajuste) |
+| `create_profile` | `(name, target, proposed_yamls) -> ProfileResult` | Écrit `profiles/<name>/` avec les 4 YAMLs validés + `.cache/` initial |
+| `lock_for_create` | `(name) -> Lock` | `profiles-create.lock` — empêche 2 onboardings concurrents sur le même nom |
+| `run_classify_dryrun` | `(profile, inbox) -> ClassifyResult` | Wrap autour de `commands/process.py --dry-run` |
+| `run_classify_execute` | `(profile, inbox) -> ClassifyResult` | Idem mais `--execute`. Garde-fou : confirmation explicite user requise |
+
+### Journal agent
+
+Toute action Phase C est journalisée dans `profile/<name>/.cache/agent-journal.jsonl` :
+```json
+{"ts": "...", "agent": "onboarding", "phase": "C", "action": "create_profile", "name": "perso-2026", "target": "/Volumes/ExtSSD/MyBooks", "files_created": ["profile.yaml", "tree.yaml", ...]}
+```
+
+### Garde-fous Phase C
+
+- **Refus de créer un profil dont le nom existe déjà** — l'agent propose un suffix `-2` ou demande de choisir un autre nom
+- **Refus si la target n'existe pas ou n'est pas un dossier** — validation `os.path.isdir()` avant tout
+- **Refus si target == target d'un autre profil** (concurrence read/write impossible à gérer) — l'agent demande à l'utilisateur de désambiguïser
+- **Validation YAML** : `yaml.safe_load()` sur chaque proposed YAML avant écriture. Refus si parse échoue
+- **Journal append-only** : pas de mutation rétroactive du journal
+- **Atomicité** : écriture des 4 YAMLs dans un répertoire temporaire puis `os.rename()` atomique vers `profiles/<name>/`
+
+---
+
+## Plan de développement
+
+### Vue d'ensemble
+
+| Phase | Effort estimé | Dépendances | Livrable |
+|---|---|---|---|
+| **A — Discovery** | ~8-12 j-h | Agent Refonte Phase A (module `agents/` créé) | Rapport discovery + 5 outils read-only |
+| **B — Proposition** | ~10-15 j-h | Phase A + Agent Refonte Phase B (pattern propose) | Proposed YAMLs + simulation |
+| **C — Bootstrap** | ~10-15 j-h | Phase B + dashboard UI nouveau | Création profil + UI complète |
+| **Total** | **~28-42 j-h** | Refonte A+B (dépendances dures) | Agent onboarding livrable en 4-6 semaines |
+
+### Phase A — Tasks détaillées
+
+- **A.1** — Extension du module `agents/` créé par Refonte. Sous-package `agents/onboarding/` avec state typé `OnboardingState`.
+- **A.2** — Outils read-only (5) : `scan_inbox`, `sample_stratified`, `analyze_sample`, `cluster_themes`, `detect_existing_tree`. Tests unitaires sur fixtures (mocks vision pour `analyze_sample`).
+- **A.3** — Prompt agent Phase A. Format de rapport markdown standardisé.
+- **A.4** — Endpoint FastAPI `POST /api/agent/onboarding/discovery` + page dashboard `/onboarding`.
+- **A.5** — Smoke run sur un inbox de test (50 PDFs réels). Coût < $1, durée < 5 min.
+
+### Phase B — Tasks détaillées
+
+- **B.1** — Outils propose (4) : `propose_tree`, `propose_theme_mapping`, `propose_categories`, `simulate_classify`. Réutilisation maximale de `lib.classifier` en read-only.
+- **B.2** — Format `onboarding-rationale.md` + générateur depuis l'état de l'agent.
+- **B.3** — UI dashboard : visualiseur des YAMLs proposés (tree.yaml expandable, theme_mapping searchable), bouton "Simulate" qui appelle `simulate_classify`.
+- **B.4** — Itération conversationnelle : interface chat dans le dashboard, chaque message ré-invoque l'agent qui ajuste les proposed YAMLs.
+
+### Phase C — Tasks détaillées
+
+- **C.1** — Outil `create_profile` : utilise `lib.profile` existant (déjà testé par `./klodo.sh init`). Wrap autour avec validation + lock.
+- **C.2** — Journal `.cache/agent-journal.jsonl`. Format aligné avec celui de Refonte Phase C.
+- **C.3** — UI Phase C : page récap pré-création (affiche les 4 YAMLs, target, options), bouton "Créer le profil" avec confirmation modale.
+- **C.4** — Tests E2E : créer profil de test, vérifier qu'il est immédiatement utilisable par `./klodo.sh process --dry-run` sans erreur.
+
+---
+
+## Tests et validation
+
+### Tests unitaires (par tâche)
+
+- **Phase A** : ~12 tests (mocks vision, fixtures inbox synthétique avec pré-orga / sans pré-orga / mixte)
+- **Phase B** : ~15 tests (génération YAML, simulation classify, edge cases : 0 cluster, 50 clusters, themes vides)
+- **Phase C** : ~10 tests (création atomique, refus collision nom, refus target inexistante, journal append)
+
+Cible : **~37 tests** ajoutés à `tests/auto/test_agent_onboarding.py`.
+
+### Tests fonctionnels
+
+- 1 série dans `tests/functional/tests.yaml` : "Onboarding agent end-to-end" qui :
+  1. Crée un dossier test avec 20 PDFs réels
+  2. Lance discovery
+  3. Vérifie que le rapport contient au moins 2 clusters
+  4. Lance proposition
+  5. Vérifie que les YAMLs proposés sont parsables
+  6. Lance bootstrap
+  7. Vérifie que `profiles/test-onboarding/` existe et que `./klodo.sh process --profile test-onboarding --dry-run` ne crashe pas
+
+### Métriques de succès
+
+| Métrique | Cible v1 |
+|---|---|
+| Profil créé en < 15 min total (discovery + dialog + bootstrap) | ✓ |
+| ≥ 70% des fichiers classés à la 1re passe de `process` post-bootstrap | ✓ |
+| ≤ 30% dans le bucket `Autres` post-bootstrap | ✓ |
+| Coût LLM total par onboarding ≤ $3 (échantillon 50 fichiers) | ✓ |
+| 0 corruption profil sur 100 onboardings consécutifs | ✓ |
+
+---
+
+## Risques identifiés + mitigations
+
+| Risque | Probabilité | Impact | Mitigation |
+|---|---|---|---|
+| Échantillon non représentatif → taxonomie biaisée | Moyenne | Majeur | Échantillonnage stratifié + warning si l'inbox est très hétérogène (variance élevée des clusters) |
+| Coût vision explose sur grosse inbox | Faible | Moyen | Cap dur à 200 fichiers échantillonnés. Si l'utilisateur veut plus, prompt explicite avec estimation $$$ |
+| Sur-spécialisation : 50 sous-dossiers pour un cluster | Moyenne | Moyen | Limite profondeur à 2 niveaux en Phase B. L'agent Refonte enrichira après |
+| Profil créé incompatible avec format Klodo | Faible | Critique | Validation `lib.profile.validate()` (existant) avant écriture |
+| Concurrence : 2 onboardings simultanés même nom | Faible | Mineur | `profiles-create.lock` simple |
+| L'utilisateur abandonne en cours de dialog → état `.cache/onboarding/<id>/` orphelin | Élevée | Mineur | TTL 7 jours sur `.cache/onboarding/`. Nettoyage via `klodo clean onboarding-cache` |
+| Mauvaise détection de pré-orga existante (faux positif) | Moyenne | Moyen | Toujours montrer la structure détectée + bouton "ignorer la pré-orga" pour repartir à plat |
+| Inbox = SSD externe non monté au moment de bootstrap | Moyenne | Mineur | Vérification de la target au moment de `create_profile`, pas seulement Phase A |
+
+---
+
+## Frameworks alternatifs considérés
+
+Mêmes considérations que pour l'agent Refonte. **LangGraph** retenu pour :
+- Cohérence avec le 1er agent (1 framework, 1 state pattern)
+- Bonne abstraction pour les phases shippables séparément
+
+Voir [refonte-agent-spec.md](refonte-agent-spec.md#frameworks-alternatifs-considérés) pour le détail.
+
+---
+
+## Glossaire technique
+
+| Terme | Définition |
+|---|---|
+| **inbox** | Dossier source brut, avant onboarding |
+| **discovery_id** | UUID d'une session de Phase A, sert de clé pour `.cache/onboarding/<id>/` |
+| **cluster** | Groupe de thèmes détectés par vision qui partagent une proximité sémantique (ex : "java programming", "java spring" → cluster Java) |
+| **proposed YAML** | YAML généré en Phase B, jamais lu par Klodo en production. Sert uniquement à la simulation et au dialogue |
+| **bootstrap** | Acte de matérialiser les proposed YAMLs en vrai profil Klodo (Phase C) |
+| **stratifié** | Échantillonnage qui respecte la distribution des sous-dossiers (si pré-orga détectée) ou des extensions/tailles (si flat) |

--- a/docs/refonte-agent-spec.md
+++ b/docs/refonte-agent-spec.md
@@ -1,6 +1,6 @@
 # Spec — Agent IA « Refonte de taxonomie »
 
-[← Retour au README](../README.md) · [Architecture](architecture.md) · [Classification](classification.md)
+[← Retour au README](../README.md) · [Architecture](architecture.md) · [Classification](classification.md) · [Spec agent Onboarding](onboarding-agent-spec.md) · [Spec agent Curation](curation-agent-spec.md)
 
 > **Statut** : spec en cours de validation · décomposition en 3 phases shippables (A → B → C).
 > **Audience** : devs Klodo + futurs contributeurs sur la couche agent.


### PR DESCRIPTION
## Summary

Spec des 2 agents IA restants après la spec Refonte (PR #149), dans l'ordre de développement convenu : Refonte → **Onboarding** → **Curation**.

Chaque spec suit la même structure que Refonte (Pourquoi / Hors scope / Architecture / Phase A-B-C / Plan dev / Tests / Risques) et embarque son propre diagramme SVG des 3 phases.

## Agent Onboarding (~28-42 j-h)

[docs/onboarding-agent-spec.md](docs/onboarding-agent-spec.md) — Bootstrap d'un nouveau profil depuis une inbox brute.

- **Phase A (Discovery)** : échantillon stratifié + LLM vision sur ~50 fichiers → clusters de thèmes + détection de pré-organisation existante
- **Phase B (Proposition)** : propose tree.yaml + theme_mapping.yaml + categories.yaml en YAMLs séparés, avec simulation dry-run
- **Phase C (Bootstrap)** : crée le profil pour de vrai (atomique, locké, journalé)

Casse le chicken-and-egg classique : sans theme_mapping initial, le 1er classify est inutilisable. L'agent observe le corpus réel pour proposer une taxonomie de départ adaptée.

## Agent Curation (~22-35 j-h)

[docs/curation-agent-spec.md](docs/curation-agent-spec.md) — Constitution de sous-ensembles intelligents entre profils.

- **Phase A (Analyze)** : stats DuckDB + désaccords classifier + doublons MD5/title + couvertures cassées
- **Phase B (Select)** : interprète un critère NL → choisit une stratégie déterministe (stratified, top_disagreement, regression_set, etc.) → produit une sélection
- **Phase C (Apply)** : copie atomique vers target_profile + journal append-only

Étend l'onglet Curation existant. **Anti-hallucination** : le LLM choisit la stratégie, la stratégie déterministe produit la liste depuis DuckDB. Le LLM ne peut pas inventer un rel_path.

## Diagrammes

- [docs/diagrams/agent-onboarding-phases.svg](docs/diagrams/agent-onboarding-phases.svg) — 3 phases avec inputs/tools/tâches/outputs
- [docs/diagrams/agent-curation-phases.svg](docs/diagrams/agent-curation-phases.svg) — idem

Cross-refs : ajout des liens vers les 2 nouvelles specs dans le header de refonte-agent-spec.md + section Agents IA de contributing.md mise à jour avec les 3 specs.

## Test plan

- [x] Rendu via `qlmanage -t` des 2 nouveaux SVG : lisibles
- [x] Cross-refs internes vérifiés
- [ ] Pas de tests auto ni de lint (changements 100% docs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)