### PR TITLE
feat(agents): A.1 scaffolding LangGraph pour l'agent Refonte

### DIFF
--- a/agents/__init__.py
+++ b/agents/__init__.py
@@ -1,0 +1,7 @@
+"""Klodo AI agents — orchestrated via LangGraph.
+
+Subpackages :
+    refonte    — agent de refonte de taxonomie (Phase A/B/C — voir docs/refonte-agent-spec.md)
+    onboarding — agent d'onboarding d'un nouveau profil (à implémenter — voir docs/onboarding-agent-spec.md)
+    curation   — agent de curation de profil (à implémenter — voir docs/curation-agent-spec.md)
+"""

--- a/agents/refonte/__init__.py
+++ b/agents/refonte/__init__.py
@@ -1,0 +1,16 @@
+"""Agent de refonte de taxonomie — Phases A (Diagnostic) / B (Proposition) / C (Dialog).
+
+Voir docs/refonte-agent-spec.md pour la spec complète.
+
+Implémentation incrémentale :
+    A.1 — Scaffolding LangGraph (ce module)
+    A.2 — Outils read-only (tools.py, à venir)
+    A.3 — Agent diagnostic (LLM, à venir)
+    A.4 — Endpoint + UI (dashboard/, à venir)
+    A.5 — Validation sur biblio réelle
+"""
+
+from agents.refonte.diagnostic import build_diagnostic_graph
+from agents.refonte.state import RefonteState
+
+__all__ = ["RefonteState", "build_diagnostic_graph"]

--- a/agents/refonte/diagnostic.py
+++ b/agents/refonte/diagnostic.py
@@ -1,0 +1,57 @@
+"""Graphe Phase A — Diagnostic (lecture seule).
+
+À ce stade (A.1 scaffolding), le graphe est minimal :
+
+    START → init → END
+
+Le nœud `init` ne fait que valider les inputs et marquer `status="running"`.
+Les phases suivantes (A.2 → A.5) ajouteront :
+
+    A.2 → ToolNode avec les 6 outils read-only
+    A.3 → Nœud LLM `analyze` + nœud `write_report`
+    A.4 → Streaming SSE pour le frontend
+
+Le graphe minimal sert à valider :
+- Que LangGraph s'installe et compile dans l'environnement Klodo
+- Que le pattern `StateGraph[RefonteState]` est viable
+- Que les tests peuvent invoquer un graphe end-to-end sans LLM
+"""
+
+from __future__ import annotations
+
+import uuid
+from typing import Any
+
+from langgraph.graph import END, START, StateGraph
+
+from agents.refonte.state import RefonteState
+
+
+def _init_node(state: RefonteState) -> dict[str, Any]:
+    """Nœud d'initialisation — valide les inputs et amorce la run.
+
+    Génère un `run_id` si absent. Refuse de tourner sans `profile`.
+    """
+    if not state.get("profile"):
+        return {
+            "status": "error",
+            "error": "profile is required",
+        }
+    return {
+        "phase": "A",
+        "run_id": state.get("run_id") or str(uuid.uuid4()),
+        "status": "running",
+    }
+
+
+def build_diagnostic_graph():
+    """Construit le graphe Phase A.
+
+    Returns:
+        Compiled LangGraph (CompiledStateGraph) prêt à `.invoke(initial_state)`.
+    """
+    builder = StateGraph(RefonteState)
+    builder.add_node("init", _init_node)
+    builder.add_edge(START, "init")
+    builder.add_edge("init", END)
+    return builder.compile()

--- a/agents/refonte/state.py
+++ b/agents/refonte/state.py
@@ -1,0 +1,29 @@
+"""État de l'agent Refonte — partagé entre les phases A/B/C.
+
+À ce stade (A.1 scaffolding), le state est volontairement minimal. Les phases
+suivantes (A.2 outils, A.3 LLM) viendront enrichir avec `tool_results`,
+`anomalies`, `report_markdown`, etc.
+"""
+
+from typing import TypedDict
+
+
+class RefonteState(TypedDict, total=False):
+    """État partagé entre les nœuds du graphe de refonte.
+
+    `total=False` car les champs sont remplis progressivement par les nœuds
+    (le graphe commence avec uniquement `profile` et `phase`).
+
+    Attributes:
+        profile: Nom du profil Klodo cible (ex. "default", "test")
+        phase: Phase courante de l'agent — "A" (diagnostic), "B" (proposition), "C" (dialog)
+        run_id: Identifiant unique de la run (UUID), sert de clé pour .cache/refonte/<run_id>/
+        status: État de progression — "pending" | "running" | "done" | "error"
+        error: Message d'erreur si status == "error"
+    """
+
+    profile: str
+    phase: str
+    run_id: str
+    status: str
+    error: str

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,7 @@ dependencies = [
     "jinja2>=3.1.0",
     "duckdb>=1.0.0",
     "pyspellchecker>=0.9.0",
+    "langgraph>=0.2.0",
 ]
 
 [tool.ruff]

--- a/tests/auto/test_agent_refonte_scaffold.py
+++ b/tests/auto/test_agent_refonte_scaffold.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python3
+"""Tests scaffold pour l'agent Refonte — Phase A.1.
+
+À ce stade, on valide uniquement :
+  - Le module agents/refonte/ s'importe correctement
+  - Le graphe Phase A se construit et se compile
+  - Le graphe s'invoque end-to-end avec un state minimal
+  - Les inputs invalides (sans profile) produisent status=error
+
+Les outils (A.2), le LLM (A.3), et l'endpoint (A.4) sont testés
+dans leurs propres modules de tests.
+"""
+
+import os
+import sys
+import unittest
+
+PROJECT_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+sys.path.insert(0, PROJECT_ROOT)
+
+from agents.refonte import RefonteState, build_diagnostic_graph  # noqa: E402
+
+
+class TestRefonteScaffold(unittest.TestCase):
+    """Pré-requis structurels avant d'ajouter les outils et le LLM."""
+
+    def test_state_is_typed_dict(self):
+        """RefonteState doit être un TypedDict utilisable comme schéma LangGraph."""
+        # TypedDict subclasses expose __annotations__
+        self.assertIn("profile", RefonteState.__annotations__)
+        self.assertIn("phase", RefonteState.__annotations__)
+        self.assertIn("run_id", RefonteState.__annotations__)
+        self.assertIn("status", RefonteState.__annotations__)
+
+    def test_graph_compiles(self):
+        """Le graphe Phase A se construit sans erreur."""
+        graph = build_diagnostic_graph()
+        self.assertIsNotNone(graph)
+
+    def test_graph_invoke_happy_path(self):
+        """Invocation end-to-end avec profile valide → status=running, run_id généré."""
+        graph = build_diagnostic_graph()
+        result = graph.invoke({"profile": "test"})
+        self.assertEqual(result["profile"], "test")
+        self.assertEqual(result["phase"], "A")
+        self.assertEqual(result["status"], "running")
+        self.assertTrue(result["run_id"])  # UUID non vide
+        self.assertEqual(len(result["run_id"]), 36)  # format UUID4 standard
+
+    def test_graph_invoke_preserves_run_id(self):
+        """Si run_id est fourni dans l'état initial, il est préservé (resumable)."""
+        graph = build_diagnostic_graph()
+        result = graph.invoke({"profile": "test", "run_id": "fixed-id-1234"})
+        self.assertEqual(result["run_id"], "fixed-id-1234")
+
+    def test_graph_invoke_rejects_missing_profile(self):
+        """Sans profile, le graphe doit reporter status=error sans crasher."""
+        graph = build_diagnostic_graph()
+        result = graph.invoke({})
+        self.assertEqual(result["status"], "error")
+        self.assertIn("profile", result["error"].lower())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Première brique de la Phase A de l'agent Refonte (cf. [docs/refonte-agent-spec.md](docs/refonte-agent-spec.md)). À ce stade, **uniquement la structure** : pas encore d'outils (A.2), pas encore de LLM (A.3). Objectif = valider que LangGraph s'intègre proprement dans l'environnement Klodo et poser les fondations sur lesquelles A.2/A.3/A.4 vont s'appuyer.

## Changements

| Fichier | Rôle |
|---|---|
| `pyproject.toml` | Dépendance `langgraph>=0.2.0` |
| `agents/__init__.py` | Nouveau module Python — futurs sous-packages : refonte, onboarding, curation |
| `agents/refonte/__init__.py` | Re-export public (`RefonteState`, `build_diagnostic_graph`) |
| `agents/refonte/state.py` | `RefonteState` TypedDict — `profile / phase / run_id / status / error` |
| `agents/refonte/diagnostic.py` | `build_diagnostic_graph()` — graphe `START → init → END` qui valide les inputs et génère un `run_id` UUID4 si absent |
| `tests/auto/test_agent_refonte_scaffold.py` | 5 tests : import, compilation graphe, invoke happy path, run_id préservé, refus si profile manquant |

## Notes techniques

- **Pas de provider LLM choisi à ce stade** — décision archi (Anthropic Sonnet / SiliconFlow / autre) à valider explicitement en A.3
- **Pas de tools encore** — A.2 ajoutera 6 outils read-only qui wrappent les helpers existants de `dashboard/taxonomy.py`
- Une install tornado fantôme dans `.venv` causait un ImportError sur le 1er `uv sync` — nettoyée localement, pas de trace dans le commit

## Test plan

- [x] 5 nouveaux tests scaffold passent (`uv run python -m unittest tests.auto.test_agent_refonte_scaffold -v`)
- [x] Suite complète : **824 tests** passent (`uv run python -m unittest discover -s tests/auto`)
- [x] `uv run ruff check agents/ tests/auto/test_agent_refonte_scaffold.py` clean
- [ ] Pas de test manuel UI (pas encore d'endpoint — A.4)

## Suite

- **A.2** (PR suivante) — 6 outils read-only + tests unitaires sur fixtures
- **A.3** — Wire LLM + prompt diagnostic + smoke test
- **A.4** — Endpoint FastAPI + onglet Refonte dans Taxonomie
- **A.5** — Validation sur biblio réelle + doc

🤖 Generated with [Claude Code](https://claude.com/claude-code)