### PR TITLE
feat(agents): B.3-ter — deletions + parsers sous-utilisés/catch-all + prompt par anomalie

### DIFF
--- a/agents/refonte/proposition.py
+++ b/agents/refonte/proposition.py
@@ -52,38 +52,64 @@ SYSTEM_PROMPT_B = """Tu es l'agent IA Klodo en **Phase B (Proposition)**.
 
 Tu reçois en entrée :
   - le rapport markdown du diagnostic Phase A
-  - **une LISTE PRÉ-EXTRAITE des mappings orphelins** (JSON) directement utilisable
+  - **3 listes JSON pré-extraites** (mappings orphelins, dossiers sous-utilisés,
+    catch-all qui débordent) directement utilisables
 
-Ta tâche : appeler **propose_changes** UNE FOIS avec une proposition COMPLÈTE.
+Ta tâche : appeler **propose_changes** UNE FOIS avec une proposition COMPLÈTE
+qui adresse les 4 types d'anomalies du diagnostic, pas seulement les mappings.
 
 ═══════ Outils disponibles ═══════
 
-**Lecture (cross-check si besoin, mais la liste pré-extraite suffit dans 90% des cas)** :
-  - list_folders(profile), count_files_per_folder(profile)
-  - read_theme_mapping(profile), list_themes_per_folder(profile)
-  - compute_folder_overlap(profile, a, b)
-  - list_vision_themes(profile, top_n=50)
-  - find_orphan_themes(profile, top_n=30)
+**Lecture (cross-check si besoin)** :
+  - list_folders, count_files_per_folder, read_theme_mapping,
+    list_themes_per_folder, compute_folder_overlap, get_classifier_breakdown,
+    list_vision_themes(top_n=50), find_orphan_themes(top_n=30)
 
 **Mutable (UNE seule fois par run, à la fin)** :
-  - propose_changes(creations, fusions, renamings, mappings_added)
+  - propose_changes(creations, fusions, renamings, deletions, mappings_added)
 
-═══════ Contraintes IMPÉRATIVES sur propose_changes ═══════
+═══════ Contraintes par type d'anomalie ═══════
 
-1. **mappings_added : exhaustif, pas symbolique.** Pour CHAQUE entrée de la
-   liste pré-extraite, tu DOIS produire un mapping. Si la liste contient 30
-   entrées, ton appel doit avoir AU MINIMUM 25 mappings_added (tolérance : tu
-   peux retirer 5 entrées que tu juges hors scope, mais tu DOIS justifier).
-   Une proposition avec 0 mapping_added est un ÉCHEC.
+**1. mappings_added — DRIVEN par la liste pré-extraite « orphan mappings »**
 
-2. **creations** : si une `target_folder` d'un orphelin n'existe pas encore
-   dans tree.yaml, crée-la (ajoute-la dans `creations`).
+Pour CHAQUE entrée de cette liste, tu DOIS produire un mapping. Si la liste
+contient 30 entrées, ton appel doit avoir AU MINIMUM 25 mappings_added.
+Une proposition avec 0 mapping_added est un ÉCHEC.
 
-3. **fusions / renamings** : optionnels, basés sur les anomalies de doublons
-   sémantiques du diagnostic. Pas obligatoires si le diagnostic n'en a pas vu.
+**2. creations — DRIVEN par les target_folder des mappings**
 
-4. **rationale** par entrée : 1 phrase courte, factuelle. Cite le count
-   d'occurrences pour les mappings_added quand pertinent.
+Si une `target_folder` (de la liste orphans) n'existe pas dans tree.yaml,
+ajoute-la dans `creations`. Aussi : si un catch-all est trop gros, créer
+des sous-dossiers où ses fichiers iront naturellement.
+
+**3. deletions — DRIVEN par les dossiers sous-utilisés sans rescousse**
+
+Pour CHAQUE dossier de la liste « sous-utilisés », évalue :
+  - Si un thème orphelin pointe naturellement vers lui → ajoute un mapping
+    (cas le plus fréquent : le dossier est vide *parce que* le mapping
+    manque) → PAS de deletion
+  - Si le dossier est vide ET aucun thème orphelin n'évoque sémantiquement
+    son nom → propose une `deletion` (folder mort)
+  - Si plusieurs dossiers sous-utilisés sont proches sémantiquement →
+    propose une `fusion`
+
+**4. fusions — DRIVEN par les doublons sémantiques + les catch-all**
+
+  - Doublons sémantiques (Jaccard élevé) → fusion (ou renaming si l'un
+    des deux a un meilleur nom)
+  - Catch-all trop gros : crée les sous-catégories via `creations` +
+    ajoute des mappings_added vers les sous-catégories. Pas de fusion ici.
+
+**5. renamings — opportuniste**
+
+Si un dossier a un nom peu informatif ou redondant (ex. `/Generale`
+contenant 2 000 fichiers très ciblés), propose un renaming.
+
+═══════ rationale par entrée ═══════
+
+1 phrase courte, factuelle. Cite les counts d'occurrences pour les
+mappings_added quand pertinent. Pour les deletions, justifie pourquoi
+**aucun** orphelin ne s'y raccroche.
 
 ═══════ Exemple d'appel correct ═══════
 
@@ -93,14 +119,18 @@ Ta tâche : appeler **propose_changes** UNE FOIS avec une proposition COMPLÈTE.
     {"path": "01-SCIENCES/CHIMIE/04-Science-des-Materiaux",
      "rationale": "78 fichiers Materials Science orphelins"}
   ],
+  "deletions": [
+    {"path": "08-LOISIRS/DESSIN",
+     "rationale": "0 fichier et aucun thème orphelin lié au dessin observé"}
+  ],
+  "fusions": [
+    {"sources": ["07-LANGUES/AUTRES"], "target": "07-LANGUES",
+     "rationale": "AUTRES vide, on consolide à la racine LANGUES"}
+  ],
   "mappings_added": [
     {"theme": "Functional Analysis", "folder": "01-SCIENCES/MATHEMATIQUES/02-Analyse",
-     "rationale": "176 fichiers — analyse fonctionnelle classique"},
-    {"theme": "Complex Analysis", "folder": "01-SCIENCES/MATHEMATIQUES/02-Analyse",
-     "rationale": "114 fichiers — analyse complexe"},
-    {"theme": "Group Theory", "folder": "01-SCIENCES/MATHEMATIQUES/01-Algebre",
-     "rationale": "112 fichiers — algèbre"}
-    /* ... 15-30 entrées au total ... */
+     "rationale": "176 fichiers — analyse fonctionnelle"},
+    /* ... 25-30 entrées au total ... */
   ]
 }
 ```
@@ -108,10 +138,12 @@ Ta tâche : appeler **propose_changes** UNE FOIS avec une proposition COMPLÈTE.
 ═══════ Anti-patterns à éviter ═══════
 
 - ❌ Ne livrer que 2-3 mappings alors que la liste pré-extraite en a 30
-- ❌ Appeler des outils de lecture en boucle pour "redécouvrir" ce qui est
-  déjà dans la liste pré-extraite
-- ❌ Inventer des `theme` ou `folder` qui ne sont pas dans la liste ou
-  dans tree.yaml
+- ❌ Ignorer les dossiers sous-utilisés et les catch-all (toi seul peux
+  décider "delete vs. map vs. fuse")
+- ❌ Appeler des outils en boucle pour "redécouvrir" ce qui est déjà
+  dans les listes pré-extraites
+- ❌ Inventer des `theme` ou `folder` qui ne sont ni dans les listes
+  pré-extraites ni dans tree.yaml
 
 Quand tu as appelé propose_changes avec succès, **termine sans nouvel outil**."""
 
@@ -132,6 +164,87 @@ _TARGET_LABEL_RE = re.compile(
     r"^\s*(?:dossier\s+cible\s*(?:évident)?|cible|target)\s*[:：]\s*",
     re.IGNORECASE,
 )
+
+
+# Matche les listes type :
+#   - **02-INFORMATIQUE/03-Langages-Programmation/Python** (0 fichier) ↔ ...
+#   - **/Path/Folder** (1 234 fichiers) – description
+# La capture extrait : folder_path + count + reste (description).
+_FOLDER_COUNT_RE = re.compile(
+    r"^\s*(?:[-*]|\d+\.)?\s*\*\*([^*]+?)\*\*\s*\(([\d\s]+?)\s*fichiers?\)\s*"
+    r"(?:[↔–\-])\s*(.+?)\s*$",
+    re.MULTILINE,
+)
+
+
+def _parse_int_with_spaces(s: str) -> int | None:
+    """Parse '4 489' → 4489 (le LLM utilise parfois des espaces comme thousands)."""
+    try:
+        return int(s.replace(" ", "").replace(" ", ""))
+    except (ValueError, AttributeError):
+        return None
+
+
+def _extract_section(report_md: str, header_regex: str) -> str:
+    """Extrait le contenu d'une section h3 du rapport markdown.
+
+    Retourne le texte entre le header matché et le prochain h2/h3, ou ''
+    si le header n'est pas trouvé.
+    """
+    h_re = re.compile(r"^###\s+" + header_regex, re.MULTILINE | re.IGNORECASE)
+    m = h_re.search(report_md)
+    if not m:
+        return ""
+    start = m.end()
+    # Cherche le prochain h2/h3
+    next_h = re.search(r"^##+\s+", report_md[start:], re.MULTILINE)
+    end = start + next_h.start() if next_h else len(report_md)
+    return report_md[start:end]
+
+
+def parse_underutilized_folders_from_report(report_md: str) -> list[dict[str, Any]]:
+    """Extrait les dossiers sous-utilisés (avec ou sans thèmes orphelins).
+
+    Cherche la section `### Dossiers sous-utilisés...` et parse les lignes
+    `**folder_path** (N fichier(s)) ↔/– description`.
+
+    Returns:
+        Liste de {"folder": str, "count": int, "note": str}.
+    """
+    if not report_md:
+        return []
+    section = _extract_section(report_md, r"dossiers?\s+sous[-\s]?utilis")
+    if not section:
+        return []
+    results: list[dict[str, Any]] = []
+    for m in _FOLDER_COUNT_RE.finditer(section):
+        folder = m.group(1).strip().strip("`")
+        count = _parse_int_with_spaces(m.group(2))
+        note = m.group(3).strip()
+        if folder and count is not None:
+            results.append({"folder": folder, "count": count, "note": note})
+    return results
+
+
+def parse_catchall_folders_from_report(report_md: str) -> list[dict[str, Any]]:
+    """Extrait les dossiers catch-all qui débordent.
+
+    Cherche la section `### Catch-all qui débordent` et parse les lignes
+    `**folder_path** (N fichiers) – description`.
+    """
+    if not report_md:
+        return []
+    section = _extract_section(report_md, r"catch[-\s]?all\s+qui\s+d[ée]bordent")
+    if not section:
+        return []
+    results: list[dict[str, Any]] = []
+    for m in _FOLDER_COUNT_RE.finditer(section):
+        folder = m.group(1).strip().strip("`")
+        count = _parse_int_with_spaces(m.group(2))
+        note = m.group(3).strip()
+        if folder and count is not None:
+            results.append({"folder": folder, "count": count, "note": note})
+    return results
 
 
 def parse_orphan_mappings_from_report(report_md: str) -> list[dict[str, Any]]:
@@ -217,11 +330,15 @@ def _init_node(state: RefonteState) -> dict[str, Any]:
                 f"avec status=done sur ce run avant de lancer Phase B."
             ),
         }
-    # Pré-extraction des mappings orphelins du rapport — on les sert au LLM
-    # en JSON pré-mâché plutôt que de lui faire ré-extraire du markdown.
+    # Pré-extraction des 3 catégories d'anomalies depuis le rapport — on
+    # sert au LLM des listes JSON pré-mâchées plutôt que de lui faire
+    # ré-extraire du markdown (ça avait produit des propositions vides en
+    # premier essai 2026-05-25).
     orphans = parse_orphan_mappings_from_report(diagnostic_md)
-    orphans_json = json.dumps(orphans, ensure_ascii=False, indent=2)
-    expected_min = max(0, len(orphans) - 5)  # tolérance : -5 du total
+    underutilized = parse_underutilized_folders_from_report(diagnostic_md)
+    catchall = parse_catchall_folders_from_report(diagnostic_md)
+
+    expected_min = max(0, len(orphans) - 5)  # tolérance sur les mappings
 
     human_content_parts = [
         f"Voici le diagnostic Phase A du profil `{profile}` :",
@@ -231,29 +348,57 @@ def _init_node(state: RefonteState) -> dict[str, Any]:
         "---",
         "",
     ]
+
     if orphans:
         human_content_parts += [
-            f"**Mappings orphelins pré-extraits** (n={len(orphans)}) — utilise CETTE liste",
-            "comme base de `mappings_added`, **pas le markdown ci-dessus** :",
-            "",
+            f"**Liste 1/3 — Mappings orphelins** (n={len(orphans)}) :",
             "```json",
-            orphans_json,
+            json.dumps(orphans, ensure_ascii=False, indent=2),
             "```",
             "",
-            "**Contrainte stricte** : ton appel à `propose_changes` doit contenir",
-            f"AU MINIMUM **{expected_min} mappings_added** issus de cette liste (ou {len(orphans)}",
-            "si tu juges qu'aucun n'est hors scope). Pour chaque target_folder qui",
-            "n'existe pas encore dans `tree.yaml`, ajoute une entrée dans `creations`.",
+            f"→ `mappings_added` doit contenir AU MINIMUM **{expected_min}** "
+            f"entrées issues de cette liste (idéalement {len(orphans)}).",
+            "",
         ]
-    else:
+
+    if underutilized:
         human_content_parts += [
-            "(Aucun mapping orphelin pré-extrait du rapport — soit le diagnostic",
-            "n'en mentionne pas, soit le format ne match pas le parser. Examine",
-            "le markdown ci-dessus et/ou utilise `find_orphan_themes(profile, top_n=30)`.)",
+            f"**Liste 2/3 — Dossiers sous-utilisés** (n={len(underutilized)}) :",
+            "```json",
+            json.dumps(underutilized, ensure_ascii=False, indent=2),
+            "```",
+            "",
+            "→ Pour chaque entrée, décide : `mappings_added` (si un thème orphelin "
+            "s'y rattache), `deletions` (si vide ET aucun orphelin lié), "
+            "ou `fusions` (si plusieurs sont sémantiquement proches).",
+            "",
         ]
+
+    if catchall:
+        human_content_parts += [
+            f"**Liste 3/3 — Catch-all qui débordent** (n={len(catchall)}) :",
+            "```json",
+            json.dumps(catchall, ensure_ascii=False, indent=2),
+            "```",
+            "",
+            "→ Pour chaque catch-all, crée les sous-catégories via `creations` + "
+            "ajoute des `mappings_added` qui redirigent les thèmes vers ces "
+            "sous-catégories. La fusion ne convient PAS ici (on veut désengorger, "
+            "pas consolider davantage).",
+            "",
+        ]
+
+    if not (orphans or underutilized or catchall):
+        human_content_parts += [
+            "(Aucune anomalie pré-extraite — soit le diagnostic n'en mentionne pas, "
+            "soit le format ne match pas les parsers. Examine le markdown ci-dessus.)",
+            "",
+        ]
+
     human_content_parts += [
-        "",
-        "Appelle `propose_changes` **une fois**, avec une proposition complète.",
+        "Appelle `propose_changes` **une fois**, avec une proposition complète",
+        "qui couvre `mappings_added`, `creations`, `deletions`, `fusions`, et "
+        "`renamings` (selon ce que les listes ci-dessus suggèrent).",
     ]
 
     return {

--- a/agents/refonte/proposition_tools.py
+++ b/agents/refonte/proposition_tools.py
@@ -46,6 +46,17 @@ class _Renaming(BaseModel):
     rationale: str = Field(description="Pourquoi renommer (1-2 phrases)")
 
 
+class _Deletion(BaseModel):
+    path: str = Field(description="Chemin relatif du dossier à supprimer (sans le fusionner)")
+    rationale: str = Field(
+        description=(
+            "Pourquoi supprimer ce dossier (vide depuis longtemps, doublon "
+            "tranchant, obsolète, etc.). Préférer une `fusion` si les fichiers "
+            "doivent migrer ailleurs."
+        ),
+    )
+
+
 class _MappingAdded(BaseModel):
     theme: str = Field(description="Thème LLM observé (ex: 'rust programming')")
     folder: str = Field(description="Dossier cible (existant ou créé dans les créations)")
@@ -58,6 +69,10 @@ class _ProposeChangesInput(BaseModel):
     creations: list[_Creation] = Field(default_factory=list, description="Nouveaux dossiers à créer")
     fusions: list[_Fusion] = Field(default_factory=list, description="Dossiers à fusionner")
     renamings: list[_Renaming] = Field(default_factory=list, description="Dossiers à renommer")
+    deletions: list[_Deletion] = Field(
+        default_factory=list,
+        description="Dossiers à supprimer purement (sans fusion)",
+    )
     mappings_added: list[_MappingAdded] = Field(
         default_factory=list,
         description="Nouveaux mappings thème → dossier à ajouter dans theme_mapping.yaml",
@@ -79,12 +94,13 @@ def _apply_changes_to_tree(
     creations: list[dict],
     fusions: list[dict],
     renamings: list[dict],
+    deletions: list[dict] | None = None,
 ) -> list[str]:
     """Construit la liste des dossiers du tree proposé.
 
-    Ordre d'application : creations → renamings → fusions (les fusions
-    suppriment, on les fait en dernier pour ne pas supprimer un dossier qu'un
-    renaming aurait pu utiliser comme source).
+    Ordre d'application : creations → renamings → fusions → deletions
+    (deletions en dernier pour pouvoir cibler un path qui aurait été créé
+    ou renommé juste avant ; cas d'usage rare mais cohérent).
     """
     folders = set(current_folders)
     # Créations
@@ -99,6 +115,9 @@ def _apply_changes_to_tree(
         for src in f["sources"]:
             folders.discard(src)
         folders.add(f["target"])
+    # Suppressions sèches (sans réaffectation des fichiers)
+    for d in (deletions or []):
+        folders.discard(d["path"])
     return sorted(folders)
 
 
@@ -107,9 +126,11 @@ def _apply_changes_to_mapping(
     mappings_added: list[dict],
     renamings: list[dict],
     fusions: list[dict],
+    deletions: list[dict] | None = None,
 ) -> dict[str, str]:
     """Construit le mapping proposé : ajoute les nouveaux mappings + ajuste les
-    cibles existantes pour les renommages et les fusions.
+    cibles existantes pour les renommages et les fusions + drop les mappings
+    qui pointent sur un dossier supprimé.
     """
     mapping = dict(current_mapping)  # copy
     # Renommages : tous les thèmes qui pointaient sur old_path pointent maintenant sur new_path
@@ -119,11 +140,15 @@ def _apply_changes_to_mapping(
     for f in fusions:
         for src in f["sources"]:
             fusion_map[src] = f["target"]
+    # Suppressions : les thèmes pointant dessus deviennent orphelins (drop)
+    deleted_paths = {d["path"] for d in (deletions or [])}
     for theme, folder in list(mapping.items()):
         if folder in rename_map:
             mapping[theme] = rename_map[folder]
         elif folder in fusion_map:
             mapping[theme] = fusion_map[folder]
+        elif folder in deleted_paths:
+            del mapping[theme]
     # Nouveaux mappings (s'ajoutent en dernier, écrasent un éventuel mapping existant)
     for m in mappings_added:
         mapping[m["theme"]] = m["folder"]
@@ -141,11 +166,13 @@ def _render_rationale_markdown(
     n_creations = len(changes.creations)
     n_fusions = len(changes.fusions)
     n_renamings = len(changes.renamings)
+    n_deletions = len(changes.deletions)
     n_mappings = len(changes.mappings_added)
     lines.append("## Résumé des changements")
     lines.append(f"- **Créations** : {n_creations}")
     lines.append(f"- **Fusions** : {n_fusions}")
     lines.append(f"- **Renommages** : {n_renamings}")
+    lines.append(f"- **Suppressions** : {n_deletions}")
     lines.append(f"- **Mappings ajoutés** : {n_mappings}")
     lines.append("")
     if changes.creations:
@@ -165,6 +192,11 @@ def _render_rationale_markdown(
         for r in changes.renamings:
             lines.append(f"- `{r.old_path}` → `{r.new_path}` — {r.rationale}")
         lines.append("")
+    if changes.deletions:
+        lines.append(f"## SUPPRESSIONS ({n_deletions})")
+        for d in changes.deletions:
+            lines.append(f"- `{d.path}` — {d.rationale}")
+        lines.append("")
     if changes.mappings_added:
         lines.append(f"## MAPPINGS AJOUTÉS ({n_mappings})")
         for m in changes.mappings_added:
@@ -182,6 +214,7 @@ def propose_changes(
     creations: list[dict] | None = None,
     fusions: list[dict] | None = None,
     renamings: list[dict] | None = None,
+    deletions: list[dict] | None = None,
     mappings_added: list[dict] | None = None,
 ) -> dict[str, Any]:
     """Écrit les 3 artefacts de proposition sur disque (read tree+mapping
@@ -217,6 +250,7 @@ def propose_changes(
         creations=creations or [],
         fusions=fusions or [],
         renamings=renamings or [],
+        deletions=deletions or [],
         mappings_added=mappings_added or [],
     )
     out_dir = _proposal_dir(profile, run_id)
@@ -230,12 +264,14 @@ def propose_changes(
         [c.model_dump() for c in changes.creations],
         [f.model_dump() for f in changes.fusions],
         [r.model_dump() for r in changes.renamings],
+        deletions=[d.model_dump() for d in changes.deletions],
     )
     new_mapping = _apply_changes_to_mapping(
         current_mapping,
         [m.model_dump() for m in changes.mappings_added],
         [r.model_dump() for r in changes.renamings],
         [f.model_dump() for f in changes.fusions],
+        deletions=[d.model_dump() for d in changes.deletions],
     )
 
     # Écritures
@@ -269,6 +305,7 @@ def propose_changes(
         "n_creations": len(changes.creations),
         "n_fusions": len(changes.fusions),
         "n_renamings": len(changes.renamings),
+        "n_deletions": len(changes.deletions),
         "n_mappings_added": len(changes.mappings_added),
         "n_folders_after": len(new_folders),
         "n_mappings_after": len(new_mapping),
@@ -299,6 +336,7 @@ def make_proposition_tools(profile: str, run_id: str) -> list[StructuredTool]:
         creations: list[dict] | None = None,
         fusions: list[dict] | None = None,
         renamings: list[dict] | None = None,
+        deletions: list[dict] | None = None,
         mappings_added: list[dict] | None = None,
     ) -> dict[str, Any]:
         """Écrit les artefacts de proposition (tree-proposed.yaml +
@@ -309,6 +347,9 @@ def make_proposition_tools(profile: str, run_id: str) -> list[StructuredTool]:
             creations: Liste de {path, rationale} — dossiers à créer.
             fusions: Liste de {sources, target, rationale} — dossiers à fusionner.
             renamings: Liste de {old_path, new_path, rationale} — dossiers à renommer.
+            deletions: Liste de {path, rationale} — dossiers à supprimer SANS fusion.
+                       Utiliser pour les dossiers vides obsolètes ou les doublons
+                       tranchants. Préférer `fusions` si les fichiers doivent migrer.
             mappings_added: Liste de {theme, folder, rationale} — nouveaux mappings.
         """
         return propose_changes(
@@ -317,6 +358,7 @@ def make_proposition_tools(profile: str, run_id: str) -> list[StructuredTool]:
             creations=creations,
             fusions=fusions,
             renamings=renamings,
+            deletions=deletions,
             mappings_added=mappings_added,
         )
 

--- a/tests/auto/test_agent_refonte_proposition.py
+++ b/tests/auto/test_agent_refonte_proposition.py
@@ -25,7 +25,9 @@ sys.path.insert(0, PROJECT_ROOT)
 
 from agents.refonte.proposition import (  # noqa: E402
     build_proposition_graph,
+    parse_catchall_folders_from_report,
     parse_orphan_mappings_from_report,
+    parse_underutilized_folders_from_report,
 )
 from agents.refonte.proposition_tools import propose_changes  # noqa: E402
 from dashboard import data  # noqa: E402
@@ -394,6 +396,102 @@ class TestParseOrphanMappings(unittest.TestCase):
         # Ordre préservé
         self.assertEqual(result[0]["theme"], "Functional Analysis")
         self.assertEqual(result[-1]["theme"], "Software Testing")
+
+
+class TestParseUnderutilizedFolders(unittest.TestCase):
+    """Parser pour la section 'Dossiers sous-utilisés' du rapport Phase A."""
+
+    def test_parses_underutilized_section(self):
+        md = """
+### Mappings manquants critiques (1 cas)
+- **Theme1** (10 fichiers) → dossier cible évident : `A/B`
+
+### Dossiers sous-utilisés avec thèmes orphelins correspondants (3 cas)
+**02-INFORMATIQUE/03-Langages-Programmation/Python** (0 fichier) ↔ thème orphelin "python programming" (320 occurrences)
+**01-SCIENCES/MATHEMATIQUES** (0 fichier) ↔ tous les sous-dossiers sont peuplés (normal)
+**08-LOISIRS/DESSIN** (0 fichier) – aucun thème orphelin associé
+
+### Catch-all qui débordent (1 cas)
+**/Autres** (4000 fichiers) – fourre-tout
+"""
+        result = parse_underutilized_folders_from_report(md)
+        self.assertEqual(len(result), 3)
+        self.assertEqual(result[0]["folder"], "02-INFORMATIQUE/03-Langages-Programmation/Python")
+        self.assertEqual(result[0]["count"], 0)
+        self.assertEqual(result[2]["folder"], "08-LOISIRS/DESSIN")
+        # Le note du 1er doit mentionner le thème orphelin
+        self.assertIn("python", result[0]["note"].lower())
+
+    def test_handles_thousands_with_spaces(self):
+        md = "### Dossiers sous-utilisés (1 cas)\n**A/B** (1 234 fichiers) – grosse note"
+        result = parse_underutilized_folders_from_report(md)
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0]["count"], 1234)
+
+    def test_returns_empty_when_section_absent(self):
+        md = "### Une autre section\n**A** (0 fichier) – note"
+        self.assertEqual(parse_underutilized_folders_from_report(md), [])
+
+
+class TestParseCatchallFolders(unittest.TestCase):
+    """Parser pour 'Catch-all qui débordent'."""
+
+    def test_parses_catchall_section(self):
+        md = """
+### Catch-all qui débordent (2 cas)
+1. **02-INFORMATIQUE/03-Langages-Programmation/Autres** (4 489 fichiers) – contient tous les langages non spécifiques
+2. **01-SCIENCES/MATHEMATIQUES/08-Mathematiques-Generales** (2 659 fichiers) – fourre-tout mathématique
+"""
+        result = parse_catchall_folders_from_report(md)
+        self.assertEqual(len(result), 2)
+        self.assertEqual(result[0]["folder"], "02-INFORMATIQUE/03-Langages-Programmation/Autres")
+        self.assertEqual(result[0]["count"], 4489)
+        self.assertEqual(result[1]["count"], 2659)
+
+    def test_returns_empty_for_non_analysed(self):
+        md = "### Catch-all qui débordent (non analysé)\n- Pas d'analyse effectuée"
+        self.assertEqual(parse_catchall_folders_from_report(md), [])
+
+
+class TestProposeChangesWithDeletions(_ProposBase):
+    """Sémantique des deletions ajoutée en B.3-ter."""
+
+    def test_deletion_removes_folder_from_tree(self):
+        result = propose_changes(
+            profile="p", run_id="del-1",
+            deletions=[{"path": "B", "rationale": "vide, plus utile"}],
+        )
+        self.assertEqual(result["n_deletions"], 1)
+        rundir = self.tmp / "profiles" / "p" / ".cache" / "refonte" / "del-1" / "proposed"
+        folders = yaml.safe_load((rundir / "tree-proposed.yaml").read_text())["folders"]
+        # B était dans le profil de base (cf. setUp _make_profile)
+        self.assertNotIn("B", folders)
+        # A et A/Python toujours là
+        self.assertIn("A", folders)
+        self.assertIn("A/Python", folders)
+
+    def test_deletion_drops_mappings_pointing_to_deleted_folder(self):
+        """Si on supprime B, le mapping 'data: B' doit disparaître."""
+        propose_changes(
+            profile="p", run_id="del-2",
+            deletions=[{"path": "B", "rationale": "vide"}],
+        )
+        rundir = self.tmp / "profiles" / "p" / ".cache" / "refonte" / "del-2" / "proposed"
+        mapping = yaml.safe_load((rundir / "theme_mapping-proposed.yaml").read_text())
+        # "data" pointait sur B → drop
+        self.assertNotIn("data", mapping)
+        # "python programming" pointait sur A/Python → toujours là
+        self.assertEqual(mapping["python programming"], "A/Python")
+
+    def test_rationale_md_includes_deletions_section(self):
+        propose_changes(
+            profile="p", run_id="del-3",
+            deletions=[{"path": "Z", "rationale": "à supprimer"}],
+        )
+        rationale = (self.tmp / "profiles" / "p" / ".cache" / "refonte" / "del-3"
+                     / "proposed" / "refonte-rationale.md").read_text()
+        self.assertIn("SUPPRESSIONS (1)", rationale)
+        self.assertIn("Z", rationale)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Suite à la question "est-ce que la proposition demande aussi la **suppression** et le **renommage** des éléments ?", refonte pour couvrir les **4 types d'anomalies** du diagnostic, pas seulement les mappings_added.

⚠️ PR ciblée sur l'intégration `feature/agent-refonte-phase-b`.

## Avant / Après

| Anomalie du diagnostic | Avant B.3-ter | Après B.3-ter |
|---|---|---|
| Mappings manquants | Pré-extrait + contrainte ≥ N-5 | ✓ inchangé |
| **Dossiers sous-utilisés** | Mention vague dans le prompt | **Pré-extrait + guide explicite (deletion / mapping / fusion selon le cas)** |
| **Catch-all qui débordent** | Mention vague dans le prompt | **Pré-extrait + guide creations + mappings vers sous-catégories** |
| **Suppression sèche** | Impossible sauf via fusion (sale) | **Nouvelle catégorie `deletions` propre** |
| Renommages | "Optionnel" | "Opportuniste" + guidé par les anomalies |
| Doublons sémantiques | "Optionnel" | Section dédiée fusions/renamings |

## Changements

### 1. Nouvelle catégorie `deletions`
- `_Deletion(path, rationale)` Pydantic
- Cascade : tree.yaml retire le folder + mapping drop les entrées qui pointaient dessus
- Section SUPPRESSIONS dans `refonte-rationale.md`

### 2. Parsers additionnels
- `parse_underutilized_folders_from_report(md)` → `[{folder, count, note}, ...]`
- `parse_catchall_folders_from_report(md)` → idem
- Helpers `_extract_section`, `_parse_int_with_spaces` (LLM écrit "4 489")

### 3. `_init_node` injecte 3 listes au lieu d'une
HumanMessage : Liste 1/3 (orphans), Liste 2/3 (sous-utilisés), Liste 3/3 (catch-all). Chaque liste vient avec un guide d'action explicite.

### 4. SYSTEM_PROMPT_B refactor
5 sections numérotées (une par catégorie d'action), chacune **DRIVEN par** une liste pré-extraite ou un signal du diagnostic. Exemple d'appel correct étoffé avec `deletions` et `fusions`.

## Tests

- 3 tests `TestParseUnderutilizedFolders`
- 2 tests `TestParseCatchallFolders`
- 3 tests `TestProposeChangesWithDeletions`
- **904 tests** suite complète (+8), ruff clean

## Suite

- **B.4** : smoke run réel sur `default` pour mesurer les 4 améliorations cumulées (B.3 + B.3-bis + B.3-ter). Si la proposition livre maintenant 25+ mappings + quelques deletions/fusions/creations → PR final phase-b → develop

🤖 Generated with [Claude Code](https://claude.com/claude-code)