### PR TITLE
feat(agents): B.3 — UI Phase B (bouton + diff tree + impact reclassify)

### DIFF
--- a/dashboard/agent_refonte.py
+++ b/dashboard/agent_refonte.py
@@ -113,23 +113,167 @@ def start_diagnostic(profile: str, max_llm_calls: int = 5) -> dict[str, Any]:
 
 
 def get_status(profile: str, run_id: str) -> dict[str, Any] | None:
-    """Lit le status d'un run + injecte le contenu du report si disponible.
+    """Lit le status d'un run + injecte le contenu pertinent si disponible.
+
+    Pour les runs **Phase A** (diagnostic) `done` : injecte `report_md`.
+    Pour les runs **Phase B** (proposition) `done` : injecte `rationale_md`
+    (le markdown de `refonte-rationale.md`). Les artefacts plus volumineux
+    (tree-diff, simulation CSV) sont exposés par des endpoints dédiés pour
+    éviter de gonfler le payload de polling.
 
     Returns:
-        Dict avec les clés de status.json + clé `report_md` si status=="done".
-        None si le run est introuvable.
+        Dict avec les clés de status.json + clés `report_md` ou `rationale_md`
+        selon le contexte. None si le run est introuvable.
     """
     status = _read_status(profile, run_id)
     if status is None:
         return None
     if status.get("status") == "done":
-        rpath = _report_path(profile, run_id)
-        if rpath.exists():
-            try:
-                status["report_md"] = rpath.read_text(encoding="utf-8")
-            except OSError:
-                status["report_md"] = ""
+        phase = status.get("phase", "A")
+        if phase == "B":
+            rationale_path = _proposal_rationale_path(profile, run_id)
+            if rationale_path and rationale_path.exists():
+                try:
+                    status["rationale_md"] = rationale_path.read_text(encoding="utf-8")
+                except OSError:
+                    status["rationale_md"] = ""
+        else:
+            rpath = _report_path(profile, run_id)
+            if rpath.exists():
+                try:
+                    status["report_md"] = rpath.read_text(encoding="utf-8")
+                except OSError:
+                    status["report_md"] = ""
     return status
+
+
+def _proposal_rationale_path(profile: str, run_id: str) -> Path | None:
+    """Chemin attendu du refonte-rationale.md pour un run Phase B."""
+    p = _run_dir(profile, run_id) / "proposed" / "refonte-rationale.md"
+    return p
+
+
+def get_proposition_tree_diff(profile: str, run_id: str) -> dict[str, Any]:
+    """Compare tree.yaml courant et tree-proposed.yaml du run B.
+
+    Returns:
+        {
+            "added": list[str],     # dossiers présents en proposed mais pas en current
+            "removed": list[str],   # absents en proposed mais en current
+            "renamed": list[{old, new, rationale}],  # depuis changes.json
+            "fused": list[{sources, target, rationale}],  # depuis changes.json
+            "n_folders_before": int,
+            "n_folders_after": int,
+        }
+    """
+    import yaml as _yaml
+    proposed_dir = _run_dir(profile, run_id) / "proposed"
+    tree_proposed = proposed_dir / "tree-proposed.yaml"
+    changes_json = proposed_dir / "changes.json"
+
+    # Charge tree courant via la fonction taxonomy
+    current_folders = set(tax._load_tree(profile))
+    proposed_folders: set[str] = set()
+    if tree_proposed.exists():
+        try:
+            raw = _yaml.safe_load(tree_proposed.read_text(encoding="utf-8")) or {}
+            proposed_folders = set(raw.get("folders") or [])
+        except _yaml.YAMLError:
+            proposed_folders = set()
+
+    renamed: list[dict[str, Any]] = []
+    fused: list[dict[str, Any]] = []
+    if changes_json.exists():
+        try:
+            ch = json.loads(changes_json.read_text(encoding="utf-8"))
+            renamed = [
+                {"old": r.get("old_path"), "new": r.get("new_path"),
+                 "rationale": r.get("rationale", "")}
+                for r in (ch.get("renamings") or [])
+            ]
+            fused = [
+                {"sources": f.get("sources", []), "target": f.get("target"),
+                 "rationale": f.get("rationale", "")}
+                for f in (ch.get("fusions") or [])
+            ]
+        except (OSError, json.JSONDecodeError):
+            pass
+
+    # On retire des "added/removed" les paires couvertes par renames/fusions
+    # (sinon on les double-compte côté UI).
+    rename_old = {r["old"] for r in renamed if r.get("old")}
+    rename_new = {r["new"] for r in renamed if r.get("new")}
+    fusion_sources = {s for f in fused for s in (f.get("sources") or [])}
+    fusion_targets = {f["target"] for f in fused if f.get("target")}
+
+    added = sorted(
+        f for f in (proposed_folders - current_folders)
+        if f not in rename_new and f not in fusion_targets
+    )
+    removed = sorted(
+        f for f in (current_folders - proposed_folders)
+        if f not in rename_old and f not in fusion_sources
+    )
+
+    return {
+        "added": added,
+        "removed": removed,
+        "renamed": renamed,
+        "fused": fused,
+        "n_folders_before": len(current_folders),
+        "n_folders_after": len(proposed_folders),
+    }
+
+
+def get_proposition_simulation(
+    profile: str,
+    run_id: str,
+    sample_limit: int = 50,
+) -> dict[str, Any] | None:
+    """Lit le simulation-summary.json + N lignes de la projection CSV.
+
+    Args:
+        profile: Nom du profil.
+        run_id: UUID du run Phase B.
+        sample_limit: Nombre max de lignes du CSV à inclure (par défaut 50).
+                      Le CSV complet peut faire 18k+ lignes — gardé côté serveur.
+
+    Returns:
+        {
+            "summary": dict (contenu de simulation-summary.json),
+            "sample_moves": list[dict] (jusqu'à `sample_limit` lignes où changed=True),
+            "n_moves_total": int,
+        }
+        None si la simulation n'a pas tourné (run Phase A par ex.).
+    """
+    import csv as _csv
+    sim_dir = _run_dir(profile, run_id) / "simulation"
+    summary_path = sim_dir / "simulation-summary.json"
+    csv_path = sim_dir / "reclassify-projection.csv"
+    if not summary_path.exists():
+        return None
+    try:
+        summary = json.loads(summary_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return None
+    moves: list[dict[str, Any]] = []
+    n_moves_total = 0
+    if csv_path.exists():
+        try:
+            with csv_path.open(encoding="utf-8", newline="") as f:
+                reader = _csv.DictReader(f)
+                for row in reader:
+                    if row.get("changed", "").lower() == "true":
+                        n_moves_total += 1
+                        if len(moves) < sample_limit:
+                            moves.append(row)
+        except (OSError, _csv.Error):
+            pass
+    return {
+        "summary": summary,
+        "sample_moves": moves,
+        "n_moves_total": n_moves_total,
+    }
 
 
 def list_runs(profile: str, limit: int = 20) -> list[dict[str, Any]]:

--- a/dashboard/app.py
+++ b/dashboard/app.py
@@ -2350,6 +2350,32 @@ async def api_agent_refonte_runs(profile: str, limit: int = 20):
 # ──────────── Phase B : Proposition ────────────
 
 
+@app.get("/api/agent/refonte/proposition/{run_id}/tree-diff")
+async def api_agent_refonte_tree_diff(run_id: str, profile: str):
+    """Diff visuel du tree.yaml courant vs tree-proposed.yaml du run B."""
+    from fastapi.responses import JSONResponse
+    if not profile:
+        return JSONResponse({"error": "profile query param is required"}, status_code=400)
+    diff = agent_refonte.get_proposition_tree_diff(profile, run_id)
+    return JSONResponse(diff)
+
+
+@app.get("/api/agent/refonte/proposition/{run_id}/simulation")
+async def api_agent_refonte_simulation(run_id: str, profile: str, sample_limit: int = 50):
+    """Lit le simulation-summary.json + N premières lignes de la projection CSV."""
+    from fastapi.responses import JSONResponse
+    if not profile:
+        return JSONResponse({"error": "profile query param is required"}, status_code=400)
+    sample_limit = max(1, min(int(sample_limit), 500))
+    result = agent_refonte.get_proposition_simulation(profile, run_id, sample_limit=sample_limit)
+    if result is None:
+        return JSONResponse(
+            {"error": f"simulation not found for run {run_id} (probably Phase A run, or simulation failed)"},
+            status_code=404,
+        )
+    return JSONResponse(result)
+
+
 @app.post("/api/agent/refonte/proposition")
 async def api_agent_refonte_proposition_start(request: Request):
     """Démarre un run Phase B basé sur un diagnostic Phase A existant.

--- a/dashboard/templates/partials/agent_refonte_panel.html
+++ b/dashboard/templates/partials/agent_refonte_panel.html
@@ -15,6 +15,11 @@
                 <span class="tax-refonte-start-icon">🚀</span>
                 <span>Lancer le diagnostic</span>
             </button>
+            <button id="tax-refonte-propose" class="tax-refonte-propose-btn" disabled
+                    title="Sélectionne un diagnostic 'done' à gauche pour activer">
+                <span class="tax-refonte-start-icon">🔧</span>
+                <span>Proposer une refonte</span>
+            </button>
             <div class="tax-refonte-budget-field">
                 <label for="tax-refonte-budget" class="filter-label">Budget LLM</label>
                 <input type="number" id="tax-refonte-budget" value="5" min="1" max="20">
@@ -109,7 +114,110 @@
     opacity: 0.55;
     cursor: wait;
 }
+.tax-refonte-propose-btn {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    padding: 8px 18px;
+    background: linear-gradient(180deg, #8b5cf6 0%, #7c3aed 100%);
+    color: #fff;
+    border: none;
+    border-radius: 6px;
+    font-size: 14px;
+    font-weight: 600;
+    cursor: pointer;
+    transition: transform 0.05s ease, box-shadow 0.15s ease;
+    box-shadow: 0 1px 2px rgba(0, 0, 0, 0.2);
+}
+.tax-refonte-propose-btn:hover:not(:disabled) {
+    transform: translateY(-1px);
+    box-shadow: 0 2px 6px rgba(124, 58, 237, 0.35);
+}
+.tax-refonte-propose-btn:disabled {
+    opacity: 0.45;
+    cursor: not-allowed;
+    background: linear-gradient(180deg, #555 0%, #444 100%);
+}
 .tax-refonte-start-icon { font-size: 16px; }
+/* ─── Phase B : onglets internes Rationale / Diff / Impact ──────────── */
+.tax-refonte-phaseb-tabs {
+    display: flex;
+    gap: 4px;
+    margin-bottom: 12px;
+    border-bottom: 1px solid var(--border);
+}
+.tax-refonte-phaseb-tab {
+    padding: 6px 14px;
+    background: transparent;
+    border: none;
+    border-bottom: 2px solid transparent;
+    color: var(--text-muted);
+    cursor: pointer;
+    font-size: 13px;
+    font-weight: 500;
+}
+.tax-refonte-phaseb-tab.active {
+    color: var(--text-primary, inherit);
+    border-bottom-color: #8b5cf6;
+}
+.tax-refonte-phaseb-pane { display: none; }
+.tax-refonte-phaseb-pane.active { display: block; }
+/* Diff tree */
+.tax-refonte-diff-section {
+    margin-bottom: 16px;
+}
+.tax-refonte-diff-section h4 { margin: 0 0 6px; font-size: 13px; }
+.tax-refonte-diff-item {
+    padding: 4px 10px;
+    margin: 3px 0;
+    border-left: 3px solid;
+    font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+    font-size: 12px;
+    border-radius: 3px;
+}
+.tax-refonte-diff-add    { border-left-color: #22c55e; background: rgba(34,197,94,.08); }
+.tax-refonte-diff-remove { border-left-color: #ef4444; background: rgba(239,68,68,.08); }
+.tax-refonte-diff-rename { border-left-color: #f59e0b; background: rgba(245,158,11,.08); }
+.tax-refonte-diff-fusion { border-left-color: #8b5cf6; background: rgba(139,92,246,.08); }
+/* Simulation impact */
+.tax-refonte-stat-cards {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+    gap: 10px;
+    margin: 8px 0 14px;
+}
+.tax-refonte-stat-card {
+    padding: 10px 12px;
+    background: var(--bg-tertiary, #1a1a1a);
+    border: 1px solid var(--border);
+    border-radius: 6px;
+    text-align: center;
+}
+.tax-refonte-stat-card .num {
+    font-size: 1.6em;
+    font-weight: 600;
+    color: var(--text-primary, inherit);
+}
+.tax-refonte-stat-card .label {
+    font-size: 11px;
+    color: var(--text-muted);
+    margin-top: 2px;
+}
+.tax-refonte-impact-table {
+    width: 100%;
+    border-collapse: collapse;
+    font-size: 12px;
+}
+.tax-refonte-impact-table th,
+.tax-refonte-impact-table td {
+    padding: 4px 8px;
+    border-bottom: 1px solid var(--border);
+    text-align: left;
+}
+.tax-refonte-impact-table th {
+    color: var(--text-muted);
+    font-weight: 500;
+}
 .tax-refonte-budget-field {
     display: flex;
     align-items: center;
@@ -242,6 +350,7 @@
 (function() {
     // ─── Module local API exposée pour intégration Taxonomie ─────────────
     const startBtn = document.getElementById('tax-refonte-start');
+    const proposeBtn = document.getElementById('tax-refonte-propose');
     const budgetInput = document.getElementById('tax-refonte-budget');
     const runsEl = document.getElementById('tax-refonte-runs');
     const statusEl = document.getElementById('tax-refonte-status');
@@ -252,6 +361,11 @@
     let lastProfile = null;
     let currentReportMd = '';     // Pour Copy + Download
     let currentRunId = null;
+    let currentRunPhase = null;   // 'A' ou 'B'
+    // Map run_id → phase + status pour pouvoir activer/désactiver le bouton
+    // "Proposer une refonte" et utiliser le bon ID comme diagnostic_run_id
+    // quand on lance une Phase B.
+    let runsIndex = {};
 
     // ─── Markdown rendering + post-processing UI ─────────────────────────
     function priorityFor(h3text) {
@@ -262,6 +376,251 @@
         if (/doublon|jaccard|s[ée]mantique/.test(t)) return 'low';
         return 'info';
     }
+
+    // ─── Rendu Phase B (multi-onglets Rationale / Diff / Impact) ─────────
+
+    function renderPhaseBReport(runId, status) {
+        const rationaleMd = status.rationale_md || '';
+        const profile = currentProfile();
+        // Vue 3 onglets dans la zone Rapport, lazy-load des contenus Diff +
+        // Impact au clic (les requêtes peuvent être lourdes sur 18k fichiers).
+        reportEl.innerHTML =
+            '<div class="tax-refonte-phaseb-tabs" role="tablist">'
+          + '  <button class="tax-refonte-phaseb-tab active" data-pane="rationale">📋 Rationale</button>'
+          + '  <button class="tax-refonte-phaseb-tab" data-pane="diff">🌳 Diff tree</button>'
+          + '  <button class="tax-refonte-phaseb-tab" data-pane="impact">📊 Impact reclassify</button>'
+          + '</div>'
+          + '<div class="tax-refonte-phaseb-pane active" data-pane="rationale">'
+          + '  <div class="tax-refonte-md" id="tax-refonte-rationale-md"></div>'
+          + '</div>'
+          + '<div class="tax-refonte-phaseb-pane" data-pane="diff">'
+          + '  <p class="muted small">Chargement du diff…</p>'
+          + '</div>'
+          + '<div class="tax-refonte-phaseb-pane" data-pane="impact">'
+          + '  <p class="muted small">Chargement de la projection…</p>'
+          + '</div>';
+        // Rationale rendu inline
+        const rationaleEl = document.getElementById('tax-refonte-rationale-md');
+        if (window.marked && rationaleMd) {
+            rationaleEl.innerHTML = window.marked.parse(rationaleMd);
+        } else {
+            rationaleEl.textContent = rationaleMd || '(rationale vide)';
+        }
+        currentReportMd = rationaleMd;  // Copy/download retourne le rationale
+        updateActionButtons(!!rationaleMd);
+
+        // Bind tabs : lazy load au clic
+        const tabs = reportEl.querySelectorAll('.tax-refonte-phaseb-tab');
+        const panes = reportEl.querySelectorAll('.tax-refonte-phaseb-pane');
+        let diffLoaded = false, impactLoaded = false;
+        tabs.forEach(t => {
+            t.addEventListener('click', () => {
+                tabs.forEach(x => x.classList.remove('active'));
+                panes.forEach(x => x.classList.remove('active'));
+                t.classList.add('active');
+                const name = t.dataset.pane;
+                const pane = reportEl.querySelector('.tax-refonte-phaseb-pane[data-pane="' + name + '"]');
+                pane.classList.add('active');
+                if (name === 'diff' && !diffLoaded) {
+                    diffLoaded = true;
+                    loadTreeDiff(runId, profile, pane);
+                } else if (name === 'impact' && !impactLoaded) {
+                    impactLoaded = true;
+                    loadSimulation(runId, profile, pane);
+                }
+            });
+        });
+    }
+
+    async function loadTreeDiff(runId, profile, pane) {
+        try {
+            const r = await fetch('/api/agent/refonte/proposition/' + runId
+                                  + '/tree-diff?profile=' + encodeURIComponent(profile));
+            if (!r.ok) throw new Error('HTTP ' + r.status);
+            const d = await r.json();
+            renderTreeDiff(d, pane);
+        } catch (err) {
+            pane.innerHTML = '<p style="color:#ef4444;">Erreur de chargement : '
+                           + err.message + '</p>';
+        }
+    }
+
+    function renderTreeDiff(d, pane) {
+        const parts = [];
+        parts.push('<p class="muted small">'
+          + d.n_folders_before + ' dossiers → ' + d.n_folders_after + ' après refonte</p>');
+        if (d.added && d.added.length) {
+            parts.push('<div class="tax-refonte-diff-section">');
+            parts.push('<h4 style="color:#22c55e;">+ Créés (' + d.added.length + ')</h4>');
+            for (const f of d.added) {
+                parts.push('<div class="tax-refonte-diff-item tax-refonte-diff-add">'
+                  + '+ ' + escapeHtml(f) + '</div>');
+            }
+            parts.push('</div>');
+        }
+        if (d.removed && d.removed.length) {
+            parts.push('<div class="tax-refonte-diff-section">');
+            parts.push('<h4 style="color:#ef4444;">− Supprimés (' + d.removed.length + ')</h4>');
+            for (const f of d.removed) {
+                parts.push('<div class="tax-refonte-diff-item tax-refonte-diff-remove">'
+                  + '− ' + escapeHtml(f) + '</div>');
+            }
+            parts.push('</div>');
+        }
+        if (d.renamed && d.renamed.length) {
+            parts.push('<div class="tax-refonte-diff-section">');
+            parts.push('<h4 style="color:#f59e0b;">↻ Renommés (' + d.renamed.length + ')</h4>');
+            for (const r of d.renamed) {
+                parts.push('<div class="tax-refonte-diff-item tax-refonte-diff-rename">'
+                  + escapeHtml(r.old) + ' → ' + escapeHtml(r.new)
+                  + (r.rationale ? '<div class="muted small">' + escapeHtml(r.rationale) + '</div>' : '')
+                  + '</div>');
+            }
+            parts.push('</div>');
+        }
+        if (d.fused && d.fused.length) {
+            parts.push('<div class="tax-refonte-diff-section">');
+            parts.push('<h4 style="color:#8b5cf6;">⇆ Fusions (' + d.fused.length + ')</h4>');
+            for (const f of d.fused) {
+                parts.push('<div class="tax-refonte-diff-item tax-refonte-diff-fusion">'
+                  + (f.sources || []).map(escapeHtml).join(' + ') + ' → ' + escapeHtml(f.target)
+                  + (f.rationale ? '<div class="muted small">' + escapeHtml(f.rationale) + '</div>' : '')
+                  + '</div>');
+            }
+            parts.push('</div>');
+        }
+        if (parts.length <= 1) {
+            parts.push('<p class="muted">Aucun changement structurel — uniquement des mappings ajoutés.</p>');
+        }
+        pane.innerHTML = parts.join('\n');
+    }
+
+    async function loadSimulation(runId, profile, pane) {
+        try {
+            const r = await fetch('/api/agent/refonte/proposition/' + runId
+                                  + '/simulation?profile=' + encodeURIComponent(profile));
+            if (!r.ok) {
+                if (r.status === 404) {
+                    pane.innerHTML = '<p class="muted">Pas de simulation disponible pour ce run.</p>';
+                    return;
+                }
+                throw new Error('HTTP ' + r.status);
+            }
+            const d = await r.json();
+            renderSimulation(d, pane);
+        } catch (err) {
+            pane.innerHTML = '<p style="color:#ef4444;">Erreur de chargement : '
+                           + err.message + '</p>';
+        }
+    }
+
+    function renderSimulation(d, pane) {
+        const s = d.summary || {};
+        const cards = [
+            { label: 'Fichiers', num: s.n_files || 0 },
+            { label: 'Déplacés', num: s.n_moving || 0 },
+            { label: 'Stables', num: s.n_stable || 0 },
+            { label: 'Non prédits', num: s.n_no_prediction || 0 },
+        ];
+        const cardsHtml = cards.map(c =>
+            '<div class="tax-refonte-stat-card">'
+          + '  <div class="num">' + c.num + '</div>'
+          + '  <div class="label">' + c.label + '</div>'
+          + '</div>'
+        ).join('');
+
+        let topDest = '';
+        if (s.top_destinations && s.top_destinations.length) {
+            topDest = '<h4 style="margin-top:14px;">Top dossiers cibles (entrants)</h4>'
+                    + '<table class="tax-refonte-impact-table">'
+                    + '<thead><tr><th>Dossier</th><th style="text-align:right;">N entrants</th></tr></thead>'
+                    + '<tbody>'
+                    + s.top_destinations.slice(0, 10).map(d =>
+                        '<tr><td><code style="font-size:11px;">' + escapeHtml(d.folder)
+                      + '</code></td><td style="text-align:right;">' + d.n_incoming + '</td></tr>'
+                    ).join('')
+                    + '</tbody></table>';
+        }
+
+        let movesTbl = '';
+        if (d.sample_moves && d.sample_moves.length) {
+            movesTbl = '<h4 style="margin-top:14px;">Échantillon de déplacements ('
+                     + d.sample_moves.length + ' sur ' + d.n_moves_total + ')</h4>'
+                     + '<table class="tax-refonte-impact-table">'
+                     + '<thead><tr><th>Fichier</th><th>De</th><th>Vers</th></tr></thead>'
+                     + '<tbody>'
+                     + d.sample_moves.slice(0, 30).map(m =>
+                        '<tr><td title="' + escapeHtml(m.rel_path) + '">'
+                      + escapeHtml(m.rel_path.split('/').pop()) + '</td>'
+                      + '<td><code style="font-size:10px;">' + escapeHtml(m.current_folder) + '</code></td>'
+                      + '<td><code style="font-size:10px;">' + escapeHtml(m.proposed_folder) + '</code></td></tr>'
+                     ).join('')
+                     + '</tbody></table>';
+        }
+
+        pane.innerHTML =
+            '<div class="tax-refonte-stat-cards">' + cardsHtml + '</div>'
+          + topDest
+          + movesTbl;
+    }
+
+    function escapeHtml(s) {
+        if (s == null) return '';
+        return String(s)
+            .replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;')
+            .replace(/"/g, '&quot;').replace(/'/g, '&#39;');
+    }
+
+    function updateProposeButton() {
+        // Bouton actif uniquement si on a au moins un run Phase A `done` à
+        // l'index ET un run actif (currentRunId) qui est ce Phase A done.
+        const active = currentRunId ? runsIndex[currentRunId] : null;
+        const isPhaseADone = active && active.status === 'done'
+                             && (active.phase || 'A') === 'A';
+        if (isPhaseADone) {
+            proposeBtn.disabled = false;
+            proposeBtn.title = 'Proposer une refonte basée sur le diagnostic '
+                             + currentRunId.slice(0, 8) + '…';
+        } else {
+            proposeBtn.disabled = true;
+            proposeBtn.title = 'Sélectionne un diagnostic Phase A done à gauche';
+        }
+    }
+
+    async function startProposition() {
+        if (!currentRunId) return;
+        const profile = currentProfile();
+        proposeBtn.disabled = true;
+        setStatus('Démarrage de la proposition…');
+        renderReport('');
+        try {
+            const r = await fetch('/api/agent/refonte/proposition', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({
+                    profile: profile,
+                    diagnostic_run_id: currentRunId,
+                    max_llm_calls: parseInt(budgetInput.value || '8', 10) + 3,
+                }),
+            });
+            if (!r.ok) {
+                const e = await r.json();
+                throw new Error(e.error || ('HTTP ' + r.status));
+            }
+            const data = await r.json();
+            currentRunId = data.run_id;
+            currentRunPhase = 'B';
+            startBtn.disabled = true;
+            setStatus('Run B ' + data.run_id.slice(0, 8) + '… démarré');
+            pollTimer = setInterval(() => pollStatus(data.run_id), 2000);
+            loadRuns();
+        } catch (err) {
+            setStatus('Erreur : ' + err.message);
+            updateProposeButton();
+        }
+    }
+
+    proposeBtn.addEventListener('click', startProposition);
 
     function renderReport(md) {
         currentReportMd = md || '';
@@ -368,6 +727,10 @@
     }
 
     function renderRuns(runs) {
+        // Indexe les runs pour décider d'activer "Proposer une refonte"
+        runsIndex = {};
+        for (const r of runs) runsIndex[r.run_id] = r;
+        updateProposeButton();
         if (!runs.length) {
             runsEl.innerHTML = '<p class="tax-refonte-runs-empty">Aucun run pour ce profil. '
                              + 'Lance ton premier diagnostic ↑</p>';
@@ -384,9 +747,15 @@
             const llmInfo = r.llm_calls
                 ? '<span class="tax-refonte-run-meta">' + r.llm_calls + ' LLM</span>'
                 : '';
+            const phaseLabel = r.phase === 'B'
+                ? '<span class="tax-refonte-run-meta" style="background:rgba(139,92,246,0.18);'
+                + 'padding:1px 6px;border-radius:3px;color:#a78bfa;">B</span>'
+                : '<span class="tax-refonte-run-meta" style="background:rgba(79,110,242,0.18);'
+                + 'padding:1px 6px;border-radius:3px;color:#93b1ff;">A</span>';
             item.innerHTML =
                 '<div class="tax-refonte-run-head">'
               + '  <code class="tax-refonte-run-id">' + r.run_id.slice(0, 8) + '</code>'
+              + '  ' + phaseLabel
               + '  <span class="status-badge status-' + r.status + '">' + r.status + '</span>'
               + '</div>'
               + '<div class="tax-refonte-run-foot">'
@@ -408,6 +777,8 @@
                     if (pollTimer) { clearInterval(pollTimer); pollTimer = null; }
                 }
                 currentRunId = r.run_id;
+                currentRunPhase = r.phase || 'A';
+                updateProposeButton();
                 pollStatus(r.run_id);
                 const stillRunning = r.status === 'running' || r.status === 'pending';
                 if (stillRunning && !pollTimer) {
@@ -452,7 +823,12 @@
                       + ' · ' + calls + '/' + max + ' appel(s) LLM' + node + elapsed);
             if (s.status === 'done') {
                 currentRunId = runId;
-                renderReport(s.report_md || '');
+                currentRunPhase = s.phase || 'A';
+                if (currentRunPhase === 'B') {
+                    renderPhaseBReport(runId, s);
+                } else {
+                    renderReport(s.report_md || '');
+                }
                 if (pollTimer) { clearInterval(pollTimer); pollTimer = null; }
                 startBtn.disabled = false;
                 loadRuns();

--- a/tests/auto/test_agent_refonte_endpoint.py
+++ b/tests/auto/test_agent_refonte_endpoint.py
@@ -254,5 +254,110 @@ class TestListRuns(_AgentEndpointBase):
         self.assertEqual(runs[2]["started_at"], "2026-01-01T00:00:00Z")
 
 
+class TestPropositionEndpoints(_AgentEndpointBase):
+    """Endpoints API Phase B : POST proposition + GET tree-diff + GET simulation."""
+
+    def _seed_phase_b_run(self, run_id: str, with_simulation: bool = True) -> None:
+        """Crée un faux run Phase B done avec proposed/ + simulation/ artefacts."""
+        rundir = self.tmp / "profiles" / "test_p" / ".cache" / "refonte" / run_id
+        proposed = rundir / "proposed"
+        proposed.mkdir(parents=True)
+        # status.json
+        (rundir / "status.json").write_text(json.dumps({
+            "run_id": run_id, "profile": "test_p",
+            "phase": "B", "status": "done",
+            "started_at": "2026-05-25T00:00:00Z",
+            "completed_at": "2026-05-25T00:01:00Z",
+            "llm_calls": 5, "diagnostic_run_id": "diag-xxx",
+        }))
+        # proposed/ artefacts
+        (proposed / "tree-proposed.yaml").write_text(
+            "folders:\n- A\n- A/Rust\n- B/New\n",
+        )
+        (proposed / "theme_mapping-proposed.yaml").write_text("rust: A/Rust\n")
+        (proposed / "refonte-rationale.md").write_text(
+            "# Refonte taxonomy — profil `test_p` — proposition\n\n## CRÉATIONS (1)\n- `A/Rust`\n",
+        )
+        (proposed / "changes.json").write_text(json.dumps({
+            "creations": [{"path": "A/Rust", "rationale": "rust orphelin"}],
+            "fusions": [],
+            "renamings": [],
+            "mappings_added": [{"theme": "rust", "folder": "A/Rust", "rationale": "x"}],
+        }))
+        # Aussi un tree.yaml côté profil pour le diff
+        (self.tmp / "profiles" / "test_p" / "tree.yaml").write_text(
+            "folders:\n- A\n- A/Python\n",
+        )
+        if with_simulation:
+            simdir = rundir / "simulation"
+            simdir.mkdir()
+            (simdir / "simulation-summary.json").write_text(json.dumps({
+                "n_files": 100, "n_moving": 30, "n_stable": 65, "n_no_prediction": 5,
+                "top_destinations": [{"folder": "A/Rust", "n_incoming": 12}],
+                "top_origins": [{"folder": "B", "n_outgoing": 12}],
+                "n_by_source": {"LLM (theme)": 80},
+            }))
+            (simdir / "reclassify-projection.csv").write_text(
+                "rel_path,current_folder,proposed_folder,changed,source,top_theme,confidence,score\n"
+                "a.pdf,B,A/Rust,True,LLM (theme),rust programming,0.9,1.0\n"
+                "b.pdf,A,A,False,LLM (theme),x,0.5,1.0\n"
+                "c.pdf,B,A/Rust,True,LLM (theme),rust programming,0.92,1.0\n",
+            )
+
+    def test_tree_diff_endpoint_returns_added_and_renames(self):
+        self._seed_phase_b_run("rb-1")
+        r = self.client.get("/api/agent/refonte/proposition/rb-1/tree-diff?profile=test_p")
+        self.assertEqual(r.status_code, 200)
+        d = r.json()
+        # A/Rust et B/New sont créés (pas dans current tree)
+        self.assertIn("A/Rust", d["added"])
+        self.assertIn("B/New", d["added"])
+        # A/Python est supprimé (présent dans current, pas dans proposed)
+        self.assertIn("A/Python", d["removed"])
+        # Compte cohérent
+        self.assertEqual(d["n_folders_before"], 2)
+        self.assertEqual(d["n_folders_after"], 3)
+
+    def test_tree_diff_missing_profile_qs(self):
+        r = self.client.get("/api/agent/refonte/proposition/rb-X/tree-diff")
+        # FastAPI 422 si query string profile manque
+        self.assertEqual(r.status_code, 422)
+
+    def test_simulation_endpoint_returns_summary_and_sample(self):
+        self._seed_phase_b_run("rb-2")
+        r = self.client.get("/api/agent/refonte/proposition/rb-2/simulation?profile=test_p")
+        self.assertEqual(r.status_code, 200)
+        d = r.json()
+        self.assertEqual(d["summary"]["n_files"], 100)
+        self.assertEqual(d["summary"]["n_moving"], 30)
+        # 2 lignes "changed=True" dans le CSV
+        self.assertEqual(d["n_moves_total"], 2)
+        self.assertEqual(len(d["sample_moves"]), 2)
+        # La première move doit être a.pdf
+        self.assertEqual(d["sample_moves"][0]["rel_path"], "a.pdf")
+
+    def test_simulation_endpoint_404_for_phase_a_run(self):
+        """Un run Phase A (sans simulation/) → 404."""
+        rundir = self.tmp / "profiles" / "test_p" / ".cache" / "refonte" / "ra-1"
+        rundir.mkdir(parents=True)
+        (rundir / "status.json").write_text(json.dumps({
+            "run_id": "ra-1", "profile": "test_p", "phase": "A", "status": "done",
+        }))
+        r = self.client.get("/api/agent/refonte/proposition/ra-1/simulation?profile=test_p")
+        self.assertEqual(r.status_code, 404)
+
+    def test_get_status_injects_rationale_md_for_phase_b(self):
+        """GET /api/agent/refonte/diagnostic/<run_id> sur un run Phase B done
+        doit injecter rationale_md (pas report_md)."""
+        self._seed_phase_b_run("rb-3", with_simulation=False)
+        r = self.client.get("/api/agent/refonte/diagnostic/rb-3?profile=test_p")
+        self.assertEqual(r.status_code, 200)
+        body = r.json()
+        self.assertEqual(body["phase"], "B")
+        self.assertIn("rationale_md", body)
+        self.assertIn("Refonte taxonomy", body["rationale_md"])
+        self.assertNotIn("report_md", body)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

Brique UI de la Phase B. Ajoute un bouton **🔧 Proposer une refonte** dans le sous-onglet Refonte (visible quand un diagnostic Phase A `done` est sélectionné). Quand un run Phase B est consulté, le panneau Rapport bascule en vue **3 onglets** :

| Onglet | Contenu |
|---|---|
| 📋 **Rationale** | Le markdown `refonte-rationale.md` rendu (CRÉATIONS / FUSIONS / RENOMMAGES / MAPPINGS) |
| 🌳 **Diff tree** | Listes vert (ajouts) / rouge (suppressions) / orange (renames) / purple (fusions) |
| 📊 **Impact** | 4 stat cards + top destinations + échantillon de déplacements |

⚠️ PR ciblée sur l'intégration `feature/agent-refonte-phase-b`.

## Backend

`dashboard/agent_refonte.py` :
- `get_status()` enrichi : injecte `rationale_md` pour les runs Phase B done (et `report_md` reste pour Phase A)
- `get_proposition_tree_diff(profile, run_id)` : sets diff entre tree.yaml et tree-proposed.yaml + lecture des renamings/fusions depuis `changes.json`. Soustrait les paires couvertes par renamings/fusions des added/removed pour ne pas double-compter
- `get_proposition_simulation(profile, run_id, sample_limit=50)` : lit summary.json + stream le CSV en gardant uniquement les `changed=True` jusqu'à sample_limit. Le CSV complet (~18k lignes) reste côté serveur

`dashboard/app.py` — 2 nouveaux endpoints :
- `GET /api/agent/refonte/proposition/{run_id}/tree-diff?profile=...`
- `GET /api/agent/refonte/proposition/{run_id}/simulation?profile=...&sample_limit=N`

## UI

`dashboard/templates/partials/agent_refonte_panel.html` :
- Bouton purple **🔧 Proposer une refonte**, disabled sauf si un run Phase A `done` est sélectionné
- Badge phase **A**/**B** sur chaque card de run à gauche
- `renderPhaseBReport(runId, status)` : crée la vue 3 onglets, charge Rationale immédiatement, lazy-load Diff et Impact au clic sur leur onglet
- `escapeHtml` pour éviter d'injecter du HTML venant du LLM
- CSS dédié : onglets, stat cards, diff items colorés, impact tables

## Test plan

- [x] **5 nouveaux tests endpoint** dans `test_agent_refonte_endpoint.py` :
  - tree-diff : added + removed corrects
  - tree-diff : 422 si profile QS absent
  - simulation : summary + sample limité aux changed=True
  - simulation : 404 pour un run Phase A (sans simulation/)
  - get_status injecte rationale_md (pas report_md) pour Phase B done
- [x] Suite complète : **889 tests** (+5 vs B.2), 0 régression
- [x] `uv run ruff check` clean
- [x] Smoke test manuel : bouton + classes CSS bien servis, POST validation OK, GET endpoints répondent JSON

## Suite

- **B.4** — smoke run réel sur profil `default` (chaîne complète A→B avec vrai LLM, budget estimé ~\$1-2)
- Puis PR final `phase-b → develop`

🤖 Generated with [Claude Code](https://claude.com/claude-code)