### PR TITLE
feat(dashboard): A.4 — endpoint + UI pour l'agent Refonte

### DIFF
--- a/dashboard/agent_refonte.py
+++ b/dashboard/agent_refonte.py
@@ -1,0 +1,197 @@
+"""Backend du dashboard pour l'agent Refonte — Phase A.
+
+Wrappe l'invocation du graphe `agents.refonte.build_diagnostic_graph` dans
+un thread pour ne pas bloquer le serveur, persiste l'état d'avancement
+dans `profile/<name>/.cache/refonte/<run_id>/`, et expose des helpers
+synchrones pour les endpoints FastAPI.
+
+État persisté par run (un sous-dossier par UUID4) :
+  - status.json : {status, started_at, completed_at, error, llm_calls, profile, max_llm_calls}
+  - report.md   : rapport markdown final (uniquement si status=="done")
+"""
+
+from __future__ import annotations
+
+import json
+import threading
+import traceback
+import uuid
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+from dashboard import data
+from dashboard import taxonomy as tax
+
+
+def _runs_dir(profile: str) -> Path:
+    """Dossier racine des runs de refonte pour un profil."""
+    base = data.get_project_root() / "profiles" / profile / ".cache" / "refonte"
+    base.mkdir(parents=True, exist_ok=True)
+    return base
+
+
+def _run_dir(profile: str, run_id: str) -> Path:
+    d = _runs_dir(profile) / run_id
+    d.mkdir(parents=True, exist_ok=True)
+    return d
+
+
+def _status_path(profile: str, run_id: str) -> Path:
+    return _run_dir(profile, run_id) / "status.json"
+
+
+def _report_path(profile: str, run_id: str) -> Path:
+    return _run_dir(profile, run_id) / "report.md"
+
+
+def _write_status(profile: str, run_id: str, payload: dict[str, Any]) -> None:
+    path = _status_path(profile, run_id)
+    path.write_text(json.dumps(payload, ensure_ascii=False, indent=2), encoding="utf-8")
+
+
+def _read_status(profile: str, run_id: str) -> dict[str, Any] | None:
+    path = _status_path(profile, run_id)
+    if not path.exists():
+        return None
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return None
+
+
+# ─── API publique (appelée par dashboard/app.py) ────────────────────────
+
+
+def start_diagnostic(profile: str, max_llm_calls: int = 5) -> dict[str, Any]:
+    """Démarre un diagnostic en arrière-plan et retourne le run_id.
+
+    Valide les inputs en synchrone (profile existe + taxonomy.yaml présent),
+    puis lance le graphe dans un thread daemon. Le caller reçoit
+    immédiatement un run_id à poller via `get_status`.
+
+    Args:
+        profile: Nom du profil (doit exister sous profiles/).
+        max_llm_calls: Budget d'appels LLM pour la boucle ReAct (default 5).
+
+    Returns:
+        {"run_id": str, "status": "pending", "profile": str}
+
+    Raises:
+        ValueError: si profile vide.
+        FileNotFoundError: si profile inexistant.
+    """
+    if not profile:
+        raise ValueError("profile is required")
+    profile_path = data.get_project_root() / "profiles" / profile
+    if not profile_path.is_dir():
+        raise FileNotFoundError(f"profile not found: {profile}")
+
+    run_id = str(uuid.uuid4())
+    now = datetime.now(UTC).isoformat()
+    initial = {
+        "run_id": run_id,
+        "profile": profile,
+        "status": "pending",
+        "started_at": now,
+        "completed_at": None,
+        "llm_calls": 0,
+        "max_llm_calls": max_llm_calls,
+        "error": None,
+    }
+    _write_status(profile, run_id, initial)
+
+    thread = threading.Thread(
+        target=_run_diagnostic,
+        args=(profile, run_id, max_llm_calls),
+        daemon=True,
+        name=f"refonte-{run_id[:8]}",
+    )
+    thread.start()
+
+    return {"run_id": run_id, "status": "pending", "profile": profile}
+
+
+def get_status(profile: str, run_id: str) -> dict[str, Any] | None:
+    """Lit le status d'un run + injecte le contenu du report si disponible.
+
+    Returns:
+        Dict avec les clés de status.json + clé `report_md` si status=="done".
+        None si le run est introuvable.
+    """
+    status = _read_status(profile, run_id)
+    if status is None:
+        return None
+    if status.get("status") == "done":
+        rpath = _report_path(profile, run_id)
+        if rpath.exists():
+            try:
+                status["report_md"] = rpath.read_text(encoding="utf-8")
+            except OSError:
+                status["report_md"] = ""
+    return status
+
+
+def list_runs(profile: str, limit: int = 20) -> list[dict[str, Any]]:
+    """Liste les runs récents pour un profil, triés par started_at desc."""
+    base = _runs_dir(profile)
+    runs: list[dict[str, Any]] = []
+    for run_dir in base.iterdir():
+        if not run_dir.is_dir():
+            continue
+        sp = run_dir / "status.json"
+        if not sp.exists():
+            continue
+        try:
+            data_ = json.loads(sp.read_text(encoding="utf-8"))
+            runs.append(data_)
+        except (OSError, json.JSONDecodeError):
+            continue
+    runs.sort(key=lambda r: r.get("started_at") or "", reverse=True)
+    return runs[:limit]
+
+
+# ─── Exécution thread ───────────────────────────────────────────────────
+
+
+def _run_diagnostic(profile: str, run_id: str, max_llm_calls: int) -> None:
+    """Lance le graphe dans le thread. Mute toutes les erreurs vers status.json."""
+    # Reset cache snapshot — sinon les outils risquent de voir un snapshot stale
+    # si le profil a été modifié entre 2 runs.
+    try:
+        tax.reset_cache(profile)
+    except Exception:  # pragma: no cover — defensive
+        pass
+
+    started_at = datetime.now(UTC).isoformat()
+    status_payload = _read_status(profile, run_id) or {}
+    status_payload.update({"status": "running", "started_at": started_at})
+    _write_status(profile, run_id, status_payload)
+
+    # Import différé : on évite de payer le coût (langchain-openai) au boot du dashboard
+    from agents.refonte import build_diagnostic_graph
+
+    try:
+        graph = build_diagnostic_graph(max_llm_calls=max_llm_calls)
+        result = graph.invoke({"profile": profile, "run_id": run_id})
+
+        completed_at = datetime.now(UTC).isoformat()
+        report = result.get("report") or ""
+        if report:
+            _report_path(profile, run_id).write_text(report, encoding="utf-8")
+
+        status_payload.update({
+            "status": result.get("status", "done"),
+            "completed_at": completed_at,
+            "llm_calls": result.get("llm_calls", 0),
+            "error": result.get("error"),
+        })
+        _write_status(profile, run_id, status_payload)
+    except Exception as exc:
+        status_payload.update({
+            "status": "error",
+            "completed_at": datetime.now(UTC).isoformat(),
+            "error": f"{type(exc).__name__}: {exc}",
+            "traceback": traceback.format_exc(),
+        })
+        _write_status(profile, run_id, status_payload)

--- a/dashboard/app.py
+++ b/dashboard/app.py
@@ -15,7 +15,7 @@ from fastapi.responses import StreamingResponse
 from fastapi.staticfiles import StaticFiles
 from fastapi.templating import Jinja2Templates
 
-from dashboard import baseline, data, taxonomy
+from dashboard import agent_refonte, baseline, data, taxonomy
 
 # Ensure functional test db module is importable
 _func_dir = str(data.get_project_root() / "tests" / "functional")
@@ -2276,3 +2276,60 @@ async def taxonomy_file_move_api(request: Request):
         return JSONResponse(result)
     except taxonomy.TaxonomyFileError as exc:
         return JSONResponse({"error": str(exc)}, status_code=exc.status)
+
+
+# ════════════════════════════════════════════════════════════════════════
+#  Agent Refonte — Phase A : Diagnostic
+# ════════════════════════════════════════════════════════════════════════
+
+
+@app.get("/agent/refonte")
+async def agent_refonte_page(request: Request, profile: str = "default"):
+    """Page dédiée à l'agent Refonte (Phase A — Diagnostic)."""
+    available = [
+        p["name"] if isinstance(p, dict) else p
+        for p in data.get_available_profiles(include_all=True)
+    ]
+    if profile not in available:
+        profile = available[0] if available else "default"
+    runs = agent_refonte.list_runs(profile, limit=20)
+    return templates.TemplateResponse(
+        request,
+        "agent_refonte.html",
+        {
+            "active": "agent_refonte",
+            "profile": profile,
+            "available_profiles": available,
+            "runs": runs,
+        },
+    )
+
+
+@app.post("/api/agent/refonte/diagnostic")
+async def api_agent_refonte_start(request: Request):
+    """Démarre un diagnostic en arrière-plan. Retourne run_id pour polling."""
+    from fastapi.responses import JSONResponse
+    body = await request.json()
+    profile = (body.get("profile") or "").strip()
+    max_llm_calls = int(body.get("max_llm_calls") or 5)
+    if max_llm_calls < 1 or max_llm_calls > 20:
+        return JSONResponse({"error": "max_llm_calls must be between 1 and 20"}, status_code=400)
+    try:
+        result = agent_refonte.start_diagnostic(profile, max_llm_calls=max_llm_calls)
+        return JSONResponse(result)
+    except ValueError as exc:
+        return JSONResponse({"error": str(exc)}, status_code=400)
+    except FileNotFoundError as exc:
+        return JSONResponse({"error": str(exc)}, status_code=404)
+
+
+@app.get("/api/agent/refonte/diagnostic/{run_id}")
+async def api_agent_refonte_status(run_id: str, profile: str):
+    """Lit le status d'un run (polling depuis le frontend)."""
+    from fastapi.responses import JSONResponse
+    if not profile:
+        return JSONResponse({"error": "profile query param is required"}, status_code=400)
+    status = agent_refonte.get_status(profile, run_id)
+    if status is None:
+        return JSONResponse({"error": f"run not found: {run_id}"}, status_code=404)
+    return JSONResponse(status)

--- a/dashboard/templates/agent_refonte.html
+++ b/dashboard/templates/agent_refonte.html
@@ -1,0 +1,172 @@
+{% extends "base.html" %}
+{% set active = "agent_refonte" %}
+{% block title %}Agent Refonte — Diagnostic{% endblock %}
+
+{% block content %}
+<h1 class="page-title">🤖 Agent Refonte — Diagnostic</h1>
+<p class="page-subtitle">
+    Lance un diagnostic LLM read-only sur la taxonomie d'un profil.
+    L'agent appelle les 6 outils de lecture (tree, mapping, count, overlap, breakdown)
+    et produit un rapport markdown listant les anomalies (catch-all qui débordent,
+    dossiers sous-utilisés, doublons sémantiques, mappings orphelins).
+</p>
+
+{# ════════════════════════════════════════════════════════════════ #}
+{# Toolbar : profil + bouton run                                     #}
+{# ════════════════════════════════════════════════════════════════ #}
+<div class="baseline-toolbar">
+    <div class="baseline-toolbar-group">
+        <label class="filter-label">Profil :</label>
+        <select id="profile-select" class="filter-select"
+                onchange="window.location.href='/agent/refonte?profile=' + this.value">
+            {% for p in available_profiles %}
+            <option value="{{ p }}" {% if p == profile %}selected{% endif %}>{{ p }}</option>
+            {% endfor %}
+        </select>
+    </div>
+    <div class="baseline-toolbar-group">
+        <label class="filter-label">Budget LLM :</label>
+        <input type="number" id="max-llm-calls" value="5" min="1" max="20"
+               style="width: 60px; padding: 4px 8px;">
+    </div>
+    <div class="baseline-toolbar-group">
+        <button id="start-diagnostic-btn" class="btn btn-primary">
+            🚀 Lancer le diagnostic
+        </button>
+    </div>
+</div>
+
+{# ════════════════════════════════════════════════════════════════ #}
+{# Layout 2 colonnes : runs récents (gauche) + rapport courant       #}
+{# ════════════════════════════════════════════════════════════════ #}
+<div style="display: grid; grid-template-columns: 320px 1fr; gap: 16px; margin-top: 16px;">
+
+    <!-- COL 1 : Historique des runs -->
+    <div>
+        <h3 style="margin-top: 0;">Runs récents</h3>
+        <div id="runs-list">
+            {% if runs %}
+                {% for r in runs %}
+                <div class="run-item" data-run-id="{{ r.run_id }}"
+                     style="padding: 8px; border: 1px solid var(--border); border-radius: 6px;
+                            margin-bottom: 8px; cursor: pointer;">
+                    <div style="display: flex; justify-content: space-between; align-items: center;">
+                        <code style="font-size: 11px;">{{ r.run_id[:8] }}…</code>
+                        <span class="status-badge status-{{ r.status }}">{{ r.status }}</span>
+                    </div>
+                    <div style="font-size: 11px; color: var(--text-muted); margin-top: 4px;">
+                        {{ r.started_at }}
+                    </div>
+                    {% if r.llm_calls %}
+                    <div style="font-size: 11px; color: var(--text-muted);">
+                        {{ r.llm_calls }} appel(s) LLM
+                    </div>
+                    {% endif %}
+                </div>
+                {% endfor %}
+            {% else %}
+            <p style="color: var(--text-muted); font-size: 13px;">
+                Aucun run pour ce profil. Lance ton premier diagnostic ↑
+            </p>
+            {% endif %}
+        </div>
+    </div>
+
+    <!-- COL 2 : Rapport courant -->
+    <div>
+        <h3 style="margin-top: 0;">Rapport</h3>
+        <div id="report-container" style="padding: 16px; border: 1px solid var(--border);
+                                          border-radius: 8px; min-height: 400px;
+                                          background: var(--bg-secondary);">
+            <div id="report-status" style="margin-bottom: 12px; color: var(--text-muted);">
+                Sélectionne un run à gauche ou lance un nouveau diagnostic.
+            </div>
+            <pre id="report-content" style="white-space: pre-wrap; font-family: inherit;
+                                            font-size: 13px; margin: 0;"></pre>
+        </div>
+    </div>
+</div>
+
+<script>
+(function() {
+    const profile = {{ profile|tojson }};
+    const startBtn = document.getElementById('start-diagnostic-btn');
+    const maxLlmCalls = document.getElementById('max-llm-calls');
+    const statusEl = document.getElementById('report-status');
+    const contentEl = document.getElementById('report-content');
+    let pollTimer = null;
+
+    function setStatus(text, cls) {
+        statusEl.textContent = text;
+        statusEl.className = cls || '';
+    }
+
+    async function pollStatus(runId) {
+        try {
+            const r = await fetch('/api/agent/refonte/diagnostic/' + runId
+                                  + '?profile=' + encodeURIComponent(profile));
+            if (!r.ok) throw new Error('HTTP ' + r.status);
+            const s = await r.json();
+            const calls = s.llm_calls || 0;
+            const max = s.max_llm_calls || 5;
+            setStatus(
+                'Run ' + runId.slice(0, 8) + '… · ' + s.status
+                + ' · ' + calls + '/' + max + ' appel(s) LLM'
+            );
+            if (s.status === 'done') {
+                contentEl.textContent = s.report_md || '(rapport vide)';
+                clearInterval(pollTimer);
+                pollTimer = null;
+                startBtn.disabled = false;
+                // Refresh la liste des runs après un petit délai
+                setTimeout(() => window.location.reload(), 800);
+            } else if (s.status === 'error') {
+                contentEl.textContent = 'ERREUR : ' + (s.error || '(inconnu)');
+                clearInterval(pollTimer);
+                pollTimer = null;
+                startBtn.disabled = false;
+            }
+        } catch (err) {
+            console.error('poll error', err);
+        }
+    }
+
+    async function startDiagnostic() {
+        startBtn.disabled = true;
+        setStatus('Démarrage…');
+        contentEl.textContent = '';
+        try {
+            const r = await fetch('/api/agent/refonte/diagnostic', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({
+                    profile: profile,
+                    max_llm_calls: parseInt(maxLlmCalls.value || '5', 10),
+                }),
+            });
+            if (!r.ok) {
+                const e = await r.json();
+                throw new Error(e.error || ('HTTP ' + r.status));
+            }
+            const data = await r.json();
+            setStatus('Run ' + data.run_id.slice(0, 8) + '… démarré');
+            pollTimer = setInterval(() => pollStatus(data.run_id), 2000);
+        } catch (err) {
+            setStatus('Erreur : ' + err.message);
+            startBtn.disabled = false;
+        }
+    }
+
+    startBtn.addEventListener('click', startDiagnostic);
+
+    // Click sur un run dans la liste → affiche son rapport
+    document.querySelectorAll('.run-item').forEach(item => {
+        item.addEventListener('click', () => {
+            const runId = item.dataset.runId;
+            setStatus('Chargement du run ' + runId.slice(0, 8) + '…');
+            pollStatus(runId);
+        });
+    });
+})();
+</script>
+{% endblock %}

--- a/dashboard/templates/base.html
+++ b/dashboard/templates/base.html
@@ -22,6 +22,7 @@
             <li><a href="/viewer" class="{% if active == 'viewer' %}active{% endif %}">Curation</a></li>
             <li><a href="/baseline" class="{% if active == 'baseline' %}active{% endif %}">Baseline</a></li>
             <li><a href="/taxonomy" class="{% if active == 'taxonomy' %}active{% endif %}">Taxonomie</a></li>
+            <li><a href="/agent/refonte" class="{% if active == 'agent_refonte' %}active{% endif %}">&#129302; Agent Refonte</a></li>
             <li><a href="/suggestions" class="{% if active == 'suggestions' %}active{% endif %}">Suggestions</a></li>
             <li style="margin-top:16px;border-top:1px solid var(--border);padding-top:8px;">
                 <a href="/admin" class="{% if active == 'admin' %}active{% endif %}">&#9881; Admin</a>

--- a/tests/auto/test_agent_refonte_endpoint.py
+++ b/tests/auto/test_agent_refonte_endpoint.py
@@ -1,0 +1,201 @@
+#!/usr/bin/env python3
+"""Tests des endpoints FastAPI de l'agent Refonte — Phase A.4.
+
+Vérifie :
+  - GET /agent/refonte : page rendue OK
+  - POST /api/agent/refonte/diagnostic : validation des inputs + kick async
+  - GET /api/agent/refonte/diagnostic/<run_id> : polling + injection report
+
+Le graphe LangGraph est mocké au niveau de `agents.refonte.build_diagnostic_graph`
+pour ne pas dépendre de SiliconFlow.
+"""
+
+import json
+import os
+import shutil
+import sys
+import tempfile
+import time
+import unittest
+from pathlib import Path
+from unittest import mock
+
+import yaml
+
+PROJECT_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+sys.path.insert(0, PROJECT_ROOT)
+
+from fastapi.testclient import TestClient  # noqa: E402
+
+from dashboard import agent_refonte, data  # noqa: E402
+
+
+class _FakeCompiledGraph:
+    """Faux graphe compilé qui retourne un state final scripté."""
+
+    def __init__(self, response: dict):
+        self.response = response
+        self.invoked_with: dict | None = None
+
+    def invoke(self, state):
+        self.invoked_with = dict(state)
+        # Simule un peu de latence pour que le thread soit observable
+        time.sleep(0.05)
+        return {**state, **self.response}
+
+
+def _make_profile_root(tmp: Path, profile: str) -> None:
+    """Crée un profil minimal sous tmp/profiles/<name>/."""
+    p = tmp / "profiles" / profile
+    p.mkdir(parents=True, exist_ok=True)
+    (p / "profile.yaml").write_text(yaml.safe_dump({"name": profile}))
+    (p / "tree.yaml").write_text(yaml.safe_dump({"folders": ["A", "B"]}))
+    (p / "theme_mapping.yaml").write_text(yaml.safe_dump({"t1": "A"}))
+
+
+class _AgentEndpointBase(unittest.TestCase):
+    """Setup commun : redirige le project root vers un temp dir."""
+
+    @classmethod
+    def setUpClass(cls):
+        from dashboard.app import app
+        cls.client = TestClient(app)
+
+    def setUp(self):
+        self.tmp = Path(tempfile.mkdtemp(prefix="klodo_refonte_endpoint_"))
+        _make_profile_root(self.tmp, "test_p")
+        # Patch les 2 entrées qui résolvent le project root :
+        # - data.get_project_root (utilisé par agent_refonte module)
+        # - data.get_available_profiles (utilisé par la page handler)
+        self._patcher = mock.patch.object(
+            data, "get_project_root", return_value=self.tmp,
+        )
+        self._patcher.start()
+        self._profiles_patcher = mock.patch.object(
+            data, "get_available_profiles", return_value=["test_p"],
+        )
+        self._profiles_patcher.start()
+
+    def tearDown(self):
+        self._patcher.stop()
+        self._profiles_patcher.stop()
+        shutil.rmtree(self.tmp, ignore_errors=True)
+
+
+class TestAgentRefontePage(_AgentEndpointBase):
+    def test_page_renders(self):
+        r = self.client.get("/agent/refonte?profile=test_p")
+        self.assertEqual(r.status_code, 200)
+        self.assertIn("Agent Refonte", r.text)
+        self.assertIn("test_p", r.text)
+
+
+class TestStartDiagnostic(_AgentEndpointBase):
+    def test_rejects_missing_profile(self):
+        r = self.client.post("/api/agent/refonte/diagnostic", json={})
+        self.assertEqual(r.status_code, 400)
+        self.assertIn("profile", r.json()["error"].lower())
+
+    def test_rejects_unknown_profile(self):
+        r = self.client.post("/api/agent/refonte/diagnostic",
+                             json={"profile": "ghost"})
+        self.assertEqual(r.status_code, 404)
+        self.assertIn("profile not found", r.json()["error"])
+
+    def test_rejects_out_of_range_budget(self):
+        r = self.client.post("/api/agent/refonte/diagnostic",
+                             json={"profile": "test_p", "max_llm_calls": 99})
+        self.assertEqual(r.status_code, 400)
+
+    def test_happy_path_returns_run_id(self):
+        fake = _FakeCompiledGraph({"status": "done", "report": "# OK", "llm_calls": 1})
+        with mock.patch(
+            "agents.refonte.build_diagnostic_graph",
+            return_value=fake,
+        ):
+            r = self.client.post("/api/agent/refonte/diagnostic",
+                                 json={"profile": "test_p"})
+            self.assertEqual(r.status_code, 200)
+            body = r.json()
+            self.assertEqual(body["status"], "pending")
+            self.assertEqual(body["profile"], "test_p")
+            self.assertTrue(body["run_id"])
+            # Attendre que le thread daemon ait fini
+            time.sleep(0.3)
+            status = agent_refonte.get_status("test_p", body["run_id"])
+            self.assertEqual(status["status"], "done")
+            self.assertEqual(status["report_md"], "# OK")
+
+
+class TestGetStatus(_AgentEndpointBase):
+    def test_404_when_run_unknown(self):
+        r = self.client.get("/api/agent/refonte/diagnostic/nope?profile=test_p")
+        self.assertEqual(r.status_code, 404)
+
+    def test_returns_status_and_report(self):
+        # On crée directement un status "done" sur disque pour isoler le test
+        # du graphe.
+        run_id = "fixed-run-1234"
+        run_dir = (self.tmp / "profiles" / "test_p" / ".cache" / "refonte" / run_id)
+        run_dir.mkdir(parents=True)
+        (run_dir / "status.json").write_text(json.dumps({
+            "run_id": run_id, "profile": "test_p", "status": "done",
+            "started_at": "2026-05-24T10:00:00Z",
+            "completed_at": "2026-05-24T10:00:42Z",
+            "llm_calls": 4, "max_llm_calls": 5, "error": None,
+        }))
+        (run_dir / "report.md").write_text("# Diagnostic\n\nTout va bien.")
+
+        r = self.client.get(
+            f"/api/agent/refonte/diagnostic/{run_id}?profile=test_p"
+        )
+        self.assertEqual(r.status_code, 200)
+        body = r.json()
+        self.assertEqual(body["status"], "done")
+        self.assertEqual(body["llm_calls"], 4)
+        self.assertIn("Tout va bien", body["report_md"])
+
+
+class TestStartDiagnosticErrorPath(_AgentEndpointBase):
+    def test_graph_exception_persisted_as_error(self):
+        """Si le graphe lève, status.json doit refléter status=error + traceback."""
+        def boom(*_args, **_kw):
+            raise RuntimeError("LLM provider unavailable")
+
+        with mock.patch("agents.refonte.build_diagnostic_graph", side_effect=boom):
+            r = self.client.post("/api/agent/refonte/diagnostic",
+                                 json={"profile": "test_p"})
+            self.assertEqual(r.status_code, 200)
+            run_id = r.json()["run_id"]
+            # Wait for the daemon thread to write the error
+            for _ in range(20):
+                status = agent_refonte.get_status("test_p", run_id)
+                if status and status.get("status") == "error":
+                    break
+                time.sleep(0.05)
+            self.assertEqual(status["status"], "error")
+            self.assertIn("LLM provider unavailable", status["error"])
+            self.assertIn("traceback", status)
+
+
+class TestListRuns(_AgentEndpointBase):
+    def test_list_sorted_by_started_at_desc(self):
+        """list_runs trie par started_at descendant (plus récent en premier)."""
+        runs_dir = self.tmp / "profiles" / "test_p" / ".cache" / "refonte"
+        runs_dir.mkdir(parents=True)
+        for i, ts in enumerate(["2026-01-01T00:00:00Z", "2026-05-24T10:00:00Z",
+                                "2026-03-15T12:00:00Z"]):
+            d = runs_dir / f"r{i}"
+            d.mkdir()
+            (d / "status.json").write_text(json.dumps({
+                "run_id": f"r{i}", "profile": "test_p",
+                "status": "done", "started_at": ts,
+            }))
+        runs = agent_refonte.list_runs("test_p")
+        self.assertEqual(len(runs), 3)
+        self.assertEqual(runs[0]["started_at"], "2026-05-24T10:00:00Z")
+        self.assertEqual(runs[2]["started_at"], "2026-01-01T00:00:00Z")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Quatrième brique de la **Phase A** de l'agent Refonte. Expose le graphe diagnostic livré en A.3 (PR #154) via le dashboard FastAPI : nouvel onglet "🤖 Agent Refonte" qui permet de lancer un diagnostic sur n'importe quel profil et de visualiser le rapport markdown.

⚠️ **PR ciblée sur la branche d'intégration \`feature/agent-refonte-phase-a\`** — conformément à la convention de branching par phase. Mergera vers develop dans un PR final post-A.5.

## Architecture backend

\`\`\`
POST /api/agent/refonte/diagnostic
  ├─ valide profile en synchrone
  ├─ écrit status.json (pending)
  ├─ démarre threading.Thread daemon
  └─ retourne run_id immédiatement (non-bloquant)

Thread daemon :
  ├─ build_diagnostic_graph(max_llm_calls=N)
  ├─ graph.invoke({profile, run_id})
  ├─ écrit report.md si status=="done"
  └─ persiste tout dans .cache/refonte/<run_id>/
\`\`\`

État persisté par run dans \`profile/<name>/.cache/refonte/<run_id>/\` :
- \`status.json\` — statut, llm_calls, timestamps, error
- \`report.md\` — markdown final si done

## Changements

| Fichier | Rôle |
|---|---|
| \`dashboard/agent_refonte.py\` (NEW) | \`start_diagnostic\`, \`get_status\`, \`list_runs\` + thread daemon + persistence |
| \`dashboard/app.py\` | + 3 endpoints (page + 2 API) |
| \`dashboard/templates/agent_refonte.html\` (NEW) | Layout 2 cols : runs récents / rapport, JS polling 2s |
| \`dashboard/templates/base.html\` | + lien nav "🤖 Agent Refonte" |
| \`tests/auto/test_agent_refonte_endpoint.py\` (NEW) | 9 tests TestClient + mock graphe |

## Test plan

- [x] 9 nouveaux tests endpoint → 9/9 OK
- [x] Suite complète : **852 tests** (pas de régression)
- [x] \`uv run ruff check\` → clean
- [x] **Smoke test manuel** :
  - \`uv run python -m dashboard 8081\`
  - GET /agent/refonte → 200, page rendue avec le sélecteur de profil + 3 occurrences "Agent Refonte"
  - GET / → nav contient bien le lien "Agent Refonte"
  - POST sans profile → 400 \`{"error":"profile is required"}\`
  - POST profile inconnu → 404 \`{"error":"profile not found: ghost"}\`
  - POST budget=99 → 400 \`{"error":"max_llm_calls must be between 1 and 20"}\`
  - GET run inconnu → 404 \`{"error":"run not found: nope"}\`
- [ ] **Smoke test avec vrai LLM** → laissé à A.5 (avec biblio réelle, coût estimé <\$1)

## Suite

- **A.5** — Smoke run end-to-end sur profil \`default\` (18k fichiers) avec vrai SiliconFlow + rédaction d'un mini-guide d'usage dans la doc
- Puis : un seul gros PR \`feature/agent-refonte-phase-a → develop\` qui passera la CI complète

🤖 Generated with [Claude Code](https://claude.com/claude-code)