### PR TITLE
feat(agents): B.3-bis — pré-extraction orphans + prompt impératif

### DIFF
--- a/agents/refonte/proposition.py
+++ b/agents/refonte/proposition.py
@@ -29,6 +29,7 @@ Topologie :
 from __future__ import annotations
 
 import json
+import re
 import uuid
 from pathlib import Path
 from typing import Any, Literal
@@ -44,61 +45,133 @@ from agents.refonte.state import RefonteState
 from agents.refonte.tools import TOOLS as READ_TOOLS
 from dashboard import data
 
-DEFAULT_MAX_LLM_CALLS = 8
+DEFAULT_MAX_LLM_CALLS = 6  # 6 suffit largement avec la pré-extraction d'orphelins
+                            # qui supprime la phase d'exploration verbeuse
 
 SYSTEM_PROMPT_B = """Tu es l'agent IA Klodo en **Phase B (Proposition)**.
 
-Ton objectif : à partir du **diagnostic Phase A** fourni en contexte, **proposer
-une refonte concrète** de la taxonomie. Tu écris des fichiers YAML "proposed"
-en side (jamais sur les YAMLs de production) qui seront ensuite simulés et,
-éventuellement, appliqués par Phase C après validation utilisateur.
+Tu reçois en entrée :
+  - le rapport markdown du diagnostic Phase A
+  - **une LISTE PRÉ-EXTRAITE des mappings orphelins** (JSON) directement utilisable
 
-Tu disposes de 9 outils :
+Ta tâche : appeler **propose_changes** UNE FOIS avec une proposition COMPLÈTE.
 
-**Outils de lecture (validation / cross-check du diagnostic)** :
-  - list_folders(profile)
-  - count_files_per_folder(profile)
-  - read_theme_mapping(profile)
-  - list_themes_per_folder(profile)
-  - compute_folder_overlap(profile, folder_a, folder_b)
-  - get_classifier_breakdown(profile)
+═══════ Outils disponibles ═══════
+
+**Lecture (cross-check si besoin, mais la liste pré-extraite suffit dans 90% des cas)** :
+  - list_folders(profile), count_files_per_folder(profile)
+  - read_theme_mapping(profile), list_themes_per_folder(profile)
+  - compute_folder_overlap(profile, a, b)
   - list_vision_themes(profile, top_n=50)
   - find_orphan_themes(profile, top_n=30)
 
-**Outil mutable (écrit les YAMLs proposed — UNE seule fois par run)** :
+**Mutable (UNE seule fois par run, à la fin)** :
   - propose_changes(creations, fusions, renamings, mappings_added)
 
-Stratégie efficace (5-7 tool calls) :
-  1. Lis le diagnostic ci-dessous. Il liste les anomalies (mappings manquants,
-     dossiers sous-utilisés, catch-all qui débordent, doublons sémantiques).
-  2. Si besoin, vérifie 1-2 cas via les outils read-only (ex. confirmer un
-     thème orphelin via find_orphan_themes).
-  3. Construis ta proposition complète, puis appelle propose_changes(...)
-     **une seule fois** avec tous les changements groupés.
+═══════ Contraintes IMPÉRATIVES sur propose_changes ═══════
 
-Conventions importantes pour propose_changes :
-  - `creations` : nouveaux dossiers (path relatif depuis le target).
-  - `fusions` : `sources` = liste de paths existants, `target` = path destination
-    (peut être un path créé par `creations` ou un dossier existant).
-  - `renamings` : changement de nom d'un dossier existant.
-  - `mappings_added` : pour chaque thème orphelin du diagnostic, mappe-le vers
-    son dossier cible évident. PRIORITÉ : c'est ça qui débloque le plus de
-    fichiers mal classés. Ajoute 15-30 mappings si le diagnostic en propose
-    autant.
+1. **mappings_added : exhaustif, pas symbolique.** Pour CHAQUE entrée de la
+   liste pré-extraite, tu DOIS produire un mapping. Si la liste contient 30
+   entrées, ton appel doit avoir AU MINIMUM 25 mappings_added (tolérance : tu
+   peux retirer 5 entrées que tu juges hors scope, mais tu DOIS justifier).
+   Une proposition avec 0 mapping_added est un ÉCHEC.
 
-Chaque entrée doit avoir un champ `rationale` court (1-2 phrases) qui justifie
-le choix — c'est ce qui apparaîtra dans `refonte-rationale.md`.
+2. **creations** : si une `target_folder` d'un orphelin n'existe pas encore
+   dans tree.yaml, crée-la (ajoute-la dans `creations`).
 
-**Règles absolues** :
-  - N'invente PAS de thèmes ou de chemins : utilise uniquement ceux du
-    diagnostic ou retournés par les outils de lecture.
-  - Les chemins cibles des `mappings_added` doivent exister dans `tree.yaml`
-    courant OU être créés via `creations`.
-  - Sois EXHAUSTIF sur les mappings_added (15-30+ si le diagnostic les liste) —
-    c'est l'action à plus haut ROI.
+3. **fusions / renamings** : optionnels, basés sur les anomalies de doublons
+   sémantiques du diagnostic. Pas obligatoires si le diagnostic n'en a pas vu.
 
-Quand tu as appelé propose_changes une fois avec succès, **réponds sans appeler
-d'autre outil** — Phase B est terminée."""
+4. **rationale** par entrée : 1 phrase courte, factuelle. Cite le count
+   d'occurrences pour les mappings_added quand pertinent.
+
+═══════ Exemple d'appel correct ═══════
+
+```json
+{
+  "creations": [
+    {"path": "01-SCIENCES/CHIMIE/04-Science-des-Materiaux",
+     "rationale": "78 fichiers Materials Science orphelins"}
+  ],
+  "mappings_added": [
+    {"theme": "Functional Analysis", "folder": "01-SCIENCES/MATHEMATIQUES/02-Analyse",
+     "rationale": "176 fichiers — analyse fonctionnelle classique"},
+    {"theme": "Complex Analysis", "folder": "01-SCIENCES/MATHEMATIQUES/02-Analyse",
+     "rationale": "114 fichiers — analyse complexe"},
+    {"theme": "Group Theory", "folder": "01-SCIENCES/MATHEMATIQUES/01-Algebre",
+     "rationale": "112 fichiers — algèbre"}
+    /* ... 15-30 entrées au total ... */
+  ]
+}
+```
+
+═══════ Anti-patterns à éviter ═══════
+
+- ❌ Ne livrer que 2-3 mappings alors que la liste pré-extraite en a 30
+- ❌ Appeler des outils de lecture en boucle pour "redécouvrir" ce qui est
+  déjà dans la liste pré-extraite
+- ❌ Inventer des `theme` ou `folder` qui ne sont pas dans la liste ou
+  dans tree.yaml
+
+Quand tu as appelé propose_changes avec succès, **termine sans nouvel outil**."""
+
+
+# ─── Parser des mappings orphelins depuis le rapport Phase A ───────────────
+
+
+# Matche : "[- ]**Theme** (NN fichiers) → <reste de ligne>"
+# Le `reste de ligne` est nettoyé en post-traitement (strip label éventuel +
+# backticks) pour tolérer plusieurs variantes du LLM ("dossier cible évident :",
+# "cible :", aucun label, etc.).
+_MAPPING_LINE_RE = re.compile(
+    r"^\s*[-*]?\s*\*\*([^*]+?)\*\*\s*\((\d+)\s*fichiers?\)\s*[→]\s*(.+?)\s*$",
+    re.MULTILINE,
+)
+# Strip un préfixe optionnel "dossier cible évident :" / "cible :" / "target :"
+_TARGET_LABEL_RE = re.compile(
+    r"^\s*(?:dossier\s+cible\s*(?:évident)?|cible|target)\s*[:：]\s*",
+    re.IGNORECASE,
+)
+
+
+def parse_orphan_mappings_from_report(report_md: str) -> list[dict[str, Any]]:
+    """Extrait la liste structurée des mappings orphelins du rapport Phase A.
+
+    Cherche les lignes du format produit par REPORT_PROMPT_TEMPLATE de Phase A :
+      - **Theme name** (NN fichiers) → dossier cible évident : `path/to/folder`
+
+    Le parser est tolérant : il accepte "dossier cible :" / "cible :" / aucun
+    label, et nettoie les backticks/guillemets résiduels autour du path.
+
+    Args:
+        report_md: Le contenu markdown du rapport (report.md).
+
+    Returns:
+        Liste de dicts `{"theme": str, "count": int, "target_folder": str}`,
+        ordonnés comme dans le rapport (typiquement par count desc).
+        Liste vide si aucun pattern matché (rapport mal formé / langue
+        inattendue / hallucination).
+    """
+    if not report_md:
+        return []
+    results: list[dict[str, Any]] = []
+    for m in _MAPPING_LINE_RE.finditer(report_md):
+        theme = m.group(1).strip()
+        try:
+            count = int(m.group(2))
+        except ValueError:
+            continue
+        raw_target = m.group(3)
+        # Strip label éventuel ("dossier cible évident :" etc.)
+        target = _TARGET_LABEL_RE.sub("", raw_target).strip()
+        # Strip backticks/guillemets externes (ex. `01-SCIENCES/...` → 01-SCIENCES/...)
+        target = target.strip("` '\"")
+        # Strip ponctuation finale qui pourrait avoir collé (virgule, point)
+        target = target.rstrip(".,;")
+        if not target or not theme:
+            continue
+        results.append({"theme": theme, "count": count, "target_folder": target})
+    return results
 
 
 # ─── Nœuds ──────────────────────────────────────────────────────────────────
@@ -144,6 +217,45 @@ def _init_node(state: RefonteState) -> dict[str, Any]:
                 f"avec status=done sur ce run avant de lancer Phase B."
             ),
         }
+    # Pré-extraction des mappings orphelins du rapport — on les sert au LLM
+    # en JSON pré-mâché plutôt que de lui faire ré-extraire du markdown.
+    orphans = parse_orphan_mappings_from_report(diagnostic_md)
+    orphans_json = json.dumps(orphans, ensure_ascii=False, indent=2)
+    expected_min = max(0, len(orphans) - 5)  # tolérance : -5 du total
+
+    human_content_parts = [
+        f"Voici le diagnostic Phase A du profil `{profile}` :",
+        "",
+        "---",
+        diagnostic_md,
+        "---",
+        "",
+    ]
+    if orphans:
+        human_content_parts += [
+            f"**Mappings orphelins pré-extraits** (n={len(orphans)}) — utilise CETTE liste",
+            "comme base de `mappings_added`, **pas le markdown ci-dessus** :",
+            "",
+            "```json",
+            orphans_json,
+            "```",
+            "",
+            "**Contrainte stricte** : ton appel à `propose_changes` doit contenir",
+            f"AU MINIMUM **{expected_min} mappings_added** issus de cette liste (ou {len(orphans)}",
+            "si tu juges qu'aucun n'est hors scope). Pour chaque target_folder qui",
+            "n'existe pas encore dans `tree.yaml`, ajoute une entrée dans `creations`.",
+        ]
+    else:
+        human_content_parts += [
+            "(Aucun mapping orphelin pré-extrait du rapport — soit le diagnostic",
+            "n'en mentionne pas, soit le format ne match pas le parser. Examine",
+            "le markdown ci-dessus et/ou utilise `find_orphan_themes(profile, top_n=30)`.)",
+        ]
+    human_content_parts += [
+        "",
+        "Appelle `propose_changes` **une fois**, avec une proposition complète.",
+    ]
+
     return {
         "phase": "B",
         "run_id": state.get("run_id") or str(uuid.uuid4()),
@@ -151,14 +263,7 @@ def _init_node(state: RefonteState) -> dict[str, Any]:
         "llm_calls": 0,
         "messages": [
             SystemMessage(content=SYSTEM_PROMPT_B),
-            HumanMessage(
-                content=(
-                    f"Voici le diagnostic Phase A du profil `{profile}` à utiliser "
-                    f"comme base de ta proposition :\n\n---\n{diagnostic_md}\n---\n\n"
-                    f"Propose maintenant une refonte via propose_changes. "
-                    f"Sois exhaustif sur les mappings_added."
-                ),
-            ),
+            HumanMessage(content="\n".join(human_content_parts)),
         ],
     }
 

--- a/dashboard/templates/partials/agent_refonte_panel.html
+++ b/dashboard/templates/partials/agent_refonte_panel.html
@@ -874,15 +874,17 @@
                 if (pollTimer) { clearInterval(pollTimer); pollTimer = null; }
                 startBtn.disabled = false;
             } else {
-                // status="running" ou "pending" — pas de rapport disponible
-                // encore. Afficher un placeholder explicite plutôt que de
-                // laisser un éventuel contenu fantôme d'un run précédent.
-                // (Évite l'illusion "Commence maintenant." sur un autre run.)
-                if (!currentReportMd) {
-                    reportEl.innerHTML = '<p class="muted" style="font-style:italic;">'
-                                       + 'Diagnostic en cours — le rapport apparaîtra '
-                                       + 'ici quand le run se termine.</p>';
-                }
+                // status="running" ou "pending" — afficher le placeholder
+                // INCONDITIONNELLEMENT. La condition `if (!currentReportMd)`
+                // précédente laissait passer le contenu d'un autre run (par
+                // ex. le rapport A reste affiché alors qu'on poll un run B
+                // running, observé 2026-05-25).
+                const phaseLabel = (s.phase === 'B') ? 'Proposition' : 'Diagnostic';
+                reportEl.innerHTML = '<p class="muted" style="font-style:italic;">'
+                                   + phaseLabel + ' en cours — le rapport apparaîtra '
+                                   + 'ici quand le run se termine.</p>';
+                currentReportMd = '';
+                updateActionButtons(false);
             }
         } catch (err) {
             console.error('poll error', err);

--- a/tests/auto/test_agent_refonte_proposition.py
+++ b/tests/auto/test_agent_refonte_proposition.py
@@ -23,7 +23,10 @@ from langchain_core.messages import AIMessage, ToolMessage
 PROJECT_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 sys.path.insert(0, PROJECT_ROOT)
 
-from agents.refonte.proposition import build_proposition_graph  # noqa: E402
+from agents.refonte.proposition import (  # noqa: E402
+    build_proposition_graph,
+    parse_orphan_mappings_from_report,
+)
 from agents.refonte.proposition_tools import propose_changes  # noqa: E402
 from dashboard import data  # noqa: E402
 from dashboard import taxonomy as tax
@@ -309,6 +312,88 @@ class TestStartProposition(_ProposBase):
             status = agent_refonte.get_status("p", result["run_id"])
             self.assertEqual(status["status"], "done")
             self.assertEqual(status["proposal_summary"]["n_creations"], 1)
+
+
+class TestParseOrphanMappings(unittest.TestCase):
+    """Parser d'orphan mappings depuis le rapport Phase A — alimente
+    le HumanMessage de Phase B avec un JSON pré-extrait."""
+
+    def test_parses_standard_format(self):
+        md = """
+# Diagnostic taxonomy — profil `default` — 2026-05-25
+
+## Anomalies détectées (par priorité)
+
+### Mappings manquants critiques (30 cas)
+- **Functional Analysis** (176 fichiers) → dossier cible évident : `01-SCIENCES/MATHEMATIQUES/02-Analyse`
+- **Complex Analysis** (114 fichiers) → dossier cible évident : `01-SCIENCES/MATHEMATIQUES/02-Analyse`
+- **Pattern Recognition** (114 fichiers) → dossier cible évident : `02-INFORMATIQUE/05-IA-ML/Machine-Learning`
+"""
+        result = parse_orphan_mappings_from_report(md)
+        self.assertEqual(len(result), 3)
+        self.assertEqual(result[0]["theme"], "Functional Analysis")
+        self.assertEqual(result[0]["count"], 176)
+        self.assertEqual(result[0]["target_folder"], "01-SCIENCES/MATHEMATIQUES/02-Analyse")
+        self.assertEqual(result[2]["theme"], "Pattern Recognition")
+        self.assertEqual(result[2]["target_folder"], "02-INFORMATIQUE/05-IA-ML/Machine-Learning")
+
+    def test_handles_variants_in_separators(self):
+        """Le parser tolère 'dossier cible :' au lieu de 'dossier cible évident :'."""
+        md = (
+            "- **Theme1** (50 fichiers) → dossier cible : `A/B`\n"
+            "- **Theme2** (10 fichiers) → dossier cible évident : `C/D`\n"
+            # Lignes sans count ne matchent pas
+            "- **Theme3** truc sans count\n"
+        )
+        result = parse_orphan_mappings_from_report(md)
+        self.assertEqual(len(result), 2)
+        self.assertEqual(result[0]["theme"], "Theme1")
+        self.assertEqual(result[1]["theme"], "Theme2")
+
+    def test_strips_backticks_from_target(self):
+        md = "- **X** (5 fichiers) → dossier cible évident : `A/B/C`"
+        result = parse_orphan_mappings_from_report(md)
+        self.assertEqual(result[0]["target_folder"], "A/B/C")
+
+    def test_works_without_backticks(self):
+        md = "- **X** (5 fichiers) → dossier cible évident : A/B/C"
+        result = parse_orphan_mappings_from_report(md)
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0]["target_folder"], "A/B/C")
+
+    def test_returns_empty_on_no_match(self):
+        self.assertEqual(parse_orphan_mappings_from_report(""), [])
+        self.assertEqual(parse_orphan_mappings_from_report("rapport vide sans liste"), [])
+
+    def test_picks_only_well_formed_lines(self):
+        """Lignes mal formées (manque arrow, manque count, etc.) sont ignorées."""
+        md = (
+            "Cette ligne **Theme** n'a pas d'arrow.\n"
+            "- **Good** (100 fichiers) → cible : `Path/A`\n"
+            "Un texte sans bullet ni format **Bad** → essayer.\n"
+        )
+        result = parse_orphan_mappings_from_report(md)
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0]["theme"], "Good")
+
+    def test_parses_30_realistic_orphans(self):
+        """Sanity check sur un rapport simulé proche du vrai format de prod."""
+        lines = ["### Mappings manquants critiques (30 cas)"]
+        for i, (theme, count) in enumerate([
+            ("Functional Analysis", 176), ("Complex Analysis", 114),
+            ("Pattern Recognition", 114), ("Group Theory", 112),
+            ("Real Analysis", 93), ("Materials Science", 78),
+            ("Optimization", 76), ("Penetration Testing", 73),
+            ("Combinatorics", 69), ("Software Testing", 69),
+        ]):
+            lines.append(
+                f"- **{theme}** ({count} fichiers) → dossier cible évident : `01-SCIENCES/FOO`"
+            )
+        result = parse_orphan_mappings_from_report("\n".join(lines))
+        self.assertEqual(len(result), 10)
+        # Ordre préservé
+        self.assertEqual(result[0]["theme"], "Functional Analysis")
+        self.assertEqual(result[-1]["theme"], "Software Testing")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Smoke run réel du run 6ea58fd0 a livré une proposition très légère (0 mappings_added alors que le diagnostic en listait 30 critiques). Cette PR corrige le flow Phase B en 4 axes pour garantir que le LLM produit une proposition riche.

⚠️ PR ciblée sur l'intégration `feature/agent-refonte-phase-b`.

## Cause racine du flop

Le LLM devait **ré-extraire** des paires `(theme, target_folder)` depuis le markdown du diagnostic. C'est fragile (interprétation de texte), et avec 9/8 LLM calls il s'épuise → propose_changes minimaliste à la fin pour ne pas timeout.

## Fixes

### 1. Pré-extraction structurée (axe 1 — gros gain)

Nouveau parser `parse_orphan_mappings_from_report(md)` qui extrait côté Python :
- `- **Theme** (NN fichiers) → dossier cible évident : \`path\``
- Tolérant aux variantes ("cible :", sans backticks, etc.)

Le `_init_node` injecte la liste pré-extraite **en JSON dans le HumanMessage** + contrainte stricte "au minimum N-5 mappings_added issus de cette liste".

### 2. Prompt impératif + exemple (axe 2)

SYSTEM_PROMPT_B réécrit :
- Contraintes IMPÉRATIVES numérotées (pas des "recommandations")
- Exemple concret d'appel propose_changes
- Anti-patterns explicites
- "Une proposition avec 0 mapping_added est un ÉCHEC"

### 3. DEFAULT_MAX_LLM_CALLS : 8 → 6

Avec la pré-extraction le LLM n'a plus besoin d'explorer en boucle. Budget 8 → sur-exploration et épuisement. Budget 6 = juste assez.

### 4. Fix UI : placeholder running inconditionnel (en bonus)

Bug observé : en jonglant entre run A done et run B running, le report area gardait le contenu A. Le check `if (!currentReportMd)` empêchait l'update.

Fix : suppression de la condition. Le placeholder s'écrit toujours pour `running`/`pending`, avec label adapté selon `s.phase` ("Diagnostic en cours" / "Proposition en cours").

## Test plan

- [x] 7 nouveaux tests `TestParseOrphanMappings` (formats variants + edge cases)
- [x] Suite complète : **896 tests** (+7), ruff clean
- [x] Tous les tests Phase B existants toujours OK
- [ ] **Validation E2E real-LLM** : laissée à la prochaine session (B.4) — la pré-extraction est testée unitairement, l'effet sur le LLM se mesurera au prochain smoke run sur `default`

## Suite

- **B.4** — smoke run réel pour mesurer l'amélioration. Si validation OK → PR final phase-b → develop

🤖 Generated with [Claude Code](https://claude.com/claude-code)