### PR TITLE
feat(agents): Phase B — Proposition de refonte de taxonomie

### DIFF
--- a/agents/llm.py
+++ b/agents/llm.py
@@ -33,7 +33,9 @@ DEFAULT_MODEL = "zai-org/GLM-4.7"  # stable + tool-use FR (2026-05-25)
 # Test rapide en cas de doute : `curl https://api.siliconflow.com/v1/models`
 # pour voir la liste live, puis vérifier que le modèle suit un prompt FR.
 DEFAULT_BASE_URL = "https://api.siliconflow.com/v1"
-DEFAULT_TIMEOUT_S = 180  # 3 min par appel LLM — write_report peut prendre 60-120s, marge pour SiliconFlow lent
+DEFAULT_TIMEOUT_S = 300  # 5 min par appel LLM — Phase B avec payload ~6k tokens
+# peut prendre >180s côté SiliconFlow quand le provider est chargé
+# (cf. run 3f290cee : timeout à 185s sur GLM-4.7 en heures de pointe).
 
 
 def get_agent_llm(

--- a/agents/llm.py
+++ b/agents/llm.py
@@ -1,10 +1,12 @@
 """Factory LLM partagée entre tous les agents Klodo.
 
-Par défaut, pointe sur SiliconFlow avec DeepSeek-V3.1 (version stable, bon
-ratio raisonnement/prix, ~$0.27/$1.10 par M tokens, function calling natif).
+Par défaut, pointe sur SiliconFlow avec GLM-4.7 (stable, tool-use propre,
+suit bien les prompts FR — testé 2026-05-25 face à des `APIConnectionError`
+récurrents sur DeepSeek-V3.2 côté SiliconFlow).
 
 Le modèle est surchargeable via la variable d'env `KLODO_AGENT_MODEL`
-(par ex. pour tester GLM-4.6 ou Qwen3 free tier).
+(par ex. pour repasser sur DeepSeek-V3.2 quand l'instabilité côté
+SiliconFlow sera résorbée).
 
 L'endpoint est compatible OpenAI — `langchain_openai.ChatOpenAI` est
 le client adéquat (pas besoin de wrapper custom).
@@ -16,16 +18,18 @@ import os
 
 from langchain_openai import ChatOpenAI
 
-DEFAULT_MODEL = "deepseek-ai/DeepSeek-V3.2"  # version stable optimisée tool-use
-# Choix de modèle (mis à jour 2026-05-25 après tests réels) :
-#   - V3.2 (stable, recommandé) — fine-tuné tool-use, suit bien les prompts FR
-#   - V3.2-Exp : DÉSACTIVÉ ce soir sans préavis (le piège des -Exp)
-#   - V3.1 : régresse vers le chinois et hallucine sur prompts multi-tour
-#     complexes (testé → produit un problème d'algo chinois au lieu du
-#     rapport demandé)
-#   - V4-Pro : très récent, peut servir en backup (tool-use OK)
-#   - GLM-4.7 / GLM-5 : alternatives non-DeepSeek si SiliconFlow coupe
-#     toute la famille DeepSeek (peu probable mais possible)
+DEFAULT_MODEL = "zai-org/GLM-4.7"  # stable + tool-use FR (2026-05-25)
+# Choix de modèle (mis à jour 2026-05-25 après plusieurs erreurs DeepSeek) :
+#   - GLM-4.7 (défaut courant) — stable, tool-use FR propre, ~9s/réponse libre,
+#     ~2s en tool-call. Pas d'APIConnectionError observée.
+#   - GLM-5 / GLM-5.1 : alternatives plus récentes, OK en tool-use, à utiliser
+#     si GLM-4.7 régresse.
+#   - DeepSeek-V3.2 : tool-use excellent quand ça marche mais
+#     `APIConnectionError` récurrent côté SiliconFlow en mai 2026 (cf. run
+#     47377f35 — 7 LLM calls puis erreur).
+#   - DeepSeek-V3.2-Exp : désactivé sans préavis sur SiliconFlow (piège -Exp).
+#   - DeepSeek-V3.1 : régresse vers le chinois sur prompts multi-tour
+#     complexes (a produit un problème d'algo chinois au lieu du rapport).
 # Test rapide en cas de doute : `curl https://api.siliconflow.com/v1/models`
 # pour voir la liste live, puis vérifier que le modèle suit un prompt FR.
 DEFAULT_BASE_URL = "https://api.siliconflow.com/v1"
@@ -43,7 +47,7 @@ def get_agent_llm(
     """Construit un ChatOpenAI configuré pour SiliconFlow.
 
     Args:
-        model: ID du modèle (ex. "deepseek-ai/DeepSeek-V3.1"). Si None,
+        model: ID du modèle (ex. "zai-org/GLM-4.7"). Si None,
                lit `KLODO_AGENT_MODEL` puis fallback sur DEFAULT_MODEL.
         temperature: Default 0.1 — bas pour raisonnement structuré + consistance
                      entre runs (à 0.2 on observait une variance importante de

--- a/agents/llm.py
+++ b/agents/llm.py
@@ -78,5 +78,14 @@ def get_agent_llm(
         api_key=resolved_key,
         temperature=temperature,
         timeout=timeout if timeout is not None else DEFAULT_TIMEOUT_S,
+        # streaming=True : on consomme les chunks au fur et à mesure plutôt que
+        # d'attendre la réponse complète. CRITIQUE pour Phase B : SiliconFlow
+        # ferme la connexion serveur-side à ~90s si aucun chunk n'a été émis
+        # ("RemoteProtocolError: Server disconnected"). Avec streaming, le
+        # 1er chunk arrive en < 10s et la connexion reste ouverte jusqu'à la
+        # fin de la génération (testé : 356s/10k chunks/41k chars sans coupure).
+        # ChatOpenAI gère le streaming en interne et reconstruit l'AIMessage
+        # avec tool_calls — transparent pour .invoke().
+        streaming=True,
         max_retries=1,
     )

--- a/agents/refonte/proposition.py
+++ b/agents/refonte/proposition.py
@@ -1,0 +1,298 @@
+"""Graphe Phase B — Proposition (read + side YAMLs).
+
+Topologie :
+
+    START → init → [conditional]
+                    │ status=error → END (court-circuit)
+                    │ ok → analyze ← ─ ┐
+                              │      tools (read-only A.2 + propose_changes)
+                              │       ↑
+                              └───────┘   (boucle ReAct)
+                              │ no tool_call OU propose_changes appelé
+                              ↓
+                            finalize → END
+
+`init` :
+  - valide profile + diagnostic_run_id en input
+  - lit le rapport Phase A correspondant et l'injecte comme contexte
+  - amorce les messages avec system + human prompts
+
+`analyze` (= explore en Phase A) :
+  - LLM avec accès aux 6 outils read-only A.2 + au tool mutable propose_changes
+  - boucle ReAct jusqu'à ce que propose_changes soit appelé OU plus de tool_call
+
+`finalize` :
+  - vérifie qu'un proposal a été écrit
+  - met status=done + remplit proposal_dir + proposal_summary dans le state
+"""
+
+from __future__ import annotations
+
+import json
+import uuid
+from pathlib import Path
+from typing import Any, Literal
+
+from langchain_core.language_models import BaseChatModel
+from langchain_core.messages import AIMessage, HumanMessage, SystemMessage, ToolMessage
+from langgraph.graph import END, START, StateGraph
+from langgraph.prebuilt import ToolNode
+
+from agents.llm import get_agent_llm
+from agents.refonte.proposition_tools import make_proposition_tools
+from agents.refonte.state import RefonteState
+from agents.refonte.tools import TOOLS as READ_TOOLS
+from dashboard import data
+
+DEFAULT_MAX_LLM_CALLS = 8
+
+SYSTEM_PROMPT_B = """Tu es l'agent IA Klodo en **Phase B (Proposition)**.
+
+Ton objectif : à partir du **diagnostic Phase A** fourni en contexte, **proposer
+une refonte concrète** de la taxonomie. Tu écris des fichiers YAML "proposed"
+en side (jamais sur les YAMLs de production) qui seront ensuite simulés et,
+éventuellement, appliqués par Phase C après validation utilisateur.
+
+Tu disposes de 9 outils :
+
+**Outils de lecture (validation / cross-check du diagnostic)** :
+  - list_folders(profile)
+  - count_files_per_folder(profile)
+  - read_theme_mapping(profile)
+  - list_themes_per_folder(profile)
+  - compute_folder_overlap(profile, folder_a, folder_b)
+  - get_classifier_breakdown(profile)
+  - list_vision_themes(profile, top_n=50)
+  - find_orphan_themes(profile, top_n=30)
+
+**Outil mutable (écrit les YAMLs proposed — UNE seule fois par run)** :
+  - propose_changes(creations, fusions, renamings, mappings_added)
+
+Stratégie efficace (5-7 tool calls) :
+  1. Lis le diagnostic ci-dessous. Il liste les anomalies (mappings manquants,
+     dossiers sous-utilisés, catch-all qui débordent, doublons sémantiques).
+  2. Si besoin, vérifie 1-2 cas via les outils read-only (ex. confirmer un
+     thème orphelin via find_orphan_themes).
+  3. Construis ta proposition complète, puis appelle propose_changes(...)
+     **une seule fois** avec tous les changements groupés.
+
+Conventions importantes pour propose_changes :
+  - `creations` : nouveaux dossiers (path relatif depuis le target).
+  - `fusions` : `sources` = liste de paths existants, `target` = path destination
+    (peut être un path créé par `creations` ou un dossier existant).
+  - `renamings` : changement de nom d'un dossier existant.
+  - `mappings_added` : pour chaque thème orphelin du diagnostic, mappe-le vers
+    son dossier cible évident. PRIORITÉ : c'est ça qui débloque le plus de
+    fichiers mal classés. Ajoute 15-30 mappings si le diagnostic en propose
+    autant.
+
+Chaque entrée doit avoir un champ `rationale` court (1-2 phrases) qui justifie
+le choix — c'est ce qui apparaîtra dans `refonte-rationale.md`.
+
+**Règles absolues** :
+  - N'invente PAS de thèmes ou de chemins : utilise uniquement ceux du
+    diagnostic ou retournés par les outils de lecture.
+  - Les chemins cibles des `mappings_added` doivent exister dans `tree.yaml`
+    courant OU être créés via `creations`.
+  - Sois EXHAUSTIF sur les mappings_added (15-30+ si le diagnostic les liste) —
+    c'est l'action à plus haut ROI.
+
+Quand tu as appelé propose_changes une fois avec succès, **réponds sans appeler
+d'autre outil** — Phase B est terminée."""
+
+
+# ─── Nœuds ──────────────────────────────────────────────────────────────────
+
+
+def _read_diagnostic_report(profile: str, diagnostic_run_id: str) -> str | None:
+    """Lit le report.md du run de diagnostic Phase A référencé."""
+    report_path = (
+        data.get_project_root()
+        / "profiles" / profile / ".cache" / "refonte"
+        / diagnostic_run_id / "report.md"
+    )
+    if not report_path.exists():
+        return None
+    try:
+        return report_path.read_text(encoding="utf-8")
+    except OSError:
+        return None
+
+
+def _init_node(state: RefonteState) -> dict[str, Any]:
+    """Valide profile + diagnostic_run_id et amorce les messages.
+
+    Lecture du rapport Phase A injectée comme contexte HumanMessage —
+    l'agent Phase B s'appuie dessus pour générer la proposition.
+    """
+    if not state.get("profile"):
+        return {"status": "error", "error": "profile is required"}
+    diagnostic_run_id = state.get("diagnostic_run_id")
+    if not diagnostic_run_id:
+        return {
+            "status": "error",
+            "error": "diagnostic_run_id is required (run de Phase A à utiliser comme contexte)",
+        }
+    profile = state["profile"]
+    diagnostic_md = _read_diagnostic_report(profile, diagnostic_run_id)
+    if diagnostic_md is None:
+        return {
+            "status": "error",
+            "error": (
+                f"Rapport de diagnostic introuvable pour run_id={diagnostic_run_id} "
+                f"(profile={profile}). Vérifie qu'une Phase A a bien terminé "
+                f"avec status=done sur ce run avant de lancer Phase B."
+            ),
+        }
+    return {
+        "phase": "B",
+        "run_id": state.get("run_id") or str(uuid.uuid4()),
+        "status": "running",
+        "llm_calls": 0,
+        "messages": [
+            SystemMessage(content=SYSTEM_PROMPT_B),
+            HumanMessage(
+                content=(
+                    f"Voici le diagnostic Phase A du profil `{profile}` à utiliser "
+                    f"comme base de ta proposition :\n\n---\n{diagnostic_md}\n---\n\n"
+                    f"Propose maintenant une refonte via propose_changes. "
+                    f"Sois exhaustif sur les mappings_added."
+                ),
+            ),
+        ],
+    }
+
+
+def _make_analyze_node(llm_with_tools: BaseChatModel, max_calls: int):
+    """Boucle ReAct Phase B — équivalent du `explore` de Phase A."""
+
+    def analyze(state: RefonteState) -> dict[str, Any]:
+        n = state.get("llm_calls", 0)
+        if n >= max_calls:
+            stop_msg = SystemMessage(
+                content=(
+                    "Budget d'appels atteint. Si tu n'as pas encore appelé "
+                    "propose_changes, fais-le maintenant avec ce que tu as en "
+                    "main, sinon termine sans nouvel appel d'outil."
+                ),
+            )
+            response = llm_with_tools.invoke(list(state["messages"]) + [stop_msg])
+        else:
+            response = llm_with_tools.invoke(state["messages"])
+        return {
+            "messages": [response],
+            "llm_calls": n + 1,
+        }
+
+    return analyze
+
+
+def _route_after_init(state: RefonteState) -> Literal["analyze", "__end__"]:
+    if state.get("status") == "error":
+        return "__end__"
+    return "analyze"
+
+
+def _route_after_analyze(state: RefonteState) -> Literal["tools", "finalize"]:
+    """Si l'AI dernier message a des tool_calls → exécuter les outils.
+    Sinon → finalize.
+    """
+    last = state["messages"][-1] if state.get("messages") else None
+    if isinstance(last, AIMessage) and getattr(last, "tool_calls", None):
+        return "tools"
+    return "finalize"
+
+
+def _finalize_node(state: RefonteState) -> dict[str, Any]:
+    """Termine le run — vérifie qu'un proposal a bien été écrit."""
+    messages = list(state.get("messages") or [])
+    # Cherche le dernier ToolMessage venant d'un appel propose_changes
+    proposal_result = None
+    for m in reversed(messages):
+        if isinstance(m, ToolMessage) and m.name == "propose_changes":
+            try:
+                proposal_result = json.loads(m.content) if isinstance(m.content, str) else m.content
+            except (json.JSONDecodeError, TypeError):
+                proposal_result = {"raw": str(m.content)}
+            break
+    if not proposal_result:
+        return {
+            "status": "error",
+            "error": (
+                "L'agent n'a pas appelé propose_changes — aucune proposition "
+                "n'a été générée. Probablement un problème de prompt ou de modèle."
+            ),
+        }
+    # Récupère le proposal_dir depuis le tool result
+    tree_path = proposal_result.get("tree_proposed_path", "")
+    proposal_dir = str(Path(tree_path).parent) if tree_path else ""
+    return {
+        "status": "done",
+        "proposal_dir": proposal_dir,
+        "proposal_summary": {
+            "n_creations": proposal_result.get("n_creations", 0),
+            "n_fusions": proposal_result.get("n_fusions", 0),
+            "n_renamings": proposal_result.get("n_renamings", 0),
+            "n_mappings_added": proposal_result.get("n_mappings_added", 0),
+            "n_folders_after": proposal_result.get("n_folders_after", 0),
+            "n_mappings_after": proposal_result.get("n_mappings_after", 0),
+        },
+    }
+
+
+# ─── Construction du graphe ───────────────────────────────────────────────
+
+
+def build_proposition_graph(
+    profile: str,
+    run_id: str,
+    llm: BaseChatModel | None = None,
+    *,
+    max_llm_calls: int = DEFAULT_MAX_LLM_CALLS,
+):
+    """Construit le graphe Phase B pour un run spécifique.
+
+    `profile` + `run_id` sont nécessaires au build pour binder le tool
+    propose_changes en closure (le LLM ne les voit jamais). En revanche
+    `diagnostic_run_id` est lu depuis le state par `_init_node` — le caller
+    le passe via `graph.invoke({"profile": ..., "diagnostic_run_id": ...})`.
+
+    Args:
+        profile: Nom du profil cible.
+        run_id: UUID du run Phase B (généré par le caller).
+        llm: ChatModel. Default = get_agent_llm() (SiliconFlow DeepSeek V3.2).
+        max_llm_calls: Budget pour la boucle ReAct (default 8, plus haut que
+                       Phase A car la proposition est plus complexe).
+
+    Returns:
+        Compiled LangGraph.
+    """
+    if llm is None:
+        llm = get_agent_llm()
+    tools = READ_TOOLS + make_proposition_tools(profile, run_id)
+    llm_with_tools = llm.bind_tools(tools)
+
+    builder = StateGraph(RefonteState)
+    builder.add_node("init", _init_node)
+    builder.add_node("analyze", _make_analyze_node(llm_with_tools, max_llm_calls))
+    builder.add_node("tools", ToolNode(tools))
+    builder.add_node("finalize", _finalize_node)
+
+    builder.add_edge(START, "init")
+    builder.add_conditional_edges(
+        "init",
+        _route_after_init,
+        {"analyze": "analyze", "__end__": END},
+    )
+    builder.add_conditional_edges(
+        "analyze",
+        _route_after_analyze,
+        {"tools": "tools", "finalize": "finalize"},
+    )
+    builder.add_edge("tools", "analyze")
+    builder.add_edge("finalize", END)
+
+    return builder.compile()
+
+
+__all__ = ["build_proposition_graph", "DEFAULT_MAX_LLM_CALLS"]

--- a/agents/refonte/proposition.py
+++ b/agents/refonte/proposition.py
@@ -43,6 +43,7 @@ from agents.llm import get_agent_llm
 from agents.refonte.proposition_tools import make_proposition_tools
 from agents.refonte.state import RefonteState
 from agents.refonte.tools import TOOLS as READ_TOOLS
+from agents.refonte.tools import find_orphan_themes
 from dashboard import data
 
 DEFAULT_MAX_LLM_CALLS = 6  # 6 suffit largement avec la pré-extraction d'orphelins
@@ -73,14 +74,20 @@ qui adresse les 4 types d'anomalies du diagnostic, pas seulement les mappings.
 **1. mappings_added — DRIVEN par la liste pré-extraite « orphan mappings »**
 
 Pour CHAQUE entrée de cette liste, tu DOIS produire un mapping. Si la liste
-contient 30 entrées, ton appel doit avoir AU MINIMUM 25 mappings_added.
-Une proposition avec 0 mapping_added est un ÉCHEC.
+contient N entrées, ton appel doit avoir au moins **N-10** mappings_added.
+Une proposition avec 0 mapping_added est un ÉCHEC. La liste peut contenir
+30, 100, 200 entrées — adapte-toi au volume, ne tronque pas.
 
-**2. creations — DRIVEN par les target_folder des mappings**
+Pour chaque entrée la liste peut contenir un champ `target_folder_suggested`
+(héritage du diagnostic markdown) — utilise-le quand il est présent. Si
+absent (orphelins au-delà du top 30 du diagnostic), tu choisis toi-même la
+destination en t'appuyant sur tree.yaml et le sens du thème.
 
-Si une `target_folder` (de la liste orphans) n'existe pas dans tree.yaml,
-ajoute-la dans `creations`. Aussi : si un catch-all est trop gros, créer
-des sous-dossiers où ses fichiers iront naturellement.
+**2. creations — DRIVEN par les destinations des mappings**
+
+Si la destination d'un mapping (suggérée ou choisie par toi) n'existe pas
+dans tree.yaml, ajoute-la dans `creations`. Aussi : si un catch-all est
+trop gros, créer des sous-dossiers où ses fichiers iront naturellement.
 
 **3. deletions — DRIVEN par les dossiers sous-utilisés sans rescousse**
 
@@ -130,14 +137,14 @@ mappings_added quand pertinent. Pour les deletions, justifie pourquoi
   "mappings_added": [
     {"theme": "Functional Analysis", "folder": "01-SCIENCES/MATHEMATIQUES/02-Analyse",
      "rationale": "176 fichiers — analyse fonctionnelle"},
-    /* ... 25-30 entrées au total ... */
+    /* ... une entrée par item de la liste orphan mappings ... */
   ]
 }
 ```
 
 ═══════ Anti-patterns à éviter ═══════
 
-- ❌ Ne livrer que 2-3 mappings alors que la liste pré-extraite en a 30
+- ❌ Ne livrer que 2-3 mappings alors que la liste pré-extraite en a 50+
 - ❌ Ignorer les dossiers sous-utilisés et les catch-all (toi seul peux
   décider "delete vs. map vs. fuse")
 - ❌ Appeler des outils en boucle pour "redécouvrir" ce qui est déjà
@@ -330,15 +337,54 @@ def _init_node(state: RefonteState) -> dict[str, Any]:
                 f"avec status=done sur ce run avant de lancer Phase B."
             ),
         }
-    # Pré-extraction des 3 catégories d'anomalies depuis le rapport — on
-    # sert au LLM des listes JSON pré-mâchées plutôt que de lui faire
-    # ré-extraire du markdown (ça avait produit des propositions vides en
-    # premier essai 2026-05-25).
-    orphans = parse_orphan_mappings_from_report(diagnostic_md)
+    # Pré-extraction des 3 catégories d'anomalies — on sert au LLM des
+    # listes JSON pré-mâchées plutôt que de lui faire ré-extraire du markdown
+    # (ça avait produit des propositions vides en premier essai 2026-05-25).
+    #
+    # Orphan mappings : appel direct à find_orphan_themes (cap 200) pour
+    # avoir une vue exhaustive — le markdown du diagnostic en cite seulement
+    # ~30 par soucis de lisibilité humaine, ce qui plafonnait Phase B à 58 %
+    # de couverture sur le profil default. On enrichit chaque orphelin avec
+    # la suggestion de target_folder du diagnostic quand elle existe (top 30) ;
+    # pour les suivants le LLM B propose lui-même la destination.
+    try:
+        all_orphans = find_orphan_themes(profile, top_n=200)
+    except Exception:  # noqa: BLE001 — on dégrade gracieusement
+        all_orphans = []
+    markdown_orphans = parse_orphan_mappings_from_report(diagnostic_md)
+    suggested_targets = {m["theme"]: m["target_folder"] for m in markdown_orphans}
+    orphans: list[dict[str, Any]] = []
+    if all_orphans:
+        for o in all_orphans:
+            theme = o.get("theme", "")
+            if not theme:
+                continue
+            entry: dict[str, Any] = {
+                "theme": theme,
+                "count": o.get("count", 0),
+            }
+            target = suggested_targets.get(theme)
+            if target:
+                entry["target_folder_suggested"] = target
+            sample = o.get("sample_titles") or []
+            if sample:
+                entry["sample_titles"] = sample[:2]
+            orphans.append(entry)
+    else:
+        # Fallback : find_orphan_themes a échoué (pas de vision_cache, IO error)
+        # → on retombe sur l'extraction markdown du diagnostic. Pas exhaustif
+        # mais évite de partir avec une proposition vide.
+        for m in markdown_orphans:
+            orphans.append({
+                "theme": m["theme"],
+                "count": m["count"],
+                "target_folder_suggested": m["target_folder"],
+            })
+
     underutilized = parse_underutilized_folders_from_report(diagnostic_md)
     catchall = parse_catchall_folders_from_report(diagnostic_md)
 
-    expected_min = max(0, len(orphans) - 5)  # tolérance sur les mappings
+    expected_min = max(0, len(orphans) - 10)  # tolérance ±10 sur les mappings
 
     human_content_parts = [
         f"Voici le diagnostic Phase A du profil `{profile}` :",

--- a/agents/refonte/proposition.py
+++ b/agents/refonte/proposition.py
@@ -52,38 +52,64 @@ SYSTEM_PROMPT_B = """Tu es l'agent IA Klodo en **Phase B (Proposition)**.
 
 Tu reçois en entrée :
   - le rapport markdown du diagnostic Phase A
-  - **une LISTE PRÉ-EXTRAITE des mappings orphelins** (JSON) directement utilisable
+  - **3 listes JSON pré-extraites** (mappings orphelins, dossiers sous-utilisés,
+    catch-all qui débordent) directement utilisables
 
-Ta tâche : appeler **propose_changes** UNE FOIS avec une proposition COMPLÈTE.
+Ta tâche : appeler **propose_changes** UNE FOIS avec une proposition COMPLÈTE
+qui adresse les 4 types d'anomalies du diagnostic, pas seulement les mappings.
 
 ═══════ Outils disponibles ═══════
 
-**Lecture (cross-check si besoin, mais la liste pré-extraite suffit dans 90% des cas)** :
-  - list_folders(profile), count_files_per_folder(profile)
-  - read_theme_mapping(profile), list_themes_per_folder(profile)
-  - compute_folder_overlap(profile, a, b)
-  - list_vision_themes(profile, top_n=50)
-  - find_orphan_themes(profile, top_n=30)
+**Lecture (cross-check si besoin)** :
+  - list_folders, count_files_per_folder, read_theme_mapping,
+    list_themes_per_folder, compute_folder_overlap, get_classifier_breakdown,
+    list_vision_themes(top_n=50), find_orphan_themes(top_n=30)
 
 **Mutable (UNE seule fois par run, à la fin)** :
-  - propose_changes(creations, fusions, renamings, mappings_added)
+  - propose_changes(creations, fusions, renamings, deletions, mappings_added)
 
-═══════ Contraintes IMPÉRATIVES sur propose_changes ═══════
+═══════ Contraintes par type d'anomalie ═══════
 
-1. **mappings_added : exhaustif, pas symbolique.** Pour CHAQUE entrée de la
-   liste pré-extraite, tu DOIS produire un mapping. Si la liste contient 30
-   entrées, ton appel doit avoir AU MINIMUM 25 mappings_added (tolérance : tu
-   peux retirer 5 entrées que tu juges hors scope, mais tu DOIS justifier).
-   Une proposition avec 0 mapping_added est un ÉCHEC.
+**1. mappings_added — DRIVEN par la liste pré-extraite « orphan mappings »**
 
-2. **creations** : si une `target_folder` d'un orphelin n'existe pas encore
-   dans tree.yaml, crée-la (ajoute-la dans `creations`).
+Pour CHAQUE entrée de cette liste, tu DOIS produire un mapping. Si la liste
+contient 30 entrées, ton appel doit avoir AU MINIMUM 25 mappings_added.
+Une proposition avec 0 mapping_added est un ÉCHEC.
 
-3. **fusions / renamings** : optionnels, basés sur les anomalies de doublons
-   sémantiques du diagnostic. Pas obligatoires si le diagnostic n'en a pas vu.
+**2. creations — DRIVEN par les target_folder des mappings**
 
-4. **rationale** par entrée : 1 phrase courte, factuelle. Cite le count
-   d'occurrences pour les mappings_added quand pertinent.
+Si une `target_folder` (de la liste orphans) n'existe pas dans tree.yaml,
+ajoute-la dans `creations`. Aussi : si un catch-all est trop gros, créer
+des sous-dossiers où ses fichiers iront naturellement.
+
+**3. deletions — DRIVEN par les dossiers sous-utilisés sans rescousse**
+
+Pour CHAQUE dossier de la liste « sous-utilisés », évalue :
+  - Si un thème orphelin pointe naturellement vers lui → ajoute un mapping
+    (cas le plus fréquent : le dossier est vide *parce que* le mapping
+    manque) → PAS de deletion
+  - Si le dossier est vide ET aucun thème orphelin n'évoque sémantiquement
+    son nom → propose une `deletion` (folder mort)
+  - Si plusieurs dossiers sous-utilisés sont proches sémantiquement →
+    propose une `fusion`
+
+**4. fusions — DRIVEN par les doublons sémantiques + les catch-all**
+
+  - Doublons sémantiques (Jaccard élevé) → fusion (ou renaming si l'un
+    des deux a un meilleur nom)
+  - Catch-all trop gros : crée les sous-catégories via `creations` +
+    ajoute des mappings_added vers les sous-catégories. Pas de fusion ici.
+
+**5. renamings — opportuniste**
+
+Si un dossier a un nom peu informatif ou redondant (ex. `/Generale`
+contenant 2 000 fichiers très ciblés), propose un renaming.
+
+═══════ rationale par entrée ═══════
+
+1 phrase courte, factuelle. Cite les counts d'occurrences pour les
+mappings_added quand pertinent. Pour les deletions, justifie pourquoi
+**aucun** orphelin ne s'y raccroche.
 
 ═══════ Exemple d'appel correct ═══════
 
@@ -93,14 +119,18 @@ Ta tâche : appeler **propose_changes** UNE FOIS avec une proposition COMPLÈTE.
     {"path": "01-SCIENCES/CHIMIE/04-Science-des-Materiaux",
      "rationale": "78 fichiers Materials Science orphelins"}
   ],
+  "deletions": [
+    {"path": "08-LOISIRS/DESSIN",
+     "rationale": "0 fichier et aucun thème orphelin lié au dessin observé"}
+  ],
+  "fusions": [
+    {"sources": ["07-LANGUES/AUTRES"], "target": "07-LANGUES",
+     "rationale": "AUTRES vide, on consolide à la racine LANGUES"}
+  ],
   "mappings_added": [
     {"theme": "Functional Analysis", "folder": "01-SCIENCES/MATHEMATIQUES/02-Analyse",
-     "rationale": "176 fichiers — analyse fonctionnelle classique"},
-    {"theme": "Complex Analysis", "folder": "01-SCIENCES/MATHEMATIQUES/02-Analyse",
-     "rationale": "114 fichiers — analyse complexe"},
-    {"theme": "Group Theory", "folder": "01-SCIENCES/MATHEMATIQUES/01-Algebre",
-     "rationale": "112 fichiers — algèbre"}
-    /* ... 15-30 entrées au total ... */
+     "rationale": "176 fichiers — analyse fonctionnelle"},
+    /* ... 25-30 entrées au total ... */
   ]
 }
 ```
@@ -108,10 +138,12 @@ Ta tâche : appeler **propose_changes** UNE FOIS avec une proposition COMPLÈTE.
 ═══════ Anti-patterns à éviter ═══════
 
 - ❌ Ne livrer que 2-3 mappings alors que la liste pré-extraite en a 30
-- ❌ Appeler des outils de lecture en boucle pour "redécouvrir" ce qui est
-  déjà dans la liste pré-extraite
-- ❌ Inventer des `theme` ou `folder` qui ne sont pas dans la liste ou
-  dans tree.yaml
+- ❌ Ignorer les dossiers sous-utilisés et les catch-all (toi seul peux
+  décider "delete vs. map vs. fuse")
+- ❌ Appeler des outils en boucle pour "redécouvrir" ce qui est déjà
+  dans les listes pré-extraites
+- ❌ Inventer des `theme` ou `folder` qui ne sont ni dans les listes
+  pré-extraites ni dans tree.yaml
 
 Quand tu as appelé propose_changes avec succès, **termine sans nouvel outil**."""
 
@@ -132,6 +164,87 @@ _TARGET_LABEL_RE = re.compile(
     r"^\s*(?:dossier\s+cible\s*(?:évident)?|cible|target)\s*[:：]\s*",
     re.IGNORECASE,
 )
+
+
+# Matche les listes type :
+#   - **02-INFORMATIQUE/03-Langages-Programmation/Python** (0 fichier) ↔ ...
+#   - **/Path/Folder** (1 234 fichiers) – description
+# La capture extrait : folder_path + count + reste (description).
+_FOLDER_COUNT_RE = re.compile(
+    r"^\s*(?:[-*]|\d+\.)?\s*\*\*([^*]+?)\*\*\s*\(([\d\s]+?)\s*fichiers?\)\s*"
+    r"(?:[↔–\-])\s*(.+?)\s*$",
+    re.MULTILINE,
+)
+
+
+def _parse_int_with_spaces(s: str) -> int | None:
+    """Parse '4 489' → 4489 (le LLM utilise parfois des espaces comme thousands)."""
+    try:
+        return int(s.replace(" ", "").replace(" ", ""))
+    except (ValueError, AttributeError):
+        return None
+
+
+def _extract_section(report_md: str, header_regex: str) -> str:
+    """Extrait le contenu d'une section h3 du rapport markdown.
+
+    Retourne le texte entre le header matché et le prochain h2/h3, ou ''
+    si le header n'est pas trouvé.
+    """
+    h_re = re.compile(r"^###\s+" + header_regex, re.MULTILINE | re.IGNORECASE)
+    m = h_re.search(report_md)
+    if not m:
+        return ""
+    start = m.end()
+    # Cherche le prochain h2/h3
+    next_h = re.search(r"^##+\s+", report_md[start:], re.MULTILINE)
+    end = start + next_h.start() if next_h else len(report_md)
+    return report_md[start:end]
+
+
+def parse_underutilized_folders_from_report(report_md: str) -> list[dict[str, Any]]:
+    """Extrait les dossiers sous-utilisés (avec ou sans thèmes orphelins).
+
+    Cherche la section `### Dossiers sous-utilisés...` et parse les lignes
+    `**folder_path** (N fichier(s)) ↔/– description`.
+
+    Returns:
+        Liste de {"folder": str, "count": int, "note": str}.
+    """
+    if not report_md:
+        return []
+    section = _extract_section(report_md, r"dossiers?\s+sous[-\s]?utilis")
+    if not section:
+        return []
+    results: list[dict[str, Any]] = []
+    for m in _FOLDER_COUNT_RE.finditer(section):
+        folder = m.group(1).strip().strip("`")
+        count = _parse_int_with_spaces(m.group(2))
+        note = m.group(3).strip()
+        if folder and count is not None:
+            results.append({"folder": folder, "count": count, "note": note})
+    return results
+
+
+def parse_catchall_folders_from_report(report_md: str) -> list[dict[str, Any]]:
+    """Extrait les dossiers catch-all qui débordent.
+
+    Cherche la section `### Catch-all qui débordent` et parse les lignes
+    `**folder_path** (N fichiers) – description`.
+    """
+    if not report_md:
+        return []
+    section = _extract_section(report_md, r"catch[-\s]?all\s+qui\s+d[ée]bordent")
+    if not section:
+        return []
+    results: list[dict[str, Any]] = []
+    for m in _FOLDER_COUNT_RE.finditer(section):
+        folder = m.group(1).strip().strip("`")
+        count = _parse_int_with_spaces(m.group(2))
+        note = m.group(3).strip()
+        if folder and count is not None:
+            results.append({"folder": folder, "count": count, "note": note})
+    return results
 
 
 def parse_orphan_mappings_from_report(report_md: str) -> list[dict[str, Any]]:
@@ -217,11 +330,15 @@ def _init_node(state: RefonteState) -> dict[str, Any]:
                 f"avec status=done sur ce run avant de lancer Phase B."
             ),
         }
-    # Pré-extraction des mappings orphelins du rapport — on les sert au LLM
-    # en JSON pré-mâché plutôt que de lui faire ré-extraire du markdown.
+    # Pré-extraction des 3 catégories d'anomalies depuis le rapport — on
+    # sert au LLM des listes JSON pré-mâchées plutôt que de lui faire
+    # ré-extraire du markdown (ça avait produit des propositions vides en
+    # premier essai 2026-05-25).
     orphans = parse_orphan_mappings_from_report(diagnostic_md)
-    orphans_json = json.dumps(orphans, ensure_ascii=False, indent=2)
-    expected_min = max(0, len(orphans) - 5)  # tolérance : -5 du total
+    underutilized = parse_underutilized_folders_from_report(diagnostic_md)
+    catchall = parse_catchall_folders_from_report(diagnostic_md)
+
+    expected_min = max(0, len(orphans) - 5)  # tolérance sur les mappings
 
     human_content_parts = [
         f"Voici le diagnostic Phase A du profil `{profile}` :",
@@ -231,29 +348,57 @@ def _init_node(state: RefonteState) -> dict[str, Any]:
         "---",
         "",
     ]
+
     if orphans:
         human_content_parts += [
-            f"**Mappings orphelins pré-extraits** (n={len(orphans)}) — utilise CETTE liste",
-            "comme base de `mappings_added`, **pas le markdown ci-dessus** :",
-            "",
+            f"**Liste 1/3 — Mappings orphelins** (n={len(orphans)}) :",
             "```json",
-            orphans_json,
+            json.dumps(orphans, ensure_ascii=False, indent=2),
             "```",
             "",
-            "**Contrainte stricte** : ton appel à `propose_changes` doit contenir",
-            f"AU MINIMUM **{expected_min} mappings_added** issus de cette liste (ou {len(orphans)}",
-            "si tu juges qu'aucun n'est hors scope). Pour chaque target_folder qui",
-            "n'existe pas encore dans `tree.yaml`, ajoute une entrée dans `creations`.",
+            f"→ `mappings_added` doit contenir AU MINIMUM **{expected_min}** "
+            f"entrées issues de cette liste (idéalement {len(orphans)}).",
+            "",
         ]
-    else:
+
+    if underutilized:
         human_content_parts += [
-            "(Aucun mapping orphelin pré-extrait du rapport — soit le diagnostic",
-            "n'en mentionne pas, soit le format ne match pas le parser. Examine",
-            "le markdown ci-dessus et/ou utilise `find_orphan_themes(profile, top_n=30)`.)",
+            f"**Liste 2/3 — Dossiers sous-utilisés** (n={len(underutilized)}) :",
+            "```json",
+            json.dumps(underutilized, ensure_ascii=False, indent=2),
+            "```",
+            "",
+            "→ Pour chaque entrée, décide : `mappings_added` (si un thème orphelin "
+            "s'y rattache), `deletions` (si vide ET aucun orphelin lié), "
+            "ou `fusions` (si plusieurs sont sémantiquement proches).",
+            "",
         ]
+
+    if catchall:
+        human_content_parts += [
+            f"**Liste 3/3 — Catch-all qui débordent** (n={len(catchall)}) :",
+            "```json",
+            json.dumps(catchall, ensure_ascii=False, indent=2),
+            "```",
+            "",
+            "→ Pour chaque catch-all, crée les sous-catégories via `creations` + "
+            "ajoute des `mappings_added` qui redirigent les thèmes vers ces "
+            "sous-catégories. La fusion ne convient PAS ici (on veut désengorger, "
+            "pas consolider davantage).",
+            "",
+        ]
+
+    if not (orphans or underutilized or catchall):
+        human_content_parts += [
+            "(Aucune anomalie pré-extraite — soit le diagnostic n'en mentionne pas, "
+            "soit le format ne match pas les parsers. Examine le markdown ci-dessus.)",
+            "",
+        ]
+
     human_content_parts += [
-        "",
-        "Appelle `propose_changes` **une fois**, avec une proposition complète.",
+        "Appelle `propose_changes` **une fois**, avec une proposition complète",
+        "qui couvre `mappings_added`, `creations`, `deletions`, `fusions`, et "
+        "`renamings` (selon ce que les listes ci-dessus suggèrent).",
     ]
 
     return {

--- a/agents/refonte/proposition.py
+++ b/agents/refonte/proposition.py
@@ -366,9 +366,10 @@ def _init_node(state: RefonteState) -> dict[str, Any]:
             target = suggested_targets.get(theme)
             if target:
                 entry["target_folder_suggested"] = target
-            sample = o.get("sample_titles") or []
-            if sample:
-                entry["sample_titles"] = sample[:2]
+            # sample_titles volontairement omis : ne change pas la décision
+            # du LLM (le nom du thème suffit) et gonflait le payload de 65 %
+            # (40 k chars → 14 k chars sur top 200) ce qui poussait le 1er
+            # appel LLM B à timeout côté SiliconFlow (cf. run 3f290cee).
             orphans.append(entry)
     else:
         # Fallback : find_orphan_themes a échoué (pas de vision_cache, IO error)

--- a/agents/refonte/proposition.py
+++ b/agents/refonte/proposition.py
@@ -204,7 +204,13 @@ def _route_after_analyze(state: RefonteState) -> Literal["tools", "finalize"]:
 
 
 def _finalize_node(state: RefonteState) -> dict[str, Any]:
-    """Termine le run — vérifie qu'un proposal a bien été écrit."""
+    """Termine le run — vérifie qu'un proposal a bien été écrit + simule.
+
+    Après vérification du proposal, déclenche automatiquement
+    `simulate_reclassify(...)` pour produire le CSV de projection. Comme
+    c'est du Python pur (no LLM), c'est rapide et c'est plus simple pour
+    l'utilisateur de tout voir d'un coup.
+    """
     messages = list(state.get("messages") or [])
     # Cherche le dernier ToolMessage venant d'un appel propose_changes
     proposal_result = None
@@ -226,6 +232,22 @@ def _finalize_node(state: RefonteState) -> dict[str, Any]:
     # Récupère le proposal_dir depuis le tool result
     tree_path = proposal_result.get("tree_proposed_path", "")
     proposal_dir = str(Path(tree_path).parent) if tree_path else ""
+
+    # Simulation reclassify avec le mapping proposé (no LLM, ~5-15s sur 18k files)
+    simulation_summary: dict[str, Any] = {}
+    if proposal_dir:
+        try:
+            from agents.refonte.simulator import simulate_reclassify
+            profile = state.get("profile", "")
+            simulation_summary = simulate_reclassify(profile, proposal_dir)
+        except Exception as exc:  # pragma: no cover — best-effort
+            # La simulation n'est pas critique pour considérer la proposition
+            # produite ; on log dans le summary plutôt que d'échouer le run.
+            simulation_summary = {
+                "error": f"{type(exc).__name__}: {exc}",
+                "n_files": 0,
+            }
+
     return {
         "status": "done",
         "proposal_dir": proposal_dir,
@@ -237,6 +259,7 @@ def _finalize_node(state: RefonteState) -> dict[str, Any]:
             "n_folders_after": proposal_result.get("n_folders_after", 0),
             "n_mappings_after": proposal_result.get("n_mappings_after", 0),
         },
+        "simulation_summary": simulation_summary,
     }
 
 

--- a/agents/refonte/proposition.py
+++ b/agents/refonte/proposition.py
@@ -29,6 +29,7 @@ Topologie :
 from __future__ import annotations
 
 import json
+import re
 import uuid
 from pathlib import Path
 from typing import Any, Literal
@@ -44,61 +45,133 @@ from agents.refonte.state import RefonteState
 from agents.refonte.tools import TOOLS as READ_TOOLS
 from dashboard import data
 
-DEFAULT_MAX_LLM_CALLS = 8
+DEFAULT_MAX_LLM_CALLS = 6  # 6 suffit largement avec la pré-extraction d'orphelins
+                            # qui supprime la phase d'exploration verbeuse
 
 SYSTEM_PROMPT_B = """Tu es l'agent IA Klodo en **Phase B (Proposition)**.
 
-Ton objectif : à partir du **diagnostic Phase A** fourni en contexte, **proposer
-une refonte concrète** de la taxonomie. Tu écris des fichiers YAML "proposed"
-en side (jamais sur les YAMLs de production) qui seront ensuite simulés et,
-éventuellement, appliqués par Phase C après validation utilisateur.
+Tu reçois en entrée :
+  - le rapport markdown du diagnostic Phase A
+  - **une LISTE PRÉ-EXTRAITE des mappings orphelins** (JSON) directement utilisable
 
-Tu disposes de 9 outils :
+Ta tâche : appeler **propose_changes** UNE FOIS avec une proposition COMPLÈTE.
 
-**Outils de lecture (validation / cross-check du diagnostic)** :
-  - list_folders(profile)
-  - count_files_per_folder(profile)
-  - read_theme_mapping(profile)
-  - list_themes_per_folder(profile)
-  - compute_folder_overlap(profile, folder_a, folder_b)
-  - get_classifier_breakdown(profile)
+═══════ Outils disponibles ═══════
+
+**Lecture (cross-check si besoin, mais la liste pré-extraite suffit dans 90% des cas)** :
+  - list_folders(profile), count_files_per_folder(profile)
+  - read_theme_mapping(profile), list_themes_per_folder(profile)
+  - compute_folder_overlap(profile, a, b)
   - list_vision_themes(profile, top_n=50)
   - find_orphan_themes(profile, top_n=30)
 
-**Outil mutable (écrit les YAMLs proposed — UNE seule fois par run)** :
+**Mutable (UNE seule fois par run, à la fin)** :
   - propose_changes(creations, fusions, renamings, mappings_added)
 
-Stratégie efficace (5-7 tool calls) :
-  1. Lis le diagnostic ci-dessous. Il liste les anomalies (mappings manquants,
-     dossiers sous-utilisés, catch-all qui débordent, doublons sémantiques).
-  2. Si besoin, vérifie 1-2 cas via les outils read-only (ex. confirmer un
-     thème orphelin via find_orphan_themes).
-  3. Construis ta proposition complète, puis appelle propose_changes(...)
-     **une seule fois** avec tous les changements groupés.
+═══════ Contraintes IMPÉRATIVES sur propose_changes ═══════
 
-Conventions importantes pour propose_changes :
-  - `creations` : nouveaux dossiers (path relatif depuis le target).
-  - `fusions` : `sources` = liste de paths existants, `target` = path destination
-    (peut être un path créé par `creations` ou un dossier existant).
-  - `renamings` : changement de nom d'un dossier existant.
-  - `mappings_added` : pour chaque thème orphelin du diagnostic, mappe-le vers
-    son dossier cible évident. PRIORITÉ : c'est ça qui débloque le plus de
-    fichiers mal classés. Ajoute 15-30 mappings si le diagnostic en propose
-    autant.
+1. **mappings_added : exhaustif, pas symbolique.** Pour CHAQUE entrée de la
+   liste pré-extraite, tu DOIS produire un mapping. Si la liste contient 30
+   entrées, ton appel doit avoir AU MINIMUM 25 mappings_added (tolérance : tu
+   peux retirer 5 entrées que tu juges hors scope, mais tu DOIS justifier).
+   Une proposition avec 0 mapping_added est un ÉCHEC.
 
-Chaque entrée doit avoir un champ `rationale` court (1-2 phrases) qui justifie
-le choix — c'est ce qui apparaîtra dans `refonte-rationale.md`.
+2. **creations** : si une `target_folder` d'un orphelin n'existe pas encore
+   dans tree.yaml, crée-la (ajoute-la dans `creations`).
 
-**Règles absolues** :
-  - N'invente PAS de thèmes ou de chemins : utilise uniquement ceux du
-    diagnostic ou retournés par les outils de lecture.
-  - Les chemins cibles des `mappings_added` doivent exister dans `tree.yaml`
-    courant OU être créés via `creations`.
-  - Sois EXHAUSTIF sur les mappings_added (15-30+ si le diagnostic les liste) —
-    c'est l'action à plus haut ROI.
+3. **fusions / renamings** : optionnels, basés sur les anomalies de doublons
+   sémantiques du diagnostic. Pas obligatoires si le diagnostic n'en a pas vu.
 
-Quand tu as appelé propose_changes une fois avec succès, **réponds sans appeler
-d'autre outil** — Phase B est terminée."""
+4. **rationale** par entrée : 1 phrase courte, factuelle. Cite le count
+   d'occurrences pour les mappings_added quand pertinent.
+
+═══════ Exemple d'appel correct ═══════
+
+```json
+{
+  "creations": [
+    {"path": "01-SCIENCES/CHIMIE/04-Science-des-Materiaux",
+     "rationale": "78 fichiers Materials Science orphelins"}
+  ],
+  "mappings_added": [
+    {"theme": "Functional Analysis", "folder": "01-SCIENCES/MATHEMATIQUES/02-Analyse",
+     "rationale": "176 fichiers — analyse fonctionnelle classique"},
+    {"theme": "Complex Analysis", "folder": "01-SCIENCES/MATHEMATIQUES/02-Analyse",
+     "rationale": "114 fichiers — analyse complexe"},
+    {"theme": "Group Theory", "folder": "01-SCIENCES/MATHEMATIQUES/01-Algebre",
+     "rationale": "112 fichiers — algèbre"}
+    /* ... 15-30 entrées au total ... */
+  ]
+}
+```
+
+═══════ Anti-patterns à éviter ═══════
+
+- ❌ Ne livrer que 2-3 mappings alors que la liste pré-extraite en a 30
+- ❌ Appeler des outils de lecture en boucle pour "redécouvrir" ce qui est
+  déjà dans la liste pré-extraite
+- ❌ Inventer des `theme` ou `folder` qui ne sont pas dans la liste ou
+  dans tree.yaml
+
+Quand tu as appelé propose_changes avec succès, **termine sans nouvel outil**."""
+
+
+# ─── Parser des mappings orphelins depuis le rapport Phase A ───────────────
+
+
+# Matche : "[- ]**Theme** (NN fichiers) → <reste de ligne>"
+# Le `reste de ligne` est nettoyé en post-traitement (strip label éventuel +
+# backticks) pour tolérer plusieurs variantes du LLM ("dossier cible évident :",
+# "cible :", aucun label, etc.).
+_MAPPING_LINE_RE = re.compile(
+    r"^\s*[-*]?\s*\*\*([^*]+?)\*\*\s*\((\d+)\s*fichiers?\)\s*[→]\s*(.+?)\s*$",
+    re.MULTILINE,
+)
+# Strip un préfixe optionnel "dossier cible évident :" / "cible :" / "target :"
+_TARGET_LABEL_RE = re.compile(
+    r"^\s*(?:dossier\s+cible\s*(?:évident)?|cible|target)\s*[:：]\s*",
+    re.IGNORECASE,
+)
+
+
+def parse_orphan_mappings_from_report(report_md: str) -> list[dict[str, Any]]:
+    """Extrait la liste structurée des mappings orphelins du rapport Phase A.
+
+    Cherche les lignes du format produit par REPORT_PROMPT_TEMPLATE de Phase A :
+      - **Theme name** (NN fichiers) → dossier cible évident : `path/to/folder`
+
+    Le parser est tolérant : il accepte "dossier cible :" / "cible :" / aucun
+    label, et nettoie les backticks/guillemets résiduels autour du path.
+
+    Args:
+        report_md: Le contenu markdown du rapport (report.md).
+
+    Returns:
+        Liste de dicts `{"theme": str, "count": int, "target_folder": str}`,
+        ordonnés comme dans le rapport (typiquement par count desc).
+        Liste vide si aucun pattern matché (rapport mal formé / langue
+        inattendue / hallucination).
+    """
+    if not report_md:
+        return []
+    results: list[dict[str, Any]] = []
+    for m in _MAPPING_LINE_RE.finditer(report_md):
+        theme = m.group(1).strip()
+        try:
+            count = int(m.group(2))
+        except ValueError:
+            continue
+        raw_target = m.group(3)
+        # Strip label éventuel ("dossier cible évident :" etc.)
+        target = _TARGET_LABEL_RE.sub("", raw_target).strip()
+        # Strip backticks/guillemets externes (ex. `01-SCIENCES/...` → 01-SCIENCES/...)
+        target = target.strip("` '\"")
+        # Strip ponctuation finale qui pourrait avoir collé (virgule, point)
+        target = target.rstrip(".,;")
+        if not target or not theme:
+            continue
+        results.append({"theme": theme, "count": count, "target_folder": target})
+    return results
 
 
 # ─── Nœuds ──────────────────────────────────────────────────────────────────
@@ -144,6 +217,45 @@ def _init_node(state: RefonteState) -> dict[str, Any]:
                 f"avec status=done sur ce run avant de lancer Phase B."
             ),
         }
+    # Pré-extraction des mappings orphelins du rapport — on les sert au LLM
+    # en JSON pré-mâché plutôt que de lui faire ré-extraire du markdown.
+    orphans = parse_orphan_mappings_from_report(diagnostic_md)
+    orphans_json = json.dumps(orphans, ensure_ascii=False, indent=2)
+    expected_min = max(0, len(orphans) - 5)  # tolérance : -5 du total
+
+    human_content_parts = [
+        f"Voici le diagnostic Phase A du profil `{profile}` :",
+        "",
+        "---",
+        diagnostic_md,
+        "---",
+        "",
+    ]
+    if orphans:
+        human_content_parts += [
+            f"**Mappings orphelins pré-extraits** (n={len(orphans)}) — utilise CETTE liste",
+            "comme base de `mappings_added`, **pas le markdown ci-dessus** :",
+            "",
+            "```json",
+            orphans_json,
+            "```",
+            "",
+            "**Contrainte stricte** : ton appel à `propose_changes` doit contenir",
+            f"AU MINIMUM **{expected_min} mappings_added** issus de cette liste (ou {len(orphans)}",
+            "si tu juges qu'aucun n'est hors scope). Pour chaque target_folder qui",
+            "n'existe pas encore dans `tree.yaml`, ajoute une entrée dans `creations`.",
+        ]
+    else:
+        human_content_parts += [
+            "(Aucun mapping orphelin pré-extrait du rapport — soit le diagnostic",
+            "n'en mentionne pas, soit le format ne match pas le parser. Examine",
+            "le markdown ci-dessus et/ou utilise `find_orphan_themes(profile, top_n=30)`.)",
+        ]
+    human_content_parts += [
+        "",
+        "Appelle `propose_changes` **une fois**, avec une proposition complète.",
+    ]
+
     return {
         "phase": "B",
         "run_id": state.get("run_id") or str(uuid.uuid4()),
@@ -151,14 +263,7 @@ def _init_node(state: RefonteState) -> dict[str, Any]:
         "llm_calls": 0,
         "messages": [
             SystemMessage(content=SYSTEM_PROMPT_B),
-            HumanMessage(
-                content=(
-                    f"Voici le diagnostic Phase A du profil `{profile}` à utiliser "
-                    f"comme base de ta proposition :\n\n---\n{diagnostic_md}\n---\n\n"
-                    f"Propose maintenant une refonte via propose_changes. "
-                    f"Sois exhaustif sur les mappings_added."
-                ),
-            ),
+            HumanMessage(content="\n".join(human_content_parts)),
         ],
     }
 

--- a/agents/refonte/proposition.py
+++ b/agents/refonte/proposition.py
@@ -83,11 +83,43 @@ Pour chaque entrée la liste peut contenir un champ `target_folder_suggested`
 absent (orphelins au-delà du top 30 du diagnostic), tu choisis toi-même la
 destination en t'appuyant sur tree.yaml et le sens du thème.
 
-**2. creations — DRIVEN par les destinations des mappings**
+**2. creations — DRIVEN par les thèmes orphelins à fort volume (stratégie
+agressive : l'humain filtrera ensuite via l'UI)**
 
-Si la destination d'un mapping (suggérée ou choisie par toi) n'existe pas
-dans tree.yaml, ajoute-la dans `creations`. Aussi : si un catch-all est
-trop gros, créer des sous-dossiers où ses fichiers iront naturellement.
+Règle quantitative : **pour CHAQUE thème orphelin avec `count ≥ 30`,
+propose un folder dédié dans `creations` SAUF si un folder existant correspond
+PRÉCISÉMENT au thème (homonymie ou quasi-homonymie)**, pas juste sémantiquement
+voisin. Le `target_folder_suggested` du diagnostic est un point de départ mais
+PAS une obligation — il pointait souvent vers un parent générique faute de
+mieux.
+
+Exemples du jeu de critères :
+
+  ❌ MAPPING TROP LÂCHE (créer un folder à la place) :
+    - `Penetration Testing` (73) → `Securite-Crypto` : trop générique, créer
+      `Securite-Crypto/Penetration-Testing`
+    - `Materials Science` (78) → `Chimie-Physique` : sujet distinct, créer
+      `Sciences-des-Materiaux` au bon niveau
+    - `Database Administration` (56) → `Bases-de-Donnees` : créer
+      `Bases-de-Donnees/Administration`
+
+  ✅ MAPPING LÉGITIME (le folder existe et désigne EXACTEMENT le thème) :
+    - `Functional Analysis` (176) → `MATHEMATIQUES/02-Analyse` : Analyse
+      fonctionnelle EST l'analyse, mappe.
+    - `Web Services` (10) → `Reseaux-Telecom/Web` : count faible + sujet
+      bien recouvert.
+
+La destination d'un mapping peut aussi être un folder nouveau de `creations` :
+si tu crées `Securite-Crypto/Penetration-Testing`, le mapping
+`Penetration Testing → Securite-Crypto/Penetration-Testing` est cohérent.
+
+Aussi : si un catch-all est trop gros, créer des sous-dossiers où ses fichiers
+iront naturellement.
+
+**Volume attendu** : sur une biblio de 18k fichiers avec 200 thèmes orphelins,
+on attend **30-60 creations** (pas 4). Si tu en proposes < 20, tu n'as pas
+appliqué la règle « count ≥ 30 → folder dédié ». L'humain filtrera les
+suggestions qu'il juge superflues — sois généreux, pas timide.
 
 **3. deletions — DRIVEN par les dossiers sous-utilisés sans rescousse**
 
@@ -124,7 +156,12 @@ mappings_added quand pertinent. Pour les deletions, justifie pourquoi
 {
   "creations": [
     {"path": "01-SCIENCES/CHIMIE/04-Science-des-Materiaux",
-     "rationale": "78 fichiers Materials Science orphelins"}
+     "rationale": "78 fichiers Materials Science orphelins, sujet distinct de Chimie-Physique"},
+    {"path": "02-INFORMATIQUE/10-Securite-Crypto/Penetration-Testing",
+     "rationale": "73 fichiers Penetration Testing — sous-dossier dédié plutôt que diluer dans Securite-Crypto"},
+    {"path": "02-INFORMATIQUE/07-Bases-de-Donnees/Administration",
+     "rationale": "56 fichiers Database Administration"},
+    /* ... une création par thème ≥ 30 sans homonyme exact ... */
   ],
   "deletions": [
     {"path": "08-LOISIRS/DESSIN",
@@ -136,7 +173,9 @@ mappings_added quand pertinent. Pour les deletions, justifie pourquoi
   ],
   "mappings_added": [
     {"theme": "Functional Analysis", "folder": "01-SCIENCES/MATHEMATIQUES/02-Analyse",
-     "rationale": "176 fichiers — analyse fonctionnelle"},
+     "rationale": "176 fichiers — homonymie exacte avec le folder Analyse"},
+    {"theme": "Penetration Testing", "folder": "02-INFORMATIQUE/10-Securite-Crypto/Penetration-Testing",
+     "rationale": "73 fichiers — pointe sur le nouveau folder créé ci-dessus"},
     /* ... une entrée par item de la liste orphan mappings ... */
   ]
 }
@@ -145,6 +184,12 @@ mappings_added quand pertinent. Pour les deletions, justifie pourquoi
 ═══════ Anti-patterns à éviter ═══════
 
 - ❌ Ne livrer que 2-3 mappings alors que la liste pré-extraite en a 50+
+- ❌ Ne proposer que 4 créations alors que 30+ thèmes orphelins ont count ≥ 30
+  — c'est l'erreur la plus fréquente. Sois généreux sur `creations`, l'humain
+  filtrera ensuite. Préférer trop que pas assez.
+- ❌ Mapper un gros thème (count ≥ 30) vers un folder existant **générique**
+  juste parce qu'il existe (`Penetration Testing → Securite-Crypto`).
+  La règle : folder dédié sauf homonymie exacte.
 - ❌ Ignorer les dossiers sous-utilisés et les catch-all (toi seul peux
   décider "delete vs. map vs. fuse")
 - ❌ Appeler des outils en boucle pour "redécouvrir" ce qui est déjà

--- a/agents/refonte/proposition_tools.py
+++ b/agents/refonte/proposition_tools.py
@@ -46,6 +46,17 @@ class _Renaming(BaseModel):
     rationale: str = Field(description="Pourquoi renommer (1-2 phrases)")
 
 
+class _Deletion(BaseModel):
+    path: str = Field(description="Chemin relatif du dossier à supprimer (sans le fusionner)")
+    rationale: str = Field(
+        description=(
+            "Pourquoi supprimer ce dossier (vide depuis longtemps, doublon "
+            "tranchant, obsolète, etc.). Préférer une `fusion` si les fichiers "
+            "doivent migrer ailleurs."
+        ),
+    )
+
+
 class _MappingAdded(BaseModel):
     theme: str = Field(description="Thème LLM observé (ex: 'rust programming')")
     folder: str = Field(description="Dossier cible (existant ou créé dans les créations)")
@@ -58,6 +69,10 @@ class _ProposeChangesInput(BaseModel):
     creations: list[_Creation] = Field(default_factory=list, description="Nouveaux dossiers à créer")
     fusions: list[_Fusion] = Field(default_factory=list, description="Dossiers à fusionner")
     renamings: list[_Renaming] = Field(default_factory=list, description="Dossiers à renommer")
+    deletions: list[_Deletion] = Field(
+        default_factory=list,
+        description="Dossiers à supprimer purement (sans fusion)",
+    )
     mappings_added: list[_MappingAdded] = Field(
         default_factory=list,
         description="Nouveaux mappings thème → dossier à ajouter dans theme_mapping.yaml",
@@ -79,12 +94,13 @@ def _apply_changes_to_tree(
     creations: list[dict],
     fusions: list[dict],
     renamings: list[dict],
+    deletions: list[dict] | None = None,
 ) -> list[str]:
     """Construit la liste des dossiers du tree proposé.
 
-    Ordre d'application : creations → renamings → fusions (les fusions
-    suppriment, on les fait en dernier pour ne pas supprimer un dossier qu'un
-    renaming aurait pu utiliser comme source).
+    Ordre d'application : creations → renamings → fusions → deletions
+    (deletions en dernier pour pouvoir cibler un path qui aurait été créé
+    ou renommé juste avant ; cas d'usage rare mais cohérent).
     """
     folders = set(current_folders)
     # Créations
@@ -99,6 +115,9 @@ def _apply_changes_to_tree(
         for src in f["sources"]:
             folders.discard(src)
         folders.add(f["target"])
+    # Suppressions sèches (sans réaffectation des fichiers)
+    for d in (deletions or []):
+        folders.discard(d["path"])
     return sorted(folders)
 
 
@@ -107,9 +126,11 @@ def _apply_changes_to_mapping(
     mappings_added: list[dict],
     renamings: list[dict],
     fusions: list[dict],
+    deletions: list[dict] | None = None,
 ) -> dict[str, str]:
     """Construit le mapping proposé : ajoute les nouveaux mappings + ajuste les
-    cibles existantes pour les renommages et les fusions.
+    cibles existantes pour les renommages et les fusions + drop les mappings
+    qui pointent sur un dossier supprimé.
     """
     mapping = dict(current_mapping)  # copy
     # Renommages : tous les thèmes qui pointaient sur old_path pointent maintenant sur new_path
@@ -119,11 +140,15 @@ def _apply_changes_to_mapping(
     for f in fusions:
         for src in f["sources"]:
             fusion_map[src] = f["target"]
+    # Suppressions : les thèmes pointant dessus deviennent orphelins (drop)
+    deleted_paths = {d["path"] for d in (deletions or [])}
     for theme, folder in list(mapping.items()):
         if folder in rename_map:
             mapping[theme] = rename_map[folder]
         elif folder in fusion_map:
             mapping[theme] = fusion_map[folder]
+        elif folder in deleted_paths:
+            del mapping[theme]
     # Nouveaux mappings (s'ajoutent en dernier, écrasent un éventuel mapping existant)
     for m in mappings_added:
         mapping[m["theme"]] = m["folder"]
@@ -141,11 +166,13 @@ def _render_rationale_markdown(
     n_creations = len(changes.creations)
     n_fusions = len(changes.fusions)
     n_renamings = len(changes.renamings)
+    n_deletions = len(changes.deletions)
     n_mappings = len(changes.mappings_added)
     lines.append("## Résumé des changements")
     lines.append(f"- **Créations** : {n_creations}")
     lines.append(f"- **Fusions** : {n_fusions}")
     lines.append(f"- **Renommages** : {n_renamings}")
+    lines.append(f"- **Suppressions** : {n_deletions}")
     lines.append(f"- **Mappings ajoutés** : {n_mappings}")
     lines.append("")
     if changes.creations:
@@ -165,6 +192,11 @@ def _render_rationale_markdown(
         for r in changes.renamings:
             lines.append(f"- `{r.old_path}` → `{r.new_path}` — {r.rationale}")
         lines.append("")
+    if changes.deletions:
+        lines.append(f"## SUPPRESSIONS ({n_deletions})")
+        for d in changes.deletions:
+            lines.append(f"- `{d.path}` — {d.rationale}")
+        lines.append("")
     if changes.mappings_added:
         lines.append(f"## MAPPINGS AJOUTÉS ({n_mappings})")
         for m in changes.mappings_added:
@@ -182,6 +214,7 @@ def propose_changes(
     creations: list[dict] | None = None,
     fusions: list[dict] | None = None,
     renamings: list[dict] | None = None,
+    deletions: list[dict] | None = None,
     mappings_added: list[dict] | None = None,
 ) -> dict[str, Any]:
     """Écrit les 3 artefacts de proposition sur disque (read tree+mapping
@@ -217,6 +250,7 @@ def propose_changes(
         creations=creations or [],
         fusions=fusions or [],
         renamings=renamings or [],
+        deletions=deletions or [],
         mappings_added=mappings_added or [],
     )
     out_dir = _proposal_dir(profile, run_id)
@@ -230,12 +264,14 @@ def propose_changes(
         [c.model_dump() for c in changes.creations],
         [f.model_dump() for f in changes.fusions],
         [r.model_dump() for r in changes.renamings],
+        deletions=[d.model_dump() for d in changes.deletions],
     )
     new_mapping = _apply_changes_to_mapping(
         current_mapping,
         [m.model_dump() for m in changes.mappings_added],
         [r.model_dump() for r in changes.renamings],
         [f.model_dump() for f in changes.fusions],
+        deletions=[d.model_dump() for d in changes.deletions],
     )
 
     # Écritures
@@ -269,6 +305,7 @@ def propose_changes(
         "n_creations": len(changes.creations),
         "n_fusions": len(changes.fusions),
         "n_renamings": len(changes.renamings),
+        "n_deletions": len(changes.deletions),
         "n_mappings_added": len(changes.mappings_added),
         "n_folders_after": len(new_folders),
         "n_mappings_after": len(new_mapping),
@@ -299,6 +336,7 @@ def make_proposition_tools(profile: str, run_id: str) -> list[StructuredTool]:
         creations: list[dict] | None = None,
         fusions: list[dict] | None = None,
         renamings: list[dict] | None = None,
+        deletions: list[dict] | None = None,
         mappings_added: list[dict] | None = None,
     ) -> dict[str, Any]:
         """Écrit les artefacts de proposition (tree-proposed.yaml +
@@ -309,6 +347,9 @@ def make_proposition_tools(profile: str, run_id: str) -> list[StructuredTool]:
             creations: Liste de {path, rationale} — dossiers à créer.
             fusions: Liste de {sources, target, rationale} — dossiers à fusionner.
             renamings: Liste de {old_path, new_path, rationale} — dossiers à renommer.
+            deletions: Liste de {path, rationale} — dossiers à supprimer SANS fusion.
+                       Utiliser pour les dossiers vides obsolètes ou les doublons
+                       tranchants. Préférer `fusions` si les fichiers doivent migrer.
             mappings_added: Liste de {theme, folder, rationale} — nouveaux mappings.
         """
         return propose_changes(
@@ -317,6 +358,7 @@ def make_proposition_tools(profile: str, run_id: str) -> list[StructuredTool]:
             creations=creations,
             fusions=fusions,
             renamings=renamings,
+            deletions=deletions,
             mappings_added=mappings_added,
         )
 

--- a/agents/refonte/proposition_tools.py
+++ b/agents/refonte/proposition_tools.py
@@ -1,0 +1,325 @@
+"""Outils write-only-to-side-YAMLs pour l'agent Refonte — Phase B.
+
+Le tool principal `propose_changes(...)` reçoit du LLM une description structurée
+des changements à appliquer (créations / fusions / renommages / mappings ajoutés)
+et produit 3 artefacts dans `profile/<name>/.cache/refonte/<run_id>/proposed/` :
+
+  - tree-proposed.yaml          (arborescence cible)
+  - theme_mapping-proposed.yaml (mapping enrichi)
+  - refonte-rationale.md        (récap des décisions, par catégorie)
+
+Aucun de ces 3 fichiers ne touche aux YAMLs de production. Phase B reste
+strictement "side YAMLs" — c'est Phase C qui appliquera (avec backup) si
+l'utilisateur valide.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import yaml
+from langchain_core.tools import StructuredTool
+from pydantic import BaseModel, Field
+
+from dashboard import data
+from dashboard import taxonomy as tax
+
+# ─── Schémas Pydantic exposés au LLM via StructuredTool ───────────────────
+
+
+class _Creation(BaseModel):
+    path: str = Field(description="Nouveau chemin relatif (ex: '02-INFORMATIQUE/03-Langages-Programmation/Rust')")
+    rationale: str = Field(description="Pourquoi créer ce dossier (1-2 phrases)")
+
+
+class _Fusion(BaseModel):
+    sources: list[str] = Field(description="Liste des dossiers actuels à fusionner (chemins relatifs)")
+    target: str = Field(description="Nouveau chemin cible (existant ou créé)")
+    rationale: str = Field(description="Pourquoi fusionner (1-2 phrases)")
+
+
+class _Renaming(BaseModel):
+    old_path: str = Field(description="Ancien chemin relatif")
+    new_path: str = Field(description="Nouveau chemin relatif")
+    rationale: str = Field(description="Pourquoi renommer (1-2 phrases)")
+
+
+class _MappingAdded(BaseModel):
+    theme: str = Field(description="Thème LLM observé (ex: 'rust programming')")
+    folder: str = Field(description="Dossier cible (existant ou créé dans les créations)")
+    rationale: str = Field(description="Pourquoi mapper ce thème ici (1-2 phrases)")
+
+
+class _ProposeChangesInput(BaseModel):
+    """Arguments du tool propose_changes — structure des changements proposés."""
+
+    creations: list[_Creation] = Field(default_factory=list, description="Nouveaux dossiers à créer")
+    fusions: list[_Fusion] = Field(default_factory=list, description="Dossiers à fusionner")
+    renamings: list[_Renaming] = Field(default_factory=list, description="Dossiers à renommer")
+    mappings_added: list[_MappingAdded] = Field(
+        default_factory=list,
+        description="Nouveaux mappings thème → dossier à ajouter dans theme_mapping.yaml",
+    )
+
+
+# ─── Helpers privés ────────────────────────────────────────────────────────
+
+
+def _proposal_dir(profile: str, run_id: str) -> Path:
+    """Renvoie le dossier proposed/ pour ce run (créé si absent)."""
+    base = data.get_project_root() / "profiles" / profile / ".cache" / "refonte" / run_id / "proposed"
+    base.mkdir(parents=True, exist_ok=True)
+    return base
+
+
+def _apply_changes_to_tree(
+    current_folders: list[str],
+    creations: list[dict],
+    fusions: list[dict],
+    renamings: list[dict],
+) -> list[str]:
+    """Construit la liste des dossiers du tree proposé.
+
+    Ordre d'application : creations → renamings → fusions (les fusions
+    suppriment, on les fait en dernier pour ne pas supprimer un dossier qu'un
+    renaming aurait pu utiliser comme source).
+    """
+    folders = set(current_folders)
+    # Créations
+    for c in creations:
+        folders.add(c["path"])
+    # Renommages (remplace l'ancien par le nouveau)
+    for r in renamings:
+        folders.discard(r["old_path"])
+        folders.add(r["new_path"])
+    # Fusions : enlève les sources, ajoute la cible (déjà ajoutée si c'était une création)
+    for f in fusions:
+        for src in f["sources"]:
+            folders.discard(src)
+        folders.add(f["target"])
+    return sorted(folders)
+
+
+def _apply_changes_to_mapping(
+    current_mapping: dict[str, str],
+    mappings_added: list[dict],
+    renamings: list[dict],
+    fusions: list[dict],
+) -> dict[str, str]:
+    """Construit le mapping proposé : ajoute les nouveaux mappings + ajuste les
+    cibles existantes pour les renommages et les fusions.
+    """
+    mapping = dict(current_mapping)  # copy
+    # Renommages : tous les thèmes qui pointaient sur old_path pointent maintenant sur new_path
+    rename_map = {r["old_path"]: r["new_path"] for r in renamings}
+    # Fusions : tous les thèmes qui pointaient sur une source pointent maintenant sur la target
+    fusion_map: dict[str, str] = {}
+    for f in fusions:
+        for src in f["sources"]:
+            fusion_map[src] = f["target"]
+    for theme, folder in list(mapping.items()):
+        if folder in rename_map:
+            mapping[theme] = rename_map[folder]
+        elif folder in fusion_map:
+            mapping[theme] = fusion_map[folder]
+    # Nouveaux mappings (s'ajoutent en dernier, écrasent un éventuel mapping existant)
+    for m in mappings_added:
+        mapping[m["theme"]] = m["folder"]
+    return mapping
+
+
+def _render_rationale_markdown(
+    profile: str,
+    changes: _ProposeChangesInput,
+) -> str:
+    """Render le markdown récapitulatif des changements proposés."""
+    lines: list[str] = []
+    lines.append(f"# Refonte taxonomy — profil `{profile}` — proposition")
+    lines.append("")
+    n_creations = len(changes.creations)
+    n_fusions = len(changes.fusions)
+    n_renamings = len(changes.renamings)
+    n_mappings = len(changes.mappings_added)
+    lines.append("## Résumé des changements")
+    lines.append(f"- **Créations** : {n_creations}")
+    lines.append(f"- **Fusions** : {n_fusions}")
+    lines.append(f"- **Renommages** : {n_renamings}")
+    lines.append(f"- **Mappings ajoutés** : {n_mappings}")
+    lines.append("")
+    if changes.creations:
+        lines.append(f"## CRÉATIONS ({n_creations})")
+        for c in changes.creations:
+            lines.append(f"- `{c.path}` — {c.rationale}")
+        lines.append("")
+    if changes.fusions:
+        lines.append(f"## FUSIONS ({n_fusions})")
+        for f in changes.fusions:
+            srcs = " + ".join(f"`{s}`" for s in f.sources)
+            lines.append(f"- {srcs} → `{f.target}`")
+            lines.append(f"  - {f.rationale}")
+        lines.append("")
+    if changes.renamings:
+        lines.append(f"## RENOMMAGES ({n_renamings})")
+        for r in changes.renamings:
+            lines.append(f"- `{r.old_path}` → `{r.new_path}` — {r.rationale}")
+        lines.append("")
+    if changes.mappings_added:
+        lines.append(f"## MAPPINGS AJOUTÉS ({n_mappings})")
+        for m in changes.mappings_added:
+            lines.append(f"- `{m.theme}` → `{m.folder}` — {m.rationale}")
+        lines.append("")
+    return "\n".join(lines)
+
+
+# ─── Tool principal ────────────────────────────────────────────────────────
+
+
+def propose_changes(
+    profile: str,
+    run_id: str,
+    creations: list[dict] | None = None,
+    fusions: list[dict] | None = None,
+    renamings: list[dict] | None = None,
+    mappings_added: list[dict] | None = None,
+) -> dict[str, Any]:
+    """Écrit les 3 artefacts de proposition sur disque (read tree+mapping
+    actuels, applique les changements à un copy, écrit les YAMLs proposés).
+
+    À appeler **une seule fois** par run de Phase B. Le tool valide la structure
+    via Pydantic et retourne les chemins absolus écrits + un récap.
+
+    Args:
+        profile: Nom du profil cible (ex. "default").
+        run_id: UUID du run de Phase B (déterminé par le caller, pas par le LLM).
+        creations: Liste de {path, rationale}.
+        fusions: Liste de {sources: list, target, rationale}.
+        renamings: Liste de {old_path, new_path, rationale}.
+        mappings_added: Liste de {theme, folder, rationale}.
+
+    Returns:
+        Dict avec les chemins écrits + métriques :
+            {
+                "tree_proposed_path": str,
+                "mapping_proposed_path": str,
+                "rationale_path": str,
+                "n_creations": int,
+                "n_fusions": int,
+                "n_renamings": int,
+                "n_mappings_added": int,
+                "n_folders_after": int,
+                "n_mappings_after": int,
+            }
+    """
+    # Validation Pydantic (raise ValidationError si malformé)
+    changes = _ProposeChangesInput(
+        creations=creations or [],
+        fusions=fusions or [],
+        renamings=renamings or [],
+        mappings_added=mappings_added or [],
+    )
+    out_dir = _proposal_dir(profile, run_id)
+
+    # Lit l'existant + applique
+    current_folders = tax._load_tree(profile)
+    current_mapping = tax._load_mapping(profile)
+
+    new_folders = _apply_changes_to_tree(
+        current_folders,
+        [c.model_dump() for c in changes.creations],
+        [f.model_dump() for f in changes.fusions],
+        [r.model_dump() for r in changes.renamings],
+    )
+    new_mapping = _apply_changes_to_mapping(
+        current_mapping,
+        [m.model_dump() for m in changes.mappings_added],
+        [r.model_dump() for r in changes.renamings],
+        [f.model_dump() for f in changes.fusions],
+    )
+
+    # Écritures
+    tree_path = out_dir / "tree-proposed.yaml"
+    mapping_path = out_dir / "theme_mapping-proposed.yaml"
+    rationale_path = out_dir / "refonte-rationale.md"
+    changes_json_path = out_dir / "changes.json"
+
+    tree_path.write_text(
+        yaml.safe_dump({"folders": new_folders}, allow_unicode=True, sort_keys=False),
+        encoding="utf-8",
+    )
+    mapping_path.write_text(
+        yaml.safe_dump(new_mapping, allow_unicode=True, sort_keys=True),
+        encoding="utf-8",
+    )
+    rationale_path.write_text(
+        _render_rationale_markdown(profile, changes),
+        encoding="utf-8",
+    )
+    # Persist aussi la structure raw — utile pour B.2 (simulateur) et debug
+    changes_json_path.write_text(
+        json.dumps(changes.model_dump(), ensure_ascii=False, indent=2),
+        encoding="utf-8",
+    )
+
+    return {
+        "tree_proposed_path": str(tree_path),
+        "mapping_proposed_path": str(mapping_path),
+        "rationale_path": str(rationale_path),
+        "n_creations": len(changes.creations),
+        "n_fusions": len(changes.fusions),
+        "n_renamings": len(changes.renamings),
+        "n_mappings_added": len(changes.mappings_added),
+        "n_folders_after": len(new_folders),
+        "n_mappings_after": len(new_mapping),
+    }
+
+
+# ─── LangChain binding ────────────────────────────────────────────────────
+
+
+def make_proposition_tools(profile: str, run_id: str) -> list[StructuredTool]:
+    """Factory : construit les tools mutables Phase B bindés à un run précis.
+
+    Pattern factory pour cacher `profile` et `run_id` au LLM (qui pourrait
+    sinon halluciner de mauvaises valeurs ou écraser un autre run). La graph
+    builder appelle cette factory en début de run pour générer les tools
+    spécifiques à cette session.
+
+    Args:
+        profile: Nom du profil ciblé.
+        run_id: UUID du run de Phase B en cours.
+
+    Returns:
+        Liste de StructuredTool prêts à `llm.bind_tools()`. Pour l'instant un
+        seul tool — `propose_changes` — mais on garde la liste pour évolution.
+    """
+
+    def _propose_changes_bound(
+        creations: list[dict] | None = None,
+        fusions: list[dict] | None = None,
+        renamings: list[dict] | None = None,
+        mappings_added: list[dict] | None = None,
+    ) -> dict[str, Any]:
+        """Écrit les artefacts de proposition (tree-proposed.yaml +
+        theme_mapping-proposed.yaml + refonte-rationale.md) à partir des
+        changements proposés. À appeler **une seule fois** par run.
+
+        Args:
+            creations: Liste de {path, rationale} — dossiers à créer.
+            fusions: Liste de {sources, target, rationale} — dossiers à fusionner.
+            renamings: Liste de {old_path, new_path, rationale} — dossiers à renommer.
+            mappings_added: Liste de {theme, folder, rationale} — nouveaux mappings.
+        """
+        return propose_changes(
+            profile=profile,
+            run_id=run_id,
+            creations=creations,
+            fusions=fusions,
+            renamings=renamings,
+            mappings_added=mappings_added,
+        )
+
+    # Pour que LangChain expose le bon name + doc au LLM
+    _propose_changes_bound.__name__ = "propose_changes"
+    return [StructuredTool.from_function(_propose_changes_bound)]

--- a/agents/refonte/simulator.py
+++ b/agents/refonte/simulator.py
@@ -1,0 +1,253 @@
+"""Simulateur reclassify pour Phase B.
+
+À partir d'un dossier `proposed/` (tree-proposed.yaml + theme_mapping-proposed.yaml),
+re-applique `lib.classifier.classify_combined` sur tous les fichiers déjà
+analysés (i.e. présents dans `vision_cache.json`) en utilisant le **mapping
+proposé** au lieu du mapping courant.
+
+Produit 2 artefacts dans `<proposal_dir>/../simulation/` :
+  - reclassify-projection.csv : 1 ligne par fichier (rel_path, current_folder,
+                                proposed_folder, changed, source, top_theme,
+                                confidence)
+  - simulation-summary.json   : stats agrégées (n_files, n_moving, n_stable,
+                                n_no_prediction, distribution_before, after)
+
+Module Python pur, **aucun appel LLM** — coût zéro, durée ~5-15s sur 18k
+fichiers (parallélisme via ThreadPoolExecutor).
+
+Convention : ne lit que les artefacts dans `proposed/`. Ne touche pas aux
+YAMLs de production. C'est Phase C qui appliquera après validation user.
+"""
+
+from __future__ import annotations
+
+import csv
+import json
+import os
+from collections import Counter, defaultdict
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+from dashboard import taxonomy as tax
+
+# Extensions de fichiers à considérer (aligné avec dashboard/taxonomy.py)
+_FILE_EXTS = (".pdf", ".epub")
+
+
+def simulate_reclassify(
+    profile: str,
+    proposal_dir: Path | str,
+    *,
+    max_workers: int = 8,
+) -> dict[str, Any]:
+    """Simule un reclassify complet avec le mapping proposé.
+
+    Args:
+        profile: Nom du profil cible.
+        proposal_dir: Chemin du dossier `proposed/` produit par propose_changes
+                      (contient `tree-proposed.yaml` + `theme_mapping-proposed.yaml`).
+        max_workers: Threads parallèles pour classifier les fichiers.
+
+    Returns:
+        Dict summary :
+            {
+                "csv_path": str,
+                "summary_path": str,
+                "n_files": int,
+                "n_moving": int,
+                "n_stable": int,
+                "n_no_prediction": int,
+                "n_by_source": {"LLM (theme)": int, "Keyword": int, ...},
+                "top_destinations": [{"folder": str, "n_incoming": int}, ...],
+                "top_origins": [{"folder": str, "n_outgoing": int}, ...],
+            }
+
+    Raises:
+        FileNotFoundError: si proposal_dir ou son theme_mapping-proposed.yaml manque.
+    """
+    from lib.classifier import classify_combined, load_keyword_classifier
+
+    proposal_dir = Path(proposal_dir)
+    mapping_path = proposal_dir / "theme_mapping-proposed.yaml"
+    if not mapping_path.exists():
+        raise FileNotFoundError(f"theme_mapping-proposed.yaml manquant dans {proposal_dir}")
+
+    # Lit le mapping proposé
+    try:
+        proposed_mapping_raw = yaml.safe_load(mapping_path.read_text(encoding="utf-8")) or {}
+    except yaml.YAMLError as exc:
+        raise ValueError(f"theme_mapping-proposed.yaml invalide : {exc}") from exc
+    proposed_mapping: dict[str, str] = {
+        str(k): str(v) for k, v in proposed_mapping_raw.items() if isinstance(v, str)
+    }
+
+    # KeywordClassifier (fallback Niveau 2) — réutilise categories.yaml courant du
+    # profil. Phase B ne propose pas de changements à categories.yaml.
+    target = tax._profile_target_path(profile)
+    if target is None or not target.exists():
+        return _empty_summary(proposal_dir)
+
+    cat_path = tax._profile_dir(profile) / "categories.yaml"
+    classifier = load_keyword_classifier(str(cat_path)) if cat_path.exists() else None
+
+    # Vision cache
+    cache_path = tax._vision_cache_path(profile)
+    cache: dict = {}
+    if cache_path.exists():
+        try:
+            cache = json.loads(cache_path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError):
+            cache = {}
+    if not isinstance(cache, dict):
+        cache = {}
+
+    # Config LLM (pour calculer la clé de cache)
+    cfg = tax._load_profile_yaml(profile)
+    model = (cfg.get("llm") or {}).get("model") or "Qwen/Qwen3-VL-32B-Instruct"
+    n_pages = int((cfg.get("defaults") or {}).get("pages") or 2)
+
+    # Enumeration des fichiers
+    target_str = str(target)
+    file_list: list[tuple[str, str, str]] = []
+    for root, dirs, files in os.walk(target_str):
+        dirs[:] = [d for d in dirs if not d.startswith(".")]
+        for f in files:
+            if f.startswith(".") or not f.lower().endswith(_FILE_EXTS):
+                continue
+            abs_path = os.path.join(root, f)
+            try:
+                rel = os.path.relpath(abs_path, target_str).replace("\\", "/")
+            except ValueError:
+                continue
+            file_list.append((abs_path, rel, f))
+
+    # Worker : récupère result vision + appelle classify_combined
+    from lib import vision_cache as vc
+
+    def _process(item: tuple[str, str, str]) -> dict[str, Any]:
+        abs_path, rel, filename = item
+        i = rel.rfind("/")
+        current_folder = rel[:i] if i >= 0 else ""
+        # Lookup vision_cache
+        key = vc.compute_cache_key(abs_path, model=model, n_pages=n_pages)
+        result = vc.lookup(cache, key) if key else None
+        if not isinstance(result, dict):
+            result = {}
+        # Top theme pour le CSV (lecture seule)
+        top_theme = ""
+        top_conf = 0.0
+        themes_arr = result.get("themes")
+        if isinstance(themes_arr, list) and themes_arr:
+            best = max(
+                (t for t in themes_arr if isinstance(t, dict)),
+                key=lambda t: float(t.get("confidence") or 0.0),
+                default=None,
+            )
+            if best is not None:
+                top_theme = str(best.get("theme") or "")
+                top_conf = float(best.get("confidence") or 0.0)
+        elif result.get("theme"):
+            top_theme = str(result.get("theme") or "")
+            top_conf = float(result.get("confidence") or 0.0)
+        # Classification avec le mapping PROPOSÉ
+        dest, score, source = classify_combined(
+            result, filename, proposed_mapping,
+            classifier=classifier,
+            llm_mapper=None,
+            pdf_path=abs_path,
+        )
+        return {
+            "rel_path": rel,
+            "current_folder": current_folder,
+            "proposed_folder": dest or "",
+            "changed": bool(dest and dest != current_folder),
+            "source": source or "FAILED",
+            "top_theme": top_theme,
+            "confidence": round(top_conf, 3),
+            "score": float(score) if score else 0.0,
+        }
+
+    # Walk parallel
+    processed: list[dict] = []
+    with ThreadPoolExecutor(max_workers=max_workers) as ex:
+        for r in ex.map(_process, file_list):
+            processed.append(r)
+
+    # Écriture CSV
+    sim_dir = proposal_dir.parent / "simulation"
+    sim_dir.mkdir(parents=True, exist_ok=True)
+    csv_path = sim_dir / "reclassify-projection.csv"
+    with csv_path.open("w", newline="", encoding="utf-8") as f:
+        writer = csv.DictWriter(f, fieldnames=[
+            "rel_path", "current_folder", "proposed_folder", "changed",
+            "source", "top_theme", "confidence", "score",
+        ])
+        writer.writeheader()
+        for r in processed:
+            writer.writerow(r)
+
+    # Agrégation summary
+    n_files = len(processed)
+    n_moving = sum(1 for r in processed if r["changed"])
+    n_stable = sum(1 for r in processed if r["proposed_folder"] and not r["changed"])
+    n_no_pred = sum(1 for r in processed if not r["proposed_folder"])
+    n_by_source = Counter(r["source"] for r in processed if r["proposed_folder"])
+
+    # Top destinations (dossiers qui reçoivent le plus de fichiers en mouvement)
+    incoming = defaultdict(int)
+    outgoing = defaultdict(int)
+    for r in processed:
+        if r["changed"] and r["proposed_folder"]:
+            incoming[r["proposed_folder"]] += 1
+            outgoing[r["current_folder"] or "(racine)"] += 1
+    top_destinations = [
+        {"folder": k, "n_incoming": v}
+        for k, v in sorted(incoming.items(), key=lambda x: -x[1])[:20]
+    ]
+    top_origins = [
+        {"folder": k, "n_outgoing": v}
+        for k, v in sorted(outgoing.items(), key=lambda x: -x[1])[:20]
+    ]
+
+    summary: dict[str, Any] = {
+        "csv_path": str(csv_path),
+        "summary_path": str(sim_dir / "simulation-summary.json"),
+        "n_files": n_files,
+        "n_moving": n_moving,
+        "n_stable": n_stable,
+        "n_no_prediction": n_no_pred,
+        "n_by_source": dict(n_by_source),
+        "top_destinations": top_destinations,
+        "top_origins": top_origins,
+    }
+    (sim_dir / "simulation-summary.json").write_text(
+        json.dumps(summary, ensure_ascii=False, indent=2),
+        encoding="utf-8",
+    )
+
+    return summary
+
+
+def _empty_summary(proposal_dir: Path) -> dict[str, Any]:
+    """Retour minimal si le profil n'a pas de target FS valide."""
+    sim_dir = proposal_dir.parent / "simulation"
+    sim_dir.mkdir(parents=True, exist_ok=True)
+    summary: dict[str, Any] = {
+        "csv_path": "",
+        "summary_path": str(sim_dir / "simulation-summary.json"),
+        "n_files": 0,
+        "n_moving": 0,
+        "n_stable": 0,
+        "n_no_prediction": 0,
+        "n_by_source": {},
+        "top_destinations": [],
+        "top_origins": [],
+    }
+    (sim_dir / "simulation-summary.json").write_text(
+        json.dumps(summary, ensure_ascii=False, indent=2),
+        encoding="utf-8",
+    )
+    return summary

--- a/agents/refonte/state.py
+++ b/agents/refonte/state.py
@@ -30,3 +30,8 @@ class RefonteState(MessagesState, total=False):
     error: str
     report: str
     llm_calls: int
+    # Phase B uniquement : run_id du diagnostic Phase A qu'on utilise comme
+    # contexte d'entrée + chemin du dossier proposed/ écrit en sortie
+    diagnostic_run_id: str
+    proposal_dir: str
+    proposal_summary: dict

--- a/agents/refonte/state.py
+++ b/agents/refonte/state.py
@@ -35,3 +35,6 @@ class RefonteState(MessagesState, total=False):
     diagnostic_run_id: str
     proposal_dir: str
     proposal_summary: dict
+    # Résultat de la simulation reclassify (déclenchée automatiquement après
+    # propose_changes) : agrégats + chemin du CSV produit
+    simulation_summary: dict

--- a/dashboard/agent_refonte.py
+++ b/dashboard/agent_refonte.py
@@ -278,3 +278,153 @@ def _run_diagnostic(profile: str, run_id: str, max_llm_calls: int) -> None:
             "traceback": traceback.format_exc(),
         })
         _write_status(profile, run_id, status_payload)
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+#  Phase B — Proposition
+# ═══════════════════════════════════════════════════════════════════════════
+#
+# Même pattern que Phase A : start_proposition() lance un thread daemon qui
+# invoque build_proposition_graph().stream(...) et écrit status.json à chaque
+# transition. Les artefacts produits (tree-proposed.yaml + theme_mapping-
+# proposed.yaml + refonte-rationale.md) sont écrits par le tool propose_changes
+# dans `.cache/refonte/<run_id>/proposed/`.
+
+
+def start_proposition(
+    profile: str,
+    diagnostic_run_id: str,
+    max_llm_calls: int = 8,
+) -> dict[str, Any]:
+    """Démarre un run de Phase B basé sur un diagnostic Phase A existant.
+
+    Args:
+        profile: Nom du profil.
+        diagnostic_run_id: UUID d'un run Phase A `done` à utiliser comme contexte.
+        max_llm_calls: Budget LLM (default 8 — la proposition est plus complexe).
+
+    Returns:
+        {"run_id": str, "status": "pending", "profile": str, "phase": "B",
+         "diagnostic_run_id": str}
+
+    Raises:
+        ValueError: profile vide ou diagnostic_run_id vide.
+        FileNotFoundError: profile inconnu, ou diagnostic absent / pas en `done`.
+    """
+    if not profile:
+        raise ValueError("profile is required")
+    if not diagnostic_run_id:
+        raise ValueError("diagnostic_run_id is required")
+    profile_path = data.get_project_root() / "profiles" / profile
+    if not profile_path.is_dir():
+        raise FileNotFoundError(f"profile not found: {profile}")
+    # Vérifie que le diagnostic existe et est en `done`
+    diag_status = _read_status(profile, diagnostic_run_id)
+    if not diag_status:
+        raise FileNotFoundError(
+            f"diagnostic run not found: {diagnostic_run_id} (profile={profile})"
+        )
+    if diag_status.get("status") != "done":
+        raise ValueError(
+            f"diagnostic run {diagnostic_run_id} is in status "
+            f"'{diag_status.get('status')}' (must be 'done' to base Phase B on it)"
+        )
+
+    run_id = str(uuid.uuid4())
+    now = datetime.now(UTC).isoformat()
+    initial = {
+        "run_id": run_id,
+        "profile": profile,
+        "phase": "B",
+        "diagnostic_run_id": diagnostic_run_id,
+        "status": "pending",
+        "started_at": now,
+        "completed_at": None,
+        "llm_calls": 0,
+        "max_llm_calls": max_llm_calls,
+        "error": None,
+    }
+    _write_status(profile, run_id, initial)
+
+    thread = threading.Thread(
+        target=_run_proposition,
+        args=(profile, run_id, diagnostic_run_id, max_llm_calls),
+        daemon=True,
+        name=f"refonte-B-{run_id[:8]}",
+    )
+    thread.start()
+
+    return {
+        "run_id": run_id,
+        "status": "pending",
+        "profile": profile,
+        "phase": "B",
+        "diagnostic_run_id": diagnostic_run_id,
+    }
+
+
+def _run_proposition(
+    profile: str,
+    run_id: str,
+    diagnostic_run_id: str,
+    max_llm_calls: int,
+) -> None:
+    """Lance le graphe Phase B dans le thread. Mute toutes erreurs vers status.json."""
+    try:
+        tax.reset_cache(profile)
+    except Exception:  # pragma: no cover — defensive
+        pass
+
+    started_at = datetime.now(UTC).isoformat()
+    status_payload = _read_status(profile, run_id) or {}
+    status_payload.update({"status": "running", "started_at": started_at})
+    _write_status(profile, run_id, status_payload)
+
+    # Import différé (langchain-openai chargé seulement à l'invocation)
+    from agents.refonte.proposition import build_proposition_graph
+
+    try:
+        graph = build_proposition_graph(
+            profile=profile,
+            run_id=run_id,
+            max_llm_calls=max_llm_calls,
+        )
+        result: dict[str, Any] = {}
+        for state_snapshot in graph.stream(
+            {
+                "profile": profile,
+                "run_id": run_id,
+                "diagnostic_run_id": diagnostic_run_id,
+            },
+            stream_mode="values",
+        ):
+            result = state_snapshot
+            if isinstance(state_snapshot, dict):
+                status_payload["llm_calls"] = state_snapshot.get("llm_calls", 0)
+                if state_snapshot.get("proposal_dir"):
+                    status_payload["current_node"] = "finalize"
+                elif state_snapshot.get("llm_calls", 0) > 0:
+                    status_payload["current_node"] = "analyze"
+                else:
+                    status_payload["current_node"] = "init"
+                _write_status(profile, run_id, status_payload)
+
+        completed_at = datetime.now(UTC).isoformat()
+        status_payload.update({
+            "status": result.get("status", "done"),
+            "completed_at": completed_at,
+            "llm_calls": result.get("llm_calls", 0),
+            "error": result.get("error"),
+            "current_node": None,
+            "proposal_dir": result.get("proposal_dir"),
+            "proposal_summary": result.get("proposal_summary"),
+        })
+        _write_status(profile, run_id, status_payload)
+    except Exception as exc:
+        status_payload.update({
+            "status": "error",
+            "completed_at": datetime.now(UTC).isoformat(),
+            "error": f"{type(exc).__name__}: {exc}",
+            "traceback": traceback.format_exc(),
+        })
+        _write_status(profile, run_id, status_payload)

--- a/dashboard/agent_refonte.py
+++ b/dashboard/agent_refonte.py
@@ -13,6 +13,8 @@ synchrones pour les endpoints FastAPI.
 from __future__ import annotations
 
 import json
+import re
+import shutil
 import threading
 import traceback
 import uuid
@@ -22,6 +24,8 @@ from typing import Any
 
 from dashboard import data
 from dashboard import taxonomy as tax
+
+_UUID_RE = re.compile(r"^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$")
 
 
 def _runs_dir(profile: str) -> Path:
@@ -298,6 +302,50 @@ def list_runs(profile: str, limit: int = 20) -> list[dict[str, Any]]:
             continue
     runs.sort(key=lambda r: r.get("started_at") or "", reverse=True)
     return runs[:limit]
+
+
+class RunBusyError(Exception):
+    """Tentative de suppression d'un run encore en cours (running/pending)."""
+
+
+def delete_run(profile: str, run_id: str) -> dict[str, Any]:
+    """Supprime un run et tous ses artefacts (status.json, report.md, proposed/, …).
+
+    Refuse de toucher à un run actif (status running/pending) pour ne pas
+    arracher le tapis sous un thread daemon qui écrit encore. Si le user
+    veut quand même purger un "running" coincé, il attend le reap zombie
+    (~5 min) ou redémarre le dashboard.
+
+    Args:
+        profile: Nom du profil.
+        run_id: UUID4 du run à supprimer.
+
+    Returns:
+        {"profile": ..., "run_id": ...}
+
+    Raises:
+        ValueError: profile / run_id vide ou run_id mal formé.
+        FileNotFoundError: run inexistant pour ce profil.
+        RunBusyError: run encore actif (running/pending).
+    """
+    if not profile:
+        raise ValueError("profile is required")
+    if not run_id or not _UUID_RE.match(run_id):
+        raise ValueError("run_id must be a UUID4")
+    runs_dir = _runs_dir(profile)
+    # Reap d'abord pour qu'un zombie devienne supprimable sans attendre.
+    _reap_zombie_runs(runs_dir)
+    target = runs_dir / run_id
+    if not target.is_dir():
+        raise FileNotFoundError(f"run not found: {run_id}")
+    status = _read_status(profile, run_id) or {}
+    if status.get("status") in ("running", "pending"):
+        raise RunBusyError(
+            f"run {run_id} is still {status.get('status')}, "
+            "wait for it to finish or be reaped (5 min)"
+        )
+    shutil.rmtree(target)
+    return {"profile": profile, "run_id": run_id}
 
 
 # Seuil au-delà duquel un run "running" est considéré orphelin (zombie).

--- a/dashboard/agent_refonte.py
+++ b/dashboard/agent_refonte.py
@@ -113,23 +113,167 @@ def start_diagnostic(profile: str, max_llm_calls: int = 5) -> dict[str, Any]:
 
 
 def get_status(profile: str, run_id: str) -> dict[str, Any] | None:
-    """Lit le status d'un run + injecte le contenu du report si disponible.
+    """Lit le status d'un run + injecte le contenu pertinent si disponible.
+
+    Pour les runs **Phase A** (diagnostic) `done` : injecte `report_md`.
+    Pour les runs **Phase B** (proposition) `done` : injecte `rationale_md`
+    (le markdown de `refonte-rationale.md`). Les artefacts plus volumineux
+    (tree-diff, simulation CSV) sont exposés par des endpoints dédiés pour
+    éviter de gonfler le payload de polling.
 
     Returns:
-        Dict avec les clés de status.json + clé `report_md` si status=="done".
-        None si le run est introuvable.
+        Dict avec les clés de status.json + clés `report_md` ou `rationale_md`
+        selon le contexte. None si le run est introuvable.
     """
     status = _read_status(profile, run_id)
     if status is None:
         return None
     if status.get("status") == "done":
-        rpath = _report_path(profile, run_id)
-        if rpath.exists():
-            try:
-                status["report_md"] = rpath.read_text(encoding="utf-8")
-            except OSError:
-                status["report_md"] = ""
+        phase = status.get("phase", "A")
+        if phase == "B":
+            rationale_path = _proposal_rationale_path(profile, run_id)
+            if rationale_path and rationale_path.exists():
+                try:
+                    status["rationale_md"] = rationale_path.read_text(encoding="utf-8")
+                except OSError:
+                    status["rationale_md"] = ""
+        else:
+            rpath = _report_path(profile, run_id)
+            if rpath.exists():
+                try:
+                    status["report_md"] = rpath.read_text(encoding="utf-8")
+                except OSError:
+                    status["report_md"] = ""
     return status
+
+
+def _proposal_rationale_path(profile: str, run_id: str) -> Path | None:
+    """Chemin attendu du refonte-rationale.md pour un run Phase B."""
+    p = _run_dir(profile, run_id) / "proposed" / "refonte-rationale.md"
+    return p
+
+
+def get_proposition_tree_diff(profile: str, run_id: str) -> dict[str, Any]:
+    """Compare tree.yaml courant et tree-proposed.yaml du run B.
+
+    Returns:
+        {
+            "added": list[str],     # dossiers présents en proposed mais pas en current
+            "removed": list[str],   # absents en proposed mais en current
+            "renamed": list[{old, new, rationale}],  # depuis changes.json
+            "fused": list[{sources, target, rationale}],  # depuis changes.json
+            "n_folders_before": int,
+            "n_folders_after": int,
+        }
+    """
+    import yaml as _yaml
+    proposed_dir = _run_dir(profile, run_id) / "proposed"
+    tree_proposed = proposed_dir / "tree-proposed.yaml"
+    changes_json = proposed_dir / "changes.json"
+
+    # Charge tree courant via la fonction taxonomy
+    current_folders = set(tax._load_tree(profile))
+    proposed_folders: set[str] = set()
+    if tree_proposed.exists():
+        try:
+            raw = _yaml.safe_load(tree_proposed.read_text(encoding="utf-8")) or {}
+            proposed_folders = set(raw.get("folders") or [])
+        except _yaml.YAMLError:
+            proposed_folders = set()
+
+    renamed: list[dict[str, Any]] = []
+    fused: list[dict[str, Any]] = []
+    if changes_json.exists():
+        try:
+            ch = json.loads(changes_json.read_text(encoding="utf-8"))
+            renamed = [
+                {"old": r.get("old_path"), "new": r.get("new_path"),
+                 "rationale": r.get("rationale", "")}
+                for r in (ch.get("renamings") or [])
+            ]
+            fused = [
+                {"sources": f.get("sources", []), "target": f.get("target"),
+                 "rationale": f.get("rationale", "")}
+                for f in (ch.get("fusions") or [])
+            ]
+        except (OSError, json.JSONDecodeError):
+            pass
+
+    # On retire des "added/removed" les paires couvertes par renames/fusions
+    # (sinon on les double-compte côté UI).
+    rename_old = {r["old"] for r in renamed if r.get("old")}
+    rename_new = {r["new"] for r in renamed if r.get("new")}
+    fusion_sources = {s for f in fused for s in (f.get("sources") or [])}
+    fusion_targets = {f["target"] for f in fused if f.get("target")}
+
+    added = sorted(
+        f for f in (proposed_folders - current_folders)
+        if f not in rename_new and f not in fusion_targets
+    )
+    removed = sorted(
+        f for f in (current_folders - proposed_folders)
+        if f not in rename_old and f not in fusion_sources
+    )
+
+    return {
+        "added": added,
+        "removed": removed,
+        "renamed": renamed,
+        "fused": fused,
+        "n_folders_before": len(current_folders),
+        "n_folders_after": len(proposed_folders),
+    }
+
+
+def get_proposition_simulation(
+    profile: str,
+    run_id: str,
+    sample_limit: int = 50,
+) -> dict[str, Any] | None:
+    """Lit le simulation-summary.json + N lignes de la projection CSV.
+
+    Args:
+        profile: Nom du profil.
+        run_id: UUID du run Phase B.
+        sample_limit: Nombre max de lignes du CSV à inclure (par défaut 50).
+                      Le CSV complet peut faire 18k+ lignes — gardé côté serveur.
+
+    Returns:
+        {
+            "summary": dict (contenu de simulation-summary.json),
+            "sample_moves": list[dict] (jusqu'à `sample_limit` lignes où changed=True),
+            "n_moves_total": int,
+        }
+        None si la simulation n'a pas tourné (run Phase A par ex.).
+    """
+    import csv as _csv
+    sim_dir = _run_dir(profile, run_id) / "simulation"
+    summary_path = sim_dir / "simulation-summary.json"
+    csv_path = sim_dir / "reclassify-projection.csv"
+    if not summary_path.exists():
+        return None
+    try:
+        summary = json.loads(summary_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return None
+    moves: list[dict[str, Any]] = []
+    n_moves_total = 0
+    if csv_path.exists():
+        try:
+            with csv_path.open(encoding="utf-8", newline="") as f:
+                reader = _csv.DictReader(f)
+                for row in reader:
+                    if row.get("changed", "").lower() == "true":
+                        n_moves_total += 1
+                        if len(moves) < sample_limit:
+                            moves.append(row)
+        except (OSError, _csv.Error):
+            pass
+    return {
+        "summary": summary,
+        "sample_moves": moves,
+        "n_moves_total": n_moves_total,
+    }
 
 
 def list_runs(profile: str, limit: int = 20) -> list[dict[str, Any]]:

--- a/dashboard/app.py
+++ b/dashboard/app.py
@@ -2345,3 +2345,32 @@ async def api_agent_refonte_runs(profile: str, limit: int = 20):
     limit = max(1, min(int(limit), 100))
     runs = agent_refonte.list_runs(profile, limit=limit)
     return JSONResponse({"profile": profile, "runs": runs})
+
+
+# ──────────── Phase B : Proposition ────────────
+
+
+@app.post("/api/agent/refonte/proposition")
+async def api_agent_refonte_proposition_start(request: Request):
+    """Démarre un run Phase B basé sur un diagnostic Phase A existant.
+
+    Body: {profile, diagnostic_run_id, max_llm_calls?}.
+    """
+    from fastapi.responses import JSONResponse
+    body = await request.json()
+    profile = (body.get("profile") or "").strip()
+    diagnostic_run_id = (body.get("diagnostic_run_id") or "").strip()
+    max_llm_calls = int(body.get("max_llm_calls") or 8)
+    if max_llm_calls < 1 or max_llm_calls > 20:
+        return JSONResponse({"error": "max_llm_calls must be between 1 and 20"}, status_code=400)
+    try:
+        result = agent_refonte.start_proposition(
+            profile=profile,
+            diagnostic_run_id=diagnostic_run_id,
+            max_llm_calls=max_llm_calls,
+        )
+        return JSONResponse(result)
+    except ValueError as exc:
+        return JSONResponse({"error": str(exc)}, status_code=400)
+    except FileNotFoundError as exc:
+        return JSONResponse({"error": str(exc)}, status_code=404)

--- a/dashboard/app.py
+++ b/dashboard/app.py
@@ -2350,6 +2350,32 @@ async def api_agent_refonte_runs(profile: str, limit: int = 20):
 # ──────────── Phase B : Proposition ────────────
 
 
+@app.get("/api/agent/refonte/proposition/{run_id}/tree-diff")
+async def api_agent_refonte_tree_diff(run_id: str, profile: str):
+    """Diff visuel du tree.yaml courant vs tree-proposed.yaml du run B."""
+    from fastapi.responses import JSONResponse
+    if not profile:
+        return JSONResponse({"error": "profile query param is required"}, status_code=400)
+    diff = agent_refonte.get_proposition_tree_diff(profile, run_id)
+    return JSONResponse(diff)
+
+
+@app.get("/api/agent/refonte/proposition/{run_id}/simulation")
+async def api_agent_refonte_simulation(run_id: str, profile: str, sample_limit: int = 50):
+    """Lit le simulation-summary.json + N premières lignes de la projection CSV."""
+    from fastapi.responses import JSONResponse
+    if not profile:
+        return JSONResponse({"error": "profile query param is required"}, status_code=400)
+    sample_limit = max(1, min(int(sample_limit), 500))
+    result = agent_refonte.get_proposition_simulation(profile, run_id, sample_limit=sample_limit)
+    if result is None:
+        return JSONResponse(
+            {"error": f"simulation not found for run {run_id} (probably Phase A run, or simulation failed)"},
+            status_code=404,
+        )
+    return JSONResponse(result)
+
+
 @app.post("/api/agent/refonte/proposition")
 async def api_agent_refonte_proposition_start(request: Request):
     """Démarre un run Phase B basé sur un diagnostic Phase A existant.

--- a/dashboard/app.py
+++ b/dashboard/app.py
@@ -2347,6 +2347,23 @@ async def api_agent_refonte_runs(profile: str, limit: int = 20):
     return JSONResponse({"profile": profile, "runs": runs})
 
 
+@app.delete("/api/agent/refonte/runs/{run_id}")
+async def api_agent_refonte_delete_run(run_id: str, profile: str):
+    """Supprime un run (et tous ses artefacts) du cache local."""
+    from fastapi.responses import JSONResponse
+    if not profile:
+        return JSONResponse({"error": "profile query param is required"}, status_code=400)
+    try:
+        result = agent_refonte.delete_run(profile, run_id)
+        return JSONResponse(result)
+    except ValueError as exc:
+        return JSONResponse({"error": str(exc)}, status_code=400)
+    except FileNotFoundError as exc:
+        return JSONResponse({"error": str(exc)}, status_code=404)
+    except agent_refonte.RunBusyError as exc:
+        return JSONResponse({"error": str(exc)}, status_code=409)
+
+
 # ──────────── Phase B : Proposition ────────────
 
 

--- a/dashboard/templates/partials/agent_refonte_panel.html
+++ b/dashboard/templates/partials/agent_refonte_panel.html
@@ -323,6 +323,43 @@
 .tax-refonte-md h1 { font-size: 1.4em; margin: 0 0 12px; padding-bottom: 6px;
                      border-bottom: 1px solid var(--border); }
 .tax-refonte-md h2 { font-size: 1.15em; margin: 18px 0 8px; }
+/* H2 stylés (rapport B — sections par type de changement) */
+.tax-refonte-md h2[data-kind] {
+    padding: 5px 10px;
+    border-radius: 4px;
+    cursor: pointer;
+    user-select: none;
+}
+.tax-refonte-md h2[data-kind]::before {
+    content: '▾ ';
+    font-size: 0.85em;
+    color: var(--text-muted);
+}
+.tax-refonte-md h2[data-kind].collapsed::before { content: '▸ '; }
+.tax-refonte-md h2[data-kind="creations"] {
+    background: rgba(34, 197, 94, 0.15);
+    border-left: 3px solid #22c55e;
+}
+.tax-refonte-md h2[data-kind="renommages"] {
+    background: rgba(249, 115, 22, 0.15);
+    border-left: 3px solid #f97316;
+}
+.tax-refonte-md h2[data-kind="suppressions"] {
+    background: rgba(239, 68, 68, 0.15);
+    border-left: 3px solid #ef4444;
+}
+.tax-refonte-md h2[data-kind="fusions"] {
+    background: rgba(168, 85, 247, 0.15);
+    border-left: 3px solid #a855f7;
+}
+.tax-refonte-md h2[data-kind="mappings"] {
+    background: rgba(59, 130, 246, 0.15);
+    border-left: 3px solid #3b82f6;
+}
+.tax-refonte-md h2[data-kind="summary"] {
+    background: rgba(107, 114, 128, 0.10);
+    border-left: 3px solid #6b7280;
+}
 .tax-refonte-md h3 {
     font-size: 1.05em;
     margin: 14px 0 6px;
@@ -441,6 +478,46 @@
         return 'info';
     }
 
+    // Type d'une section H2 du rationale Phase B (créations / renommages /
+    // suppressions / fusions / mappings / summary) — drive la colorisation
+    // et le collapse par défaut côté mappings (200 lignes sinon).
+    function kindForH2(h2text) {
+        const t = h2text.toLowerCase();
+        if (/cr[ée]ation/.test(t)) return 'creations';
+        if (/renomm/.test(t)) return 'renommages';
+        if (/suppression/.test(t)) return 'suppressions';
+        if (/fusion/.test(t)) return 'fusions';
+        if (/mapping/.test(t)) return 'mappings';
+        if (/r[ée]sum[ée]/.test(t)) return 'summary';
+        return null;  // h2 non typé → pas de polish
+    }
+
+    // Wrap les éléments suivants un header jusqu'au prochain header de
+    // niveau ≤ stopAtLevels dans un .tax-refonte-section collapsible.
+    // collapsed=true → section masquée et header en classe "collapsed".
+    function wrapSectionAfter(header, stopAtLevels, collapsed) {
+        const stop = new Set(stopAtLevels.map(l => 'H' + l));
+        const section = document.createElement('div');
+        section.className = 'tax-refonte-section';
+        let next = header.nextElementSibling;
+        while (next && !stop.has(next.tagName)) {
+            const tmp = next.nextElementSibling;
+            section.appendChild(next);
+            next = tmp;
+        }
+        header.parentNode.insertBefore(section, next);
+        if (collapsed) {
+            section.style.display = 'none';
+            header.classList.add('collapsed');
+        }
+        header.addEventListener('click', () => {
+            const hidden = section.style.display === 'none';
+            section.style.display = hidden ? '' : 'none';
+            header.classList.toggle('collapsed', !hidden);
+        });
+        return section;
+    }
+
     // ─── Rendu Phase B (multi-onglets Rationale / Diff / Impact) ─────────
 
     function renderPhaseBReport(runId, status) {
@@ -467,6 +544,7 @@
         const rationaleEl = document.getElementById('tax-refonte-rationale-md');
         if (window.marked && rationaleMd) {
             rationaleEl.innerHTML = window.marked.parse(rationaleMd);
+            enhancePhaseBRationale(rationaleEl);
         } else {
             rationaleEl.textContent = rationaleMd || '(rationale vide)';
         }
@@ -692,28 +770,26 @@
         // marked.parse v13 : escapes HTML par défaut, headerIds auto-générés
         const html = window.marked ? window.marked.parse(md) : md;
         reportEl.innerHTML = html;
-        // Post-process : priorité + collapse
-        const h3s = Array.from(reportEl.querySelectorAll('h3'));
-        for (const h3 of h3s) {
+        // Post-process : priorité + collapse sur les h3 du diagnostic A
+        for (const h3 of Array.from(reportEl.querySelectorAll('h3'))) {
             h3.dataset.priority = priorityFor(h3.textContent);
-            // Regroupe tous les éléments suivants jusqu'au prochain h3/h2 dans
-            // un wrapper qu'on peut hide/show via la classe "collapsed".
-            const section = document.createElement('div');
-            section.className = 'tax-refonte-section';
-            let next = h3.nextElementSibling;
-            while (next && !['H3', 'H2'].includes(next.tagName)) {
-                const tmp = next.nextElementSibling;
-                section.appendChild(next);
-                next = tmp;
-            }
-            h3.parentNode.insertBefore(section, next);
-            h3.addEventListener('click', () => {
-                const hidden = section.style.display === 'none';
-                section.style.display = hidden ? '' : 'none';
-                h3.classList.toggle('collapsed', !hidden);
-            });
+            wrapSectionAfter(h3, [2, 3], false);
         }
         updateActionButtons(true);
+    }
+
+    // Polish visuel du rationale Phase B : colorisation des h2 par type
+    // (créations vert / renommages orange / suppressions rouge / fusions
+    // violet / mappings bleu / résumé neutre) + collapse, avec la section
+    // "Mappings ajoutés" repliée par défaut (200 lignes sinon illisible).
+    function enhancePhaseBRationale(rootEl) {
+        for (const h2 of Array.from(rootEl.querySelectorAll('h2'))) {
+            const kind = kindForH2(h2.textContent);
+            if (!kind) continue;
+            h2.dataset.kind = kind;
+            const collapseByDefault = (kind === 'mappings');
+            wrapSectionAfter(h2, [1, 2], collapseByDefault);
+        }
     }
 
     function updateActionButtons(enabled) {

--- a/dashboard/templates/partials/agent_refonte_panel.html
+++ b/dashboard/templates/partials/agent_refonte_panel.html
@@ -290,6 +290,24 @@
     color: var(--text-muted);
 }
 .tax-refonte-run-sep { opacity: 0.5; }
+.tax-refonte-run-delete {
+    margin-left: auto;
+    background: transparent;
+    border: none;
+    color: var(--text-muted);
+    cursor: pointer;
+    font-size: 16px;
+    line-height: 1;
+    padding: 0 4px;
+    border-radius: 3px;
+    opacity: 0.5;
+    transition: opacity 0.15s, color 0.15s, background 0.15s;
+}
+.tax-refonte-run-item:hover .tax-refonte-run-delete { opacity: 1; }
+.tax-refonte-run-delete:hover {
+    color: #ff8b8b;
+    background: rgba(255, 92, 92, 0.12);
+}
 
 .tax-refonte-report-header {
     display: flex;
@@ -752,16 +770,53 @@
                 + 'padding:1px 6px;border-radius:3px;color:#a78bfa;">B</span>'
                 : '<span class="tax-refonte-run-meta" style="background:rgba(79,110,242,0.18);'
                 + 'padding:1px 6px;border-radius:3px;color:#93b1ff;">A</span>';
+            const isBusy = r.status === 'running' || r.status === 'pending';
+            const deleteBtn = isBusy
+                ? ''
+                : '<button type="button" class="tax-refonte-run-delete" '
+                + 'title="Supprimer ce run" aria-label="Supprimer ce run">×</button>';
             item.innerHTML =
                 '<div class="tax-refonte-run-head">'
               + '  <code class="tax-refonte-run-id">' + r.run_id.slice(0, 8) + '</code>'
               + '  ' + phaseLabel
               + '  <span class="status-badge status-' + r.status + '">' + r.status + '</span>'
+              + '  ' + deleteBtn
               + '</div>'
               + '<div class="tax-refonte-run-foot">'
               + '  <span class="tax-refonte-run-meta">' + startedTxt + '</span>'
               + (llmInfo ? '<span class="tax-refonte-run-sep">·</span>' + llmInfo : '')
               + '</div>';
+            const delEl = item.querySelector('.tax-refonte-run-delete');
+            if (delEl) {
+                delEl.addEventListener('click', async (ev) => {
+                    ev.stopPropagation();
+                    if (!confirm('Supprimer le run ' + r.run_id.slice(0, 8) + ' ?')) return;
+                    try {
+                        const resp = await fetch(
+                            '/api/agent/refonte/runs/' + encodeURIComponent(r.run_id)
+                          + '?profile=' + encodeURIComponent(currentProfile()),
+                            { method: 'DELETE' }
+                        );
+                        if (!resp.ok) {
+                            const err = await resp.json().catch(() => ({}));
+                            alert('Erreur : ' + (err.error || resp.status));
+                            return;
+                        }
+                        // Si on supprime le run actif → clear l'UI
+                        if (currentRunId === r.run_id) {
+                            if (pollTimer) { clearInterval(pollTimer); pollTimer = null; }
+                            currentRunId = null;
+                            currentRunPhase = null;
+                            renderReport('');
+                            startBtn.disabled = false;
+                            updateProposeButton();
+                        }
+                        loadRuns();
+                    } catch (e) {
+                        alert('Erreur réseau : ' + e.message);
+                    }
+                });
+            }
             item.addEventListener('click', () => {
                 const switchingRun = currentRunId !== r.run_id;
                 runsEl.querySelectorAll('.tax-refonte-run-item.active')

--- a/dashboard/templates/partials/agent_refonte_panel.html
+++ b/dashboard/templates/partials/agent_refonte_panel.html
@@ -254,59 +254,158 @@
     margin: 6px 0 0;
 }
 .tax-refonte-run-item {
-    padding: 8px 10px;
+    position: relative;
+    display: grid;
+    grid-template-columns: 32px 1fr auto;
+    grid-template-rows: auto auto;
+    grid-column-gap: 10px;
+    grid-row-gap: 2px;
+    align-items: center;
+    padding: 10px 12px 10px 14px;
     border: 1px solid var(--border);
-    border-radius: 6px;
+    border-radius: 8px;
     margin-bottom: 8px;
     cursor: pointer;
     background: var(--bg-secondary);
-    transition: background 0.12s ease, border-color 0.12s ease;
+    transition: background 0.15s ease, border-color 0.15s ease, transform 0.1s ease;
+    overflow: hidden;
+}
+.tax-refonte-run-item::before {
+    content: '';
+    position: absolute;
+    left: 0; top: 0; bottom: 0;
+    width: 3px;
+    background: transparent;
+    transition: background 0.15s ease;
 }
 .tax-refonte-run-item:hover {
     background: var(--bg-tertiary, rgba(255, 255, 255, 0.04));
     border-color: var(--border-light, #3a3a3a);
 }
 .tax-refonte-run-item.active {
-    border-color: #4f6ef2;
-    background: rgba(79, 110, 242, 0.08);
+    border-color: rgba(79, 110, 242, 0.5);
+    background: rgba(79, 110, 242, 0.07);
+    box-shadow: 0 0 0 1px rgba(79, 110, 242, 0.15);
 }
-.tax-refonte-run-head {
+.tax-refonte-run-item.active::before {
+    background: linear-gradient(180deg, #4f6ef2, #8b5cf6);
+}
+
+/* Avatar phase circulaire (col 1, span 2 rows) */
+.tax-refonte-run-phase {
+    grid-row: 1 / span 2;
+    width: 32px;
+    height: 32px;
+    border-radius: 50%;
     display: flex;
-    justify-content: space-between;
     align-items: center;
-    gap: 8px;
+    justify-content: center;
+    font-size: 13px;
+    font-weight: 600;
+    letter-spacing: 0.5px;
+    color: #fff;
+    flex-shrink: 0;
 }
-.tax-refonte-run-id {
-    font-size: 11px;
-    color: var(--text-muted);
-    font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+.tax-refonte-run-phase[data-phase="A"] {
+    background: linear-gradient(135deg, #4f6ef2, #6d8aff);
+    box-shadow: 0 1px 4px rgba(79, 110, 242, 0.35);
 }
-.tax-refonte-run-foot {
-    display: flex;
+.tax-refonte-run-phase[data-phase="B"] {
+    background: linear-gradient(135deg, #8b5cf6, #a78bfa);
+    box-shadow: 0 1px 4px rgba(139, 92, 246, 0.35);
+}
+
+/* Status (col 2, row 1) : dot coloré + label */
+.tax-refonte-run-status {
+    display: inline-flex;
     align-items: center;
     gap: 6px;
-    margin-top: 4px;
-    font-size: 11.5px;
-    color: var(--text-muted);
+    font-size: 12.5px;
+    font-weight: 500;
+    color: var(--text-primary, #e6e6e6);
+    text-transform: capitalize;
 }
-.tax-refonte-run-sep { opacity: 0.5; }
+.tax-refonte-run-status::before {
+    content: '';
+    width: 7px;
+    height: 7px;
+    border-radius: 50%;
+    background: var(--text-muted);
+    flex-shrink: 0;
+}
+.tax-refonte-run-status[data-status="done"]::before {
+    background: #22c55e;
+    box-shadow: 0 0 6px rgba(34, 197, 94, 0.5);
+}
+.tax-refonte-run-status[data-status="running"]::before,
+.tax-refonte-run-status[data-status="pending"]::before {
+    background: #4f6ef2;
+    animation: taxRefonteRunPulse 1.4s ease-in-out infinite;
+}
+.tax-refonte-run-status[data-status="error"]::before {
+    background: #ef4444;
+    box-shadow: 0 0 6px rgba(239, 68, 68, 0.5);
+}
+@keyframes taxRefonteRunPulse {
+    0%, 100% { transform: scale(1); opacity: 1; box-shadow: 0 0 0 0 rgba(79, 110, 242, 0.6); }
+    50%      { transform: scale(1.15); opacity: 0.85; box-shadow: 0 0 0 5px rgba(79, 110, 242, 0); }
+}
+
+/* Bouton × (col 3, row 1) */
 .tax-refonte-run-delete {
-    margin-left: auto;
+    grid-column: 3;
+    grid-row: 1;
     background: transparent;
     border: none;
     color: var(--text-muted);
     cursor: pointer;
-    font-size: 16px;
+    font-size: 18px;
     line-height: 1;
-    padding: 0 4px;
-    border-radius: 3px;
-    opacity: 0.5;
+    padding: 2px 6px;
+    border-radius: 4px;
+    opacity: 0;
     transition: opacity 0.15s, color 0.15s, background 0.15s;
 }
-.tax-refonte-run-item:hover .tax-refonte-run-delete { opacity: 1; }
+.tax-refonte-run-item:hover .tax-refonte-run-delete,
+.tax-refonte-run-item.active .tax-refonte-run-delete { opacity: 0.7; }
 .tax-refonte-run-delete:hover {
+    opacity: 1 !important;
     color: #ff8b8b;
     background: rgba(255, 92, 92, 0.12);
+}
+
+/* Footer (col 2, row 2) : time + LLM count */
+.tax-refonte-run-meta-row {
+    grid-column: 2;
+    grid-row: 2;
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    font-size: 11.5px;
+    color: var(--text-muted);
+}
+.tax-refonte-run-meta {
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+}
+.tax-refonte-run-meta svg {
+    width: 11px;
+    height: 11px;
+    opacity: 0.7;
+    flex-shrink: 0;
+}
+
+/* UUID discret (col 3, row 2, justifié droite) */
+.tax-refonte-run-id {
+    grid-column: 3;
+    grid-row: 2;
+    justify-self: end;
+    font-size: 10.5px;
+    color: var(--text-muted);
+    font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+    opacity: 0.55;
+    letter-spacing: 0.3px;
 }
 
 .tax-refonte-report-header {
@@ -884,30 +983,29 @@
             item.dataset.runId = r.run_id;
             // Format date plus lisible : "il y a Xm" si récent, sinon date courte
             const startedTxt = formatStarted(r.started_at);
-            const llmInfo = r.llm_calls
-                ? '<span class="tax-refonte-run-meta">' + r.llm_calls + ' LLM</span>'
-                : '';
-            const phaseLabel = r.phase === 'B'
-                ? '<span class="tax-refonte-run-meta" style="background:rgba(139,92,246,0.18);'
-                + 'padding:1px 6px;border-radius:3px;color:#a78bfa;">B</span>'
-                : '<span class="tax-refonte-run-meta" style="background:rgba(79,110,242,0.18);'
-                + 'padding:1px 6px;border-radius:3px;color:#93b1ff;">A</span>';
             const isBusy = r.status === 'running' || r.status === 'pending';
             const deleteBtn = isBusy
                 ? ''
                 : '<button type="button" class="tax-refonte-run-delete" '
                 + 'title="Supprimer ce run" aria-label="Supprimer ce run">×</button>';
+            const phaseLetter = r.phase === 'B' ? 'B' : 'A';
+            const clockSvg = '<svg viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5">'
+                + '<circle cx="8" cy="8" r="6.25"/><path d="M8 4.5V8l2.5 2"/></svg>';
+            const llmSvg = '<svg viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5">'
+                + '<path d="M3 4.5h10M3 8h10M3 11.5h6"/></svg>';
+            const llmMetaHtml = r.llm_calls
+                ? '<span class="tax-refonte-run-meta" title="Appels LLM">' + llmSvg
+                  + '<span>' + r.llm_calls + '</span></span>'
+                : '';
             item.innerHTML =
-                '<div class="tax-refonte-run-head">'
-              + '  <code class="tax-refonte-run-id">' + r.run_id.slice(0, 8) + '</code>'
-              + '  ' + phaseLabel
-              + '  <span class="status-badge status-' + r.status + '">' + r.status + '</span>'
-              + '  ' + deleteBtn
+                '<div class="tax-refonte-run-phase" data-phase="' + phaseLetter + '">' + phaseLetter + '</div>'
+              + '<span class="tax-refonte-run-status" data-status="' + r.status + '">' + r.status + '</span>'
+              + deleteBtn
+              + '<div class="tax-refonte-run-meta-row">'
+              + '  <span class="tax-refonte-run-meta" title="Démarré">' + clockSvg + '<span>' + startedTxt + '</span></span>'
+              + llmMetaHtml
               + '</div>'
-              + '<div class="tax-refonte-run-foot">'
-              + '  <span class="tax-refonte-run-meta">' + startedTxt + '</span>'
-              + (llmInfo ? '<span class="tax-refonte-run-sep">·</span>' + llmInfo : '')
-              + '</div>';
+              + '<code class="tax-refonte-run-id" title="' + r.run_id + '">' + r.run_id.slice(0, 8) + '</code>';
             const delEl = item.querySelector('.tax-refonte-run-delete');
             if (delEl) {
                 delEl.addEventListener('click', async (ev) => {

--- a/dashboard/templates/partials/agent_refonte_panel.html
+++ b/dashboard/templates/partials/agent_refonte_panel.html
@@ -15,6 +15,11 @@
                 <span class="tax-refonte-start-icon">🚀</span>
                 <span>Lancer le diagnostic</span>
             </button>
+            <button id="tax-refonte-propose" class="tax-refonte-propose-btn" disabled
+                    title="Sélectionne un diagnostic 'done' à gauche pour activer">
+                <span class="tax-refonte-start-icon">🔧</span>
+                <span>Proposer une refonte</span>
+            </button>
             <div class="tax-refonte-budget-field">
                 <label for="tax-refonte-budget" class="filter-label">Budget LLM</label>
                 <input type="number" id="tax-refonte-budget" value="5" min="1" max="20">
@@ -109,7 +114,110 @@
     opacity: 0.55;
     cursor: wait;
 }
+.tax-refonte-propose-btn {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    padding: 8px 18px;
+    background: linear-gradient(180deg, #8b5cf6 0%, #7c3aed 100%);
+    color: #fff;
+    border: none;
+    border-radius: 6px;
+    font-size: 14px;
+    font-weight: 600;
+    cursor: pointer;
+    transition: transform 0.05s ease, box-shadow 0.15s ease;
+    box-shadow: 0 1px 2px rgba(0, 0, 0, 0.2);
+}
+.tax-refonte-propose-btn:hover:not(:disabled) {
+    transform: translateY(-1px);
+    box-shadow: 0 2px 6px rgba(124, 58, 237, 0.35);
+}
+.tax-refonte-propose-btn:disabled {
+    opacity: 0.45;
+    cursor: not-allowed;
+    background: linear-gradient(180deg, #555 0%, #444 100%);
+}
 .tax-refonte-start-icon { font-size: 16px; }
+/* ─── Phase B : onglets internes Rationale / Diff / Impact ──────────── */
+.tax-refonte-phaseb-tabs {
+    display: flex;
+    gap: 4px;
+    margin-bottom: 12px;
+    border-bottom: 1px solid var(--border);
+}
+.tax-refonte-phaseb-tab {
+    padding: 6px 14px;
+    background: transparent;
+    border: none;
+    border-bottom: 2px solid transparent;
+    color: var(--text-muted);
+    cursor: pointer;
+    font-size: 13px;
+    font-weight: 500;
+}
+.tax-refonte-phaseb-tab.active {
+    color: var(--text-primary, inherit);
+    border-bottom-color: #8b5cf6;
+}
+.tax-refonte-phaseb-pane { display: none; }
+.tax-refonte-phaseb-pane.active { display: block; }
+/* Diff tree */
+.tax-refonte-diff-section {
+    margin-bottom: 16px;
+}
+.tax-refonte-diff-section h4 { margin: 0 0 6px; font-size: 13px; }
+.tax-refonte-diff-item {
+    padding: 4px 10px;
+    margin: 3px 0;
+    border-left: 3px solid;
+    font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+    font-size: 12px;
+    border-radius: 3px;
+}
+.tax-refonte-diff-add    { border-left-color: #22c55e; background: rgba(34,197,94,.08); }
+.tax-refonte-diff-remove { border-left-color: #ef4444; background: rgba(239,68,68,.08); }
+.tax-refonte-diff-rename { border-left-color: #f59e0b; background: rgba(245,158,11,.08); }
+.tax-refonte-diff-fusion { border-left-color: #8b5cf6; background: rgba(139,92,246,.08); }
+/* Simulation impact */
+.tax-refonte-stat-cards {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+    gap: 10px;
+    margin: 8px 0 14px;
+}
+.tax-refonte-stat-card {
+    padding: 10px 12px;
+    background: var(--bg-tertiary, #1a1a1a);
+    border: 1px solid var(--border);
+    border-radius: 6px;
+    text-align: center;
+}
+.tax-refonte-stat-card .num {
+    font-size: 1.6em;
+    font-weight: 600;
+    color: var(--text-primary, inherit);
+}
+.tax-refonte-stat-card .label {
+    font-size: 11px;
+    color: var(--text-muted);
+    margin-top: 2px;
+}
+.tax-refonte-impact-table {
+    width: 100%;
+    border-collapse: collapse;
+    font-size: 12px;
+}
+.tax-refonte-impact-table th,
+.tax-refonte-impact-table td {
+    padding: 4px 8px;
+    border-bottom: 1px solid var(--border);
+    text-align: left;
+}
+.tax-refonte-impact-table th {
+    color: var(--text-muted);
+    font-weight: 500;
+}
 .tax-refonte-budget-field {
     display: flex;
     align-items: center;
@@ -242,6 +350,7 @@
 (function() {
     // ─── Module local API exposée pour intégration Taxonomie ─────────────
     const startBtn = document.getElementById('tax-refonte-start');
+    const proposeBtn = document.getElementById('tax-refonte-propose');
     const budgetInput = document.getElementById('tax-refonte-budget');
     const runsEl = document.getElementById('tax-refonte-runs');
     const statusEl = document.getElementById('tax-refonte-status');
@@ -252,6 +361,11 @@
     let lastProfile = null;
     let currentReportMd = '';     // Pour Copy + Download
     let currentRunId = null;
+    let currentRunPhase = null;   // 'A' ou 'B'
+    // Map run_id → phase + status pour pouvoir activer/désactiver le bouton
+    // "Proposer une refonte" et utiliser le bon ID comme diagnostic_run_id
+    // quand on lance une Phase B.
+    let runsIndex = {};
 
     // ─── Markdown rendering + post-processing UI ─────────────────────────
     function priorityFor(h3text) {
@@ -262,6 +376,251 @@
         if (/doublon|jaccard|s[ée]mantique/.test(t)) return 'low';
         return 'info';
     }
+
+    // ─── Rendu Phase B (multi-onglets Rationale / Diff / Impact) ─────────
+
+    function renderPhaseBReport(runId, status) {
+        const rationaleMd = status.rationale_md || '';
+        const profile = currentProfile();
+        // Vue 3 onglets dans la zone Rapport, lazy-load des contenus Diff +
+        // Impact au clic (les requêtes peuvent être lourdes sur 18k fichiers).
+        reportEl.innerHTML =
+            '<div class="tax-refonte-phaseb-tabs" role="tablist">'
+          + '  <button class="tax-refonte-phaseb-tab active" data-pane="rationale">📋 Rationale</button>'
+          + '  <button class="tax-refonte-phaseb-tab" data-pane="diff">🌳 Diff tree</button>'
+          + '  <button class="tax-refonte-phaseb-tab" data-pane="impact">📊 Impact reclassify</button>'
+          + '</div>'
+          + '<div class="tax-refonte-phaseb-pane active" data-pane="rationale">'
+          + '  <div class="tax-refonte-md" id="tax-refonte-rationale-md"></div>'
+          + '</div>'
+          + '<div class="tax-refonte-phaseb-pane" data-pane="diff">'
+          + '  <p class="muted small">Chargement du diff…</p>'
+          + '</div>'
+          + '<div class="tax-refonte-phaseb-pane" data-pane="impact">'
+          + '  <p class="muted small">Chargement de la projection…</p>'
+          + '</div>';
+        // Rationale rendu inline
+        const rationaleEl = document.getElementById('tax-refonte-rationale-md');
+        if (window.marked && rationaleMd) {
+            rationaleEl.innerHTML = window.marked.parse(rationaleMd);
+        } else {
+            rationaleEl.textContent = rationaleMd || '(rationale vide)';
+        }
+        currentReportMd = rationaleMd;  // Copy/download retourne le rationale
+        updateActionButtons(!!rationaleMd);
+
+        // Bind tabs : lazy load au clic
+        const tabs = reportEl.querySelectorAll('.tax-refonte-phaseb-tab');
+        const panes = reportEl.querySelectorAll('.tax-refonte-phaseb-pane');
+        let diffLoaded = false, impactLoaded = false;
+        tabs.forEach(t => {
+            t.addEventListener('click', () => {
+                tabs.forEach(x => x.classList.remove('active'));
+                panes.forEach(x => x.classList.remove('active'));
+                t.classList.add('active');
+                const name = t.dataset.pane;
+                const pane = reportEl.querySelector('.tax-refonte-phaseb-pane[data-pane="' + name + '"]');
+                pane.classList.add('active');
+                if (name === 'diff' && !diffLoaded) {
+                    diffLoaded = true;
+                    loadTreeDiff(runId, profile, pane);
+                } else if (name === 'impact' && !impactLoaded) {
+                    impactLoaded = true;
+                    loadSimulation(runId, profile, pane);
+                }
+            });
+        });
+    }
+
+    async function loadTreeDiff(runId, profile, pane) {
+        try {
+            const r = await fetch('/api/agent/refonte/proposition/' + runId
+                                  + '/tree-diff?profile=' + encodeURIComponent(profile));
+            if (!r.ok) throw new Error('HTTP ' + r.status);
+            const d = await r.json();
+            renderTreeDiff(d, pane);
+        } catch (err) {
+            pane.innerHTML = '<p style="color:#ef4444;">Erreur de chargement : '
+                           + err.message + '</p>';
+        }
+    }
+
+    function renderTreeDiff(d, pane) {
+        const parts = [];
+        parts.push('<p class="muted small">'
+          + d.n_folders_before + ' dossiers → ' + d.n_folders_after + ' après refonte</p>');
+        if (d.added && d.added.length) {
+            parts.push('<div class="tax-refonte-diff-section">');
+            parts.push('<h4 style="color:#22c55e;">+ Créés (' + d.added.length + ')</h4>');
+            for (const f of d.added) {
+                parts.push('<div class="tax-refonte-diff-item tax-refonte-diff-add">'
+                  + '+ ' + escapeHtml(f) + '</div>');
+            }
+            parts.push('</div>');
+        }
+        if (d.removed && d.removed.length) {
+            parts.push('<div class="tax-refonte-diff-section">');
+            parts.push('<h4 style="color:#ef4444;">− Supprimés (' + d.removed.length + ')</h4>');
+            for (const f of d.removed) {
+                parts.push('<div class="tax-refonte-diff-item tax-refonte-diff-remove">'
+                  + '− ' + escapeHtml(f) + '</div>');
+            }
+            parts.push('</div>');
+        }
+        if (d.renamed && d.renamed.length) {
+            parts.push('<div class="tax-refonte-diff-section">');
+            parts.push('<h4 style="color:#f59e0b;">↻ Renommés (' + d.renamed.length + ')</h4>');
+            for (const r of d.renamed) {
+                parts.push('<div class="tax-refonte-diff-item tax-refonte-diff-rename">'
+                  + escapeHtml(r.old) + ' → ' + escapeHtml(r.new)
+                  + (r.rationale ? '<div class="muted small">' + escapeHtml(r.rationale) + '</div>' : '')
+                  + '</div>');
+            }
+            parts.push('</div>');
+        }
+        if (d.fused && d.fused.length) {
+            parts.push('<div class="tax-refonte-diff-section">');
+            parts.push('<h4 style="color:#8b5cf6;">⇆ Fusions (' + d.fused.length + ')</h4>');
+            for (const f of d.fused) {
+                parts.push('<div class="tax-refonte-diff-item tax-refonte-diff-fusion">'
+                  + (f.sources || []).map(escapeHtml).join(' + ') + ' → ' + escapeHtml(f.target)
+                  + (f.rationale ? '<div class="muted small">' + escapeHtml(f.rationale) + '</div>' : '')
+                  + '</div>');
+            }
+            parts.push('</div>');
+        }
+        if (parts.length <= 1) {
+            parts.push('<p class="muted">Aucun changement structurel — uniquement des mappings ajoutés.</p>');
+        }
+        pane.innerHTML = parts.join('\n');
+    }
+
+    async function loadSimulation(runId, profile, pane) {
+        try {
+            const r = await fetch('/api/agent/refonte/proposition/' + runId
+                                  + '/simulation?profile=' + encodeURIComponent(profile));
+            if (!r.ok) {
+                if (r.status === 404) {
+                    pane.innerHTML = '<p class="muted">Pas de simulation disponible pour ce run.</p>';
+                    return;
+                }
+                throw new Error('HTTP ' + r.status);
+            }
+            const d = await r.json();
+            renderSimulation(d, pane);
+        } catch (err) {
+            pane.innerHTML = '<p style="color:#ef4444;">Erreur de chargement : '
+                           + err.message + '</p>';
+        }
+    }
+
+    function renderSimulation(d, pane) {
+        const s = d.summary || {};
+        const cards = [
+            { label: 'Fichiers', num: s.n_files || 0 },
+            { label: 'Déplacés', num: s.n_moving || 0 },
+            { label: 'Stables', num: s.n_stable || 0 },
+            { label: 'Non prédits', num: s.n_no_prediction || 0 },
+        ];
+        const cardsHtml = cards.map(c =>
+            '<div class="tax-refonte-stat-card">'
+          + '  <div class="num">' + c.num + '</div>'
+          + '  <div class="label">' + c.label + '</div>'
+          + '</div>'
+        ).join('');
+
+        let topDest = '';
+        if (s.top_destinations && s.top_destinations.length) {
+            topDest = '<h4 style="margin-top:14px;">Top dossiers cibles (entrants)</h4>'
+                    + '<table class="tax-refonte-impact-table">'
+                    + '<thead><tr><th>Dossier</th><th style="text-align:right;">N entrants</th></tr></thead>'
+                    + '<tbody>'
+                    + s.top_destinations.slice(0, 10).map(d =>
+                        '<tr><td><code style="font-size:11px;">' + escapeHtml(d.folder)
+                      + '</code></td><td style="text-align:right;">' + d.n_incoming + '</td></tr>'
+                    ).join('')
+                    + '</tbody></table>';
+        }
+
+        let movesTbl = '';
+        if (d.sample_moves && d.sample_moves.length) {
+            movesTbl = '<h4 style="margin-top:14px;">Échantillon de déplacements ('
+                     + d.sample_moves.length + ' sur ' + d.n_moves_total + ')</h4>'
+                     + '<table class="tax-refonte-impact-table">'
+                     + '<thead><tr><th>Fichier</th><th>De</th><th>Vers</th></tr></thead>'
+                     + '<tbody>'
+                     + d.sample_moves.slice(0, 30).map(m =>
+                        '<tr><td title="' + escapeHtml(m.rel_path) + '">'
+                      + escapeHtml(m.rel_path.split('/').pop()) + '</td>'
+                      + '<td><code style="font-size:10px;">' + escapeHtml(m.current_folder) + '</code></td>'
+                      + '<td><code style="font-size:10px;">' + escapeHtml(m.proposed_folder) + '</code></td></tr>'
+                     ).join('')
+                     + '</tbody></table>';
+        }
+
+        pane.innerHTML =
+            '<div class="tax-refonte-stat-cards">' + cardsHtml + '</div>'
+          + topDest
+          + movesTbl;
+    }
+
+    function escapeHtml(s) {
+        if (s == null) return '';
+        return String(s)
+            .replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;')
+            .replace(/"/g, '&quot;').replace(/'/g, '&#39;');
+    }
+
+    function updateProposeButton() {
+        // Bouton actif uniquement si on a au moins un run Phase A `done` à
+        // l'index ET un run actif (currentRunId) qui est ce Phase A done.
+        const active = currentRunId ? runsIndex[currentRunId] : null;
+        const isPhaseADone = active && active.status === 'done'
+                             && (active.phase || 'A') === 'A';
+        if (isPhaseADone) {
+            proposeBtn.disabled = false;
+            proposeBtn.title = 'Proposer une refonte basée sur le diagnostic '
+                             + currentRunId.slice(0, 8) + '…';
+        } else {
+            proposeBtn.disabled = true;
+            proposeBtn.title = 'Sélectionne un diagnostic Phase A done à gauche';
+        }
+    }
+
+    async function startProposition() {
+        if (!currentRunId) return;
+        const profile = currentProfile();
+        proposeBtn.disabled = true;
+        setStatus('Démarrage de la proposition…');
+        renderReport('');
+        try {
+            const r = await fetch('/api/agent/refonte/proposition', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({
+                    profile: profile,
+                    diagnostic_run_id: currentRunId,
+                    max_llm_calls: parseInt(budgetInput.value || '8', 10) + 3,
+                }),
+            });
+            if (!r.ok) {
+                const e = await r.json();
+                throw new Error(e.error || ('HTTP ' + r.status));
+            }
+            const data = await r.json();
+            currentRunId = data.run_id;
+            currentRunPhase = 'B';
+            startBtn.disabled = true;
+            setStatus('Run B ' + data.run_id.slice(0, 8) + '… démarré');
+            pollTimer = setInterval(() => pollStatus(data.run_id), 2000);
+            loadRuns();
+        } catch (err) {
+            setStatus('Erreur : ' + err.message);
+            updateProposeButton();
+        }
+    }
+
+    proposeBtn.addEventListener('click', startProposition);
 
     function renderReport(md) {
         currentReportMd = md || '';
@@ -368,6 +727,10 @@
     }
 
     function renderRuns(runs) {
+        // Indexe les runs pour décider d'activer "Proposer une refonte"
+        runsIndex = {};
+        for (const r of runs) runsIndex[r.run_id] = r;
+        updateProposeButton();
         if (!runs.length) {
             runsEl.innerHTML = '<p class="tax-refonte-runs-empty">Aucun run pour ce profil. '
                              + 'Lance ton premier diagnostic ↑</p>';
@@ -384,9 +747,15 @@
             const llmInfo = r.llm_calls
                 ? '<span class="tax-refonte-run-meta">' + r.llm_calls + ' LLM</span>'
                 : '';
+            const phaseLabel = r.phase === 'B'
+                ? '<span class="tax-refonte-run-meta" style="background:rgba(139,92,246,0.18);'
+                + 'padding:1px 6px;border-radius:3px;color:#a78bfa;">B</span>'
+                : '<span class="tax-refonte-run-meta" style="background:rgba(79,110,242,0.18);'
+                + 'padding:1px 6px;border-radius:3px;color:#93b1ff;">A</span>';
             item.innerHTML =
                 '<div class="tax-refonte-run-head">'
               + '  <code class="tax-refonte-run-id">' + r.run_id.slice(0, 8) + '</code>'
+              + '  ' + phaseLabel
               + '  <span class="status-badge status-' + r.status + '">' + r.status + '</span>'
               + '</div>'
               + '<div class="tax-refonte-run-foot">'
@@ -408,6 +777,8 @@
                     if (pollTimer) { clearInterval(pollTimer); pollTimer = null; }
                 }
                 currentRunId = r.run_id;
+                currentRunPhase = r.phase || 'A';
+                updateProposeButton();
                 pollStatus(r.run_id);
                 const stillRunning = r.status === 'running' || r.status === 'pending';
                 if (stillRunning && !pollTimer) {
@@ -452,7 +823,12 @@
                       + ' · ' + calls + '/' + max + ' appel(s) LLM' + node + elapsed);
             if (s.status === 'done') {
                 currentRunId = runId;
-                renderReport(s.report_md || '');
+                currentRunPhase = s.phase || 'A';
+                if (currentRunPhase === 'B') {
+                    renderPhaseBReport(runId, s);
+                } else {
+                    renderReport(s.report_md || '');
+                }
                 if (pollTimer) { clearInterval(pollTimer); pollTimer = null; }
                 startBtn.disabled = false;
                 loadRuns();

--- a/dashboard/templates/partials/agent_refonte_panel.html
+++ b/dashboard/templates/partials/agent_refonte_panel.html
@@ -874,15 +874,17 @@
                 if (pollTimer) { clearInterval(pollTimer); pollTimer = null; }
                 startBtn.disabled = false;
             } else {
-                // status="running" ou "pending" — pas de rapport disponible
-                // encore. Afficher un placeholder explicite plutôt que de
-                // laisser un éventuel contenu fantôme d'un run précédent.
-                // (Évite l'illusion "Commence maintenant." sur un autre run.)
-                if (!currentReportMd) {
-                    reportEl.innerHTML = '<p class="muted" style="font-style:italic;">'
-                                       + 'Diagnostic en cours — le rapport apparaîtra '
-                                       + 'ici quand le run se termine.</p>';
-                }
+                // status="running" ou "pending" — afficher le placeholder
+                // INCONDITIONNELLEMENT. La condition `if (!currentReportMd)`
+                // précédente laissait passer le contenu d'un autre run (par
+                // ex. le rapport A reste affiché alors qu'on poll un run B
+                // running, observé 2026-05-25).
+                const phaseLabel = (s.phase === 'B') ? 'Proposition' : 'Diagnostic';
+                reportEl.innerHTML = '<p class="muted" style="font-style:italic;">'
+                                   + phaseLabel + ' en cours — le rapport apparaîtra '
+                                   + 'ici quand le run se termine.</p>';
+                currentReportMd = '';
+                updateActionButtons(false);
             }
         } catch (err) {
             console.error('poll error', err);

--- a/dashboard/templates/partials/agent_refonte_panel.html
+++ b/dashboard/templates/partials/agent_refonte_panel.html
@@ -377,6 +377,52 @@
     const downloadBtn = document.getElementById('tax-refonte-download');
     let pollTimer = null;
     let lastProfile = null;
+
+    // Duplication assumée du helper documentée dans taxonomy_rename.js — chaque
+    // sous-onglet vit dans son IIFE, on préfère 30 lignes recopiées à un global.
+    function showConfirm({title, body, confirmLabel, cancelLabel, variant}) {
+        return new Promise((resolve) => {
+            const modal = document.getElementById('tax-confirm-modal');
+            const okBtn = document.getElementById('tax-confirm-ok');
+            const cancelBtn = document.getElementById('tax-confirm-cancel');
+            if (!modal || !okBtn || !cancelBtn) {
+                resolve(window.confirm((title || '') + '\n\n' + (body || '')));
+                return;
+            }
+            document.getElementById('tax-confirm-title').textContent = title || 'Confirmer ?';
+            document.getElementById('tax-confirm-body').textContent = body || '';
+            okBtn.textContent = confirmLabel || 'Confirmer';
+            cancelBtn.textContent = cancelLabel || 'Annuler';
+            okBtn.className = (variant === 'danger') ? 'btn-danger' : 'btn-primary';
+            modal.style.display = 'flex';
+
+            function cleanup(result) {
+                modal.style.display = 'none';
+                okBtn.onclick = null;
+                cancelBtn.onclick = null;
+                document.removeEventListener('keydown', onKey);
+                resolve(result);
+            }
+            function onKey(e) {
+                if (e.key === 'Escape') { e.preventDefault(); cleanup(false); }
+                if (e.key === 'Enter')  { e.preventDefault(); cleanup(true); }
+            }
+            okBtn.onclick = () => cleanup(true);
+            cancelBtn.onclick = () => cleanup(false);
+            document.addEventListener('keydown', onKey);
+            setTimeout(() => okBtn.focus(), 50);
+        });
+    }
+
+    function showToast(msg, type) {
+        const t = document.getElementById('tax-toast');
+        if (!t) { console.log(msg); return; }
+        t.textContent = msg;
+        t.className = 'tax-toast ' + (type || 'info');
+        t.style.display = 'block';
+        clearTimeout(showToast._tid);
+        showToast._tid = setTimeout(() => { t.style.display = 'none'; }, 4500);
+    }
     let currentReportMd = '';     // Pour Copy + Download
     let currentRunId = null;
     let currentRunPhase = null;   // 'A' ou 'B'
@@ -790,7 +836,15 @@
             if (delEl) {
                 delEl.addEventListener('click', async (ev) => {
                     ev.stopPropagation();
-                    if (!confirm('Supprimer le run ' + r.run_id.slice(0, 8) + ' ?')) return;
+                    const ok = await showConfirm({
+                        title: 'Supprimer ce run ?',
+                        body: 'Run ' + r.run_id.slice(0, 8) + ' (phase ' + (r.phase || 'A')
+                            + ', ' + r.status + ') et tous ses artefacts seront effacés. Action irréversible.',
+                        confirmLabel: 'Supprimer',
+                        cancelLabel: 'Annuler',
+                        variant: 'danger',
+                    });
+                    if (!ok) return;
                     try {
                         const resp = await fetch(
                             '/api/agent/refonte/runs/' + encodeURIComponent(r.run_id)
@@ -799,7 +853,7 @@
                         );
                         if (!resp.ok) {
                             const err = await resp.json().catch(() => ({}));
-                            alert('Erreur : ' + (err.error || resp.status));
+                            showToast('Erreur : ' + (err.error || resp.status), 'error');
                             return;
                         }
                         // Si on supprime le run actif → clear l'UI
@@ -811,9 +865,10 @@
                             startBtn.disabled = false;
                             updateProposeButton();
                         }
+                        showToast('Run ' + r.run_id.slice(0, 8) + ' supprimé', 'success');
                         loadRuns();
                     } catch (e) {
-                        alert('Erreur réseau : ' + e.message);
+                        showToast('Erreur réseau : ' + e.message, 'error');
                     }
                 });
             }

--- a/docs/agent-refonte-guide.md
+++ b/docs/agent-refonte-guide.md
@@ -50,10 +50,10 @@ Affiche en sortie : status, llm_calls, durée, tool_calls/tool_results, rapport 
 | `test` (30 fichiers) | < 50 | ~30s | 3-5 | < $0.01 |
 | `default` (réel) | ~18 250 | ~75s | 5-7 | ~$0.01-0.05 |
 
-Modèle utilisé : **DeepSeek V3.2** (`deepseek-ai/DeepSeek-V3.2` sur SiliconFlow, version stable optimisée pour le tool-use). On évite `-Exp` (désactivable sans préavis) et `V3.1` (régresse vers le chinois et hallucine sur prompts multi-tour complexes). Surchargeable :
+Modèle utilisé : **GLM-4.7** (`zai-org/GLM-4.7` sur SiliconFlow). Stable, tool-use propre en français, ~$0.02/run. On évite DeepSeek V3.2 (APIConnectionError récurrents côté SiliconFlow en mai 2026), V3.2-Exp (désactivable sans préavis) et V3.1 (régresse vers le chinois sur prompts multi-tour complexes). Surchargeable :
 
 ```bash
-export KLODO_AGENT_MODEL="zai-org/GLM-4.6"   # alternative
+export KLODO_AGENT_MODEL="deepseek-ai/DeepSeek-V3.2"   # alternative si GLM régresse
 ```
 
 ## Interpréter le rapport
@@ -133,7 +133,8 @@ Pour les détails complets : [spec](refonte-agent-spec.md) · [diagramme des pha
 |---|---|---|
 | `RuntimeError: SILICONFLOW_API_KEY is required` | clé absente de `.env` ou de l'env shell | Ajouter `SILICONFLOW_API_KEY=sk-...` dans `.env` (régénérer sur cloud.siliconflow.com si périmée) |
 | `AuthenticationError 401: Api key is invalid` | Clé périmée, révoquée, ou (rare) endpoint cn vs com | Régénérer la clé. Vérifier que `agents/llm.py` pointe sur `api.siliconflow.com` (pas `.cn`) |
-| Status `error` avec timeout LLM | SiliconFlow lent ou surchargé | Réessayer. Si persistant, essayer `KLODO_AGENT_MODEL=zai-org/GLM-4.6` |
+| Status `error` avec timeout LLM | SiliconFlow lent ou surchargé | Réessayer. Si persistant, essayer `KLODO_AGENT_MODEL=zai-org/GLM-5` ou `deepseek-ai/DeepSeek-V3.2` |
+| Status `error` avec `APIConnectionError` | Modèle instable côté SiliconFlow (cas observé sur DeepSeek-V3.2 en mai 2026) | Le défaut GLM-4.7 est censé éviter ça ; si on a forcé un autre modèle via `KLODO_AGENT_MODEL`, repasser sur GLM-4.7 |
 | Rapport markdown qui répète le prompt | Bug de l'A.5 (corrigé) — le nettoyage `# Diagnostic` strip tout préambule | Si encore présent : ouvrir un issue |
 | Rapport avec une date passée | Bug si `date` n'est plus injectée dans le prompt | Vérifier `_make_write_report_node` dans `agents/refonte/diagnostic.py` |
 

--- a/tests/auto/test_agent_refonte_endpoint.py
+++ b/tests/auto/test_agent_refonte_endpoint.py
@@ -254,5 +254,110 @@ class TestListRuns(_AgentEndpointBase):
         self.assertEqual(runs[2]["started_at"], "2026-01-01T00:00:00Z")
 
 
+class TestPropositionEndpoints(_AgentEndpointBase):
+    """Endpoints API Phase B : POST proposition + GET tree-diff + GET simulation."""
+
+    def _seed_phase_b_run(self, run_id: str, with_simulation: bool = True) -> None:
+        """Crée un faux run Phase B done avec proposed/ + simulation/ artefacts."""
+        rundir = self.tmp / "profiles" / "test_p" / ".cache" / "refonte" / run_id
+        proposed = rundir / "proposed"
+        proposed.mkdir(parents=True)
+        # status.json
+        (rundir / "status.json").write_text(json.dumps({
+            "run_id": run_id, "profile": "test_p",
+            "phase": "B", "status": "done",
+            "started_at": "2026-05-25T00:00:00Z",
+            "completed_at": "2026-05-25T00:01:00Z",
+            "llm_calls": 5, "diagnostic_run_id": "diag-xxx",
+        }))
+        # proposed/ artefacts
+        (proposed / "tree-proposed.yaml").write_text(
+            "folders:\n- A\n- A/Rust\n- B/New\n",
+        )
+        (proposed / "theme_mapping-proposed.yaml").write_text("rust: A/Rust\n")
+        (proposed / "refonte-rationale.md").write_text(
+            "# Refonte taxonomy — profil `test_p` — proposition\n\n## CRÉATIONS (1)\n- `A/Rust`\n",
+        )
+        (proposed / "changes.json").write_text(json.dumps({
+            "creations": [{"path": "A/Rust", "rationale": "rust orphelin"}],
+            "fusions": [],
+            "renamings": [],
+            "mappings_added": [{"theme": "rust", "folder": "A/Rust", "rationale": "x"}],
+        }))
+        # Aussi un tree.yaml côté profil pour le diff
+        (self.tmp / "profiles" / "test_p" / "tree.yaml").write_text(
+            "folders:\n- A\n- A/Python\n",
+        )
+        if with_simulation:
+            simdir = rundir / "simulation"
+            simdir.mkdir()
+            (simdir / "simulation-summary.json").write_text(json.dumps({
+                "n_files": 100, "n_moving": 30, "n_stable": 65, "n_no_prediction": 5,
+                "top_destinations": [{"folder": "A/Rust", "n_incoming": 12}],
+                "top_origins": [{"folder": "B", "n_outgoing": 12}],
+                "n_by_source": {"LLM (theme)": 80},
+            }))
+            (simdir / "reclassify-projection.csv").write_text(
+                "rel_path,current_folder,proposed_folder,changed,source,top_theme,confidence,score\n"
+                "a.pdf,B,A/Rust,True,LLM (theme),rust programming,0.9,1.0\n"
+                "b.pdf,A,A,False,LLM (theme),x,0.5,1.0\n"
+                "c.pdf,B,A/Rust,True,LLM (theme),rust programming,0.92,1.0\n",
+            )
+
+    def test_tree_diff_endpoint_returns_added_and_renames(self):
+        self._seed_phase_b_run("rb-1")
+        r = self.client.get("/api/agent/refonte/proposition/rb-1/tree-diff?profile=test_p")
+        self.assertEqual(r.status_code, 200)
+        d = r.json()
+        # A/Rust et B/New sont créés (pas dans current tree)
+        self.assertIn("A/Rust", d["added"])
+        self.assertIn("B/New", d["added"])
+        # A/Python est supprimé (présent dans current, pas dans proposed)
+        self.assertIn("A/Python", d["removed"])
+        # Compte cohérent
+        self.assertEqual(d["n_folders_before"], 2)
+        self.assertEqual(d["n_folders_after"], 3)
+
+    def test_tree_diff_missing_profile_qs(self):
+        r = self.client.get("/api/agent/refonte/proposition/rb-X/tree-diff")
+        # FastAPI 422 si query string profile manque
+        self.assertEqual(r.status_code, 422)
+
+    def test_simulation_endpoint_returns_summary_and_sample(self):
+        self._seed_phase_b_run("rb-2")
+        r = self.client.get("/api/agent/refonte/proposition/rb-2/simulation?profile=test_p")
+        self.assertEqual(r.status_code, 200)
+        d = r.json()
+        self.assertEqual(d["summary"]["n_files"], 100)
+        self.assertEqual(d["summary"]["n_moving"], 30)
+        # 2 lignes "changed=True" dans le CSV
+        self.assertEqual(d["n_moves_total"], 2)
+        self.assertEqual(len(d["sample_moves"]), 2)
+        # La première move doit être a.pdf
+        self.assertEqual(d["sample_moves"][0]["rel_path"], "a.pdf")
+
+    def test_simulation_endpoint_404_for_phase_a_run(self):
+        """Un run Phase A (sans simulation/) → 404."""
+        rundir = self.tmp / "profiles" / "test_p" / ".cache" / "refonte" / "ra-1"
+        rundir.mkdir(parents=True)
+        (rundir / "status.json").write_text(json.dumps({
+            "run_id": "ra-1", "profile": "test_p", "phase": "A", "status": "done",
+        }))
+        r = self.client.get("/api/agent/refonte/proposition/ra-1/simulation?profile=test_p")
+        self.assertEqual(r.status_code, 404)
+
+    def test_get_status_injects_rationale_md_for_phase_b(self):
+        """GET /api/agent/refonte/diagnostic/<run_id> sur un run Phase B done
+        doit injecter rationale_md (pas report_md)."""
+        self._seed_phase_b_run("rb-3", with_simulation=False)
+        r = self.client.get("/api/agent/refonte/diagnostic/rb-3?profile=test_p")
+        self.assertEqual(r.status_code, 200)
+        body = r.json()
+        self.assertEqual(body["phase"], "B")
+        self.assertIn("rationale_md", body)
+        self.assertIn("Refonte taxonomy", body["rationale_md"])
+        self.assertNotIn("report_md", body)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/auto/test_agent_refonte_endpoint.py
+++ b/tests/auto/test_agent_refonte_endpoint.py
@@ -254,6 +254,82 @@ class TestListRuns(_AgentEndpointBase):
         self.assertEqual(runs[2]["started_at"], "2026-01-01T00:00:00Z")
 
 
+class TestDeleteRun(_AgentEndpointBase):
+    """delete_run + endpoint DELETE /api/agent/refonte/runs/<id>."""
+
+    _DONE_UUID = "11111111-2222-3333-4444-555555555555"
+    _RUNNING_UUID = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+
+    def _seed_run(self, run_id: str, status: str = "done") -> Path:
+        runs_dir = self.tmp / "profiles" / "test_p" / ".cache" / "refonte"
+        runs_dir.mkdir(parents=True, exist_ok=True)
+        d = runs_dir / run_id
+        d.mkdir()
+        (d / "status.json").write_text(json.dumps({
+            "run_id": run_id, "profile": "test_p",
+            "status": status, "started_at": "2026-05-25T00:00:00Z",
+        }))
+        (d / "report.md").write_text("# Diagnostic\n…")
+        return d
+
+    def test_delete_done_run_removes_dir(self):
+        d = self._seed_run(self._DONE_UUID, status="done")
+        self.assertTrue(d.exists())
+        agent_refonte.delete_run("test_p", self._DONE_UUID)
+        self.assertFalse(d.exists())
+
+    def test_delete_refuses_running(self):
+        # Pour éviter le reap, on touche le mtime à maintenant.
+        d = self._seed_run(self._RUNNING_UUID, status="running")
+        (d / "status.json").touch()
+        with self.assertRaises(agent_refonte.RunBusyError):
+            agent_refonte.delete_run("test_p", self._RUNNING_UUID)
+        self.assertTrue(d.exists())  # toujours là
+
+    def test_delete_refuses_bad_uuid(self):
+        with self.assertRaises(ValueError):
+            agent_refonte.delete_run("test_p", "../etc/passwd")
+
+    def test_delete_unknown_run_raises(self):
+        with self.assertRaises(FileNotFoundError):
+            agent_refonte.delete_run("test_p", self._DONE_UUID)
+
+    def test_endpoint_delete_happy_path(self):
+        self._seed_run(self._DONE_UUID, status="done")
+        r = self.client.delete(
+            f"/api/agent/refonte/runs/{self._DONE_UUID}?profile=test_p"
+        )
+        self.assertEqual(r.status_code, 200)
+        self.assertEqual(r.json()["run_id"], self._DONE_UUID)
+
+    def test_endpoint_delete_404_when_missing(self):
+        r = self.client.delete(
+            f"/api/agent/refonte/runs/{self._DONE_UUID}?profile=test_p"
+        )
+        self.assertEqual(r.status_code, 404)
+
+    def test_endpoint_delete_409_when_busy(self):
+        d = self._seed_run(self._RUNNING_UUID, status="running")
+        (d / "status.json").touch()
+        r = self.client.delete(
+            f"/api/agent/refonte/runs/{self._RUNNING_UUID}?profile=test_p"
+        )
+        self.assertEqual(r.status_code, 409)
+
+    def test_endpoint_delete_400_when_uuid_bad(self):
+        r = self.client.delete(
+            "/api/agent/refonte/runs/not-an-uuid?profile=test_p"
+        )
+        self.assertEqual(r.status_code, 400)
+
+    def test_endpoint_delete_422_when_profile_missing(self):
+        # FastAPI: query param required → 422
+        r = self.client.delete(
+            f"/api/agent/refonte/runs/{self._DONE_UUID}"
+        )
+        self.assertEqual(r.status_code, 422)
+
+
 class TestPropositionEndpoints(_AgentEndpointBase):
     """Endpoints API Phase B : POST proposition + GET tree-diff + GET simulation."""
 

--- a/tests/auto/test_agent_refonte_proposition.py
+++ b/tests/auto/test_agent_refonte_proposition.py
@@ -23,7 +23,10 @@ from langchain_core.messages import AIMessage, ToolMessage
 PROJECT_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 sys.path.insert(0, PROJECT_ROOT)
 
-from agents.refonte.proposition import build_proposition_graph  # noqa: E402
+from agents.refonte.proposition import (  # noqa: E402
+    build_proposition_graph,
+    parse_orphan_mappings_from_report,
+)
 from agents.refonte.proposition_tools import propose_changes  # noqa: E402
 from dashboard import data  # noqa: E402
 from dashboard import taxonomy as tax
@@ -309,6 +312,88 @@ class TestStartProposition(_ProposBase):
             status = agent_refonte.get_status("p", result["run_id"])
             self.assertEqual(status["status"], "done")
             self.assertEqual(status["proposal_summary"]["n_creations"], 1)
+
+
+class TestParseOrphanMappings(unittest.TestCase):
+    """Parser d'orphan mappings depuis le rapport Phase A — alimente
+    le HumanMessage de Phase B avec un JSON pré-extrait."""
+
+    def test_parses_standard_format(self):
+        md = """
+# Diagnostic taxonomy — profil `default` — 2026-05-25
+
+## Anomalies détectées (par priorité)
+
+### Mappings manquants critiques (30 cas)
+- **Functional Analysis** (176 fichiers) → dossier cible évident : `01-SCIENCES/MATHEMATIQUES/02-Analyse`
+- **Complex Analysis** (114 fichiers) → dossier cible évident : `01-SCIENCES/MATHEMATIQUES/02-Analyse`
+- **Pattern Recognition** (114 fichiers) → dossier cible évident : `02-INFORMATIQUE/05-IA-ML/Machine-Learning`
+"""
+        result = parse_orphan_mappings_from_report(md)
+        self.assertEqual(len(result), 3)
+        self.assertEqual(result[0]["theme"], "Functional Analysis")
+        self.assertEqual(result[0]["count"], 176)
+        self.assertEqual(result[0]["target_folder"], "01-SCIENCES/MATHEMATIQUES/02-Analyse")
+        self.assertEqual(result[2]["theme"], "Pattern Recognition")
+        self.assertEqual(result[2]["target_folder"], "02-INFORMATIQUE/05-IA-ML/Machine-Learning")
+
+    def test_handles_variants_in_separators(self):
+        """Le parser tolère 'dossier cible :' au lieu de 'dossier cible évident :'."""
+        md = (
+            "- **Theme1** (50 fichiers) → dossier cible : `A/B`\n"
+            "- **Theme2** (10 fichiers) → dossier cible évident : `C/D`\n"
+            # Lignes sans count ne matchent pas
+            "- **Theme3** truc sans count\n"
+        )
+        result = parse_orphan_mappings_from_report(md)
+        self.assertEqual(len(result), 2)
+        self.assertEqual(result[0]["theme"], "Theme1")
+        self.assertEqual(result[1]["theme"], "Theme2")
+
+    def test_strips_backticks_from_target(self):
+        md = "- **X** (5 fichiers) → dossier cible évident : `A/B/C`"
+        result = parse_orphan_mappings_from_report(md)
+        self.assertEqual(result[0]["target_folder"], "A/B/C")
+
+    def test_works_without_backticks(self):
+        md = "- **X** (5 fichiers) → dossier cible évident : A/B/C"
+        result = parse_orphan_mappings_from_report(md)
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0]["target_folder"], "A/B/C")
+
+    def test_returns_empty_on_no_match(self):
+        self.assertEqual(parse_orphan_mappings_from_report(""), [])
+        self.assertEqual(parse_orphan_mappings_from_report("rapport vide sans liste"), [])
+
+    def test_picks_only_well_formed_lines(self):
+        """Lignes mal formées (manque arrow, manque count, etc.) sont ignorées."""
+        md = (
+            "Cette ligne **Theme** n'a pas d'arrow.\n"
+            "- **Good** (100 fichiers) → cible : `Path/A`\n"
+            "Un texte sans bullet ni format **Bad** → essayer.\n"
+        )
+        result = parse_orphan_mappings_from_report(md)
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0]["theme"], "Good")
+
+    def test_parses_30_realistic_orphans(self):
+        """Sanity check sur un rapport simulé proche du vrai format de prod."""
+        lines = ["### Mappings manquants critiques (30 cas)"]
+        for i, (theme, count) in enumerate([
+            ("Functional Analysis", 176), ("Complex Analysis", 114),
+            ("Pattern Recognition", 114), ("Group Theory", 112),
+            ("Real Analysis", 93), ("Materials Science", 78),
+            ("Optimization", 76), ("Penetration Testing", 73),
+            ("Combinatorics", 69), ("Software Testing", 69),
+        ]):
+            lines.append(
+                f"- **{theme}** ({count} fichiers) → dossier cible évident : `01-SCIENCES/FOO`"
+            )
+        result = parse_orphan_mappings_from_report("\n".join(lines))
+        self.assertEqual(len(result), 10)
+        # Ordre préservé
+        self.assertEqual(result[0]["theme"], "Functional Analysis")
+        self.assertEqual(result[-1]["theme"], "Software Testing")
 
 
 if __name__ == "__main__":

--- a/tests/auto/test_agent_refonte_proposition.py
+++ b/tests/auto/test_agent_refonte_proposition.py
@@ -25,7 +25,9 @@ sys.path.insert(0, PROJECT_ROOT)
 
 from agents.refonte.proposition import (  # noqa: E402
     build_proposition_graph,
+    parse_catchall_folders_from_report,
     parse_orphan_mappings_from_report,
+    parse_underutilized_folders_from_report,
 )
 from agents.refonte.proposition_tools import propose_changes  # noqa: E402
 from dashboard import data  # noqa: E402
@@ -394,6 +396,102 @@ class TestParseOrphanMappings(unittest.TestCase):
         # Ordre préservé
         self.assertEqual(result[0]["theme"], "Functional Analysis")
         self.assertEqual(result[-1]["theme"], "Software Testing")
+
+
+class TestParseUnderutilizedFolders(unittest.TestCase):
+    """Parser pour la section 'Dossiers sous-utilisés' du rapport Phase A."""
+
+    def test_parses_underutilized_section(self):
+        md = """
+### Mappings manquants critiques (1 cas)
+- **Theme1** (10 fichiers) → dossier cible évident : `A/B`
+
+### Dossiers sous-utilisés avec thèmes orphelins correspondants (3 cas)
+**02-INFORMATIQUE/03-Langages-Programmation/Python** (0 fichier) ↔ thème orphelin "python programming" (320 occurrences)
+**01-SCIENCES/MATHEMATIQUES** (0 fichier) ↔ tous les sous-dossiers sont peuplés (normal)
+**08-LOISIRS/DESSIN** (0 fichier) – aucun thème orphelin associé
+
+### Catch-all qui débordent (1 cas)
+**/Autres** (4000 fichiers) – fourre-tout
+"""
+        result = parse_underutilized_folders_from_report(md)
+        self.assertEqual(len(result), 3)
+        self.assertEqual(result[0]["folder"], "02-INFORMATIQUE/03-Langages-Programmation/Python")
+        self.assertEqual(result[0]["count"], 0)
+        self.assertEqual(result[2]["folder"], "08-LOISIRS/DESSIN")
+        # Le note du 1er doit mentionner le thème orphelin
+        self.assertIn("python", result[0]["note"].lower())
+
+    def test_handles_thousands_with_spaces(self):
+        md = "### Dossiers sous-utilisés (1 cas)\n**A/B** (1 234 fichiers) – grosse note"
+        result = parse_underutilized_folders_from_report(md)
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0]["count"], 1234)
+
+    def test_returns_empty_when_section_absent(self):
+        md = "### Une autre section\n**A** (0 fichier) – note"
+        self.assertEqual(parse_underutilized_folders_from_report(md), [])
+
+
+class TestParseCatchallFolders(unittest.TestCase):
+    """Parser pour 'Catch-all qui débordent'."""
+
+    def test_parses_catchall_section(self):
+        md = """
+### Catch-all qui débordent (2 cas)
+1. **02-INFORMATIQUE/03-Langages-Programmation/Autres** (4 489 fichiers) – contient tous les langages non spécifiques
+2. **01-SCIENCES/MATHEMATIQUES/08-Mathematiques-Generales** (2 659 fichiers) – fourre-tout mathématique
+"""
+        result = parse_catchall_folders_from_report(md)
+        self.assertEqual(len(result), 2)
+        self.assertEqual(result[0]["folder"], "02-INFORMATIQUE/03-Langages-Programmation/Autres")
+        self.assertEqual(result[0]["count"], 4489)
+        self.assertEqual(result[1]["count"], 2659)
+
+    def test_returns_empty_for_non_analysed(self):
+        md = "### Catch-all qui débordent (non analysé)\n- Pas d'analyse effectuée"
+        self.assertEqual(parse_catchall_folders_from_report(md), [])
+
+
+class TestProposeChangesWithDeletions(_ProposBase):
+    """Sémantique des deletions ajoutée en B.3-ter."""
+
+    def test_deletion_removes_folder_from_tree(self):
+        result = propose_changes(
+            profile="p", run_id="del-1",
+            deletions=[{"path": "B", "rationale": "vide, plus utile"}],
+        )
+        self.assertEqual(result["n_deletions"], 1)
+        rundir = self.tmp / "profiles" / "p" / ".cache" / "refonte" / "del-1" / "proposed"
+        folders = yaml.safe_load((rundir / "tree-proposed.yaml").read_text())["folders"]
+        # B était dans le profil de base (cf. setUp _make_profile)
+        self.assertNotIn("B", folders)
+        # A et A/Python toujours là
+        self.assertIn("A", folders)
+        self.assertIn("A/Python", folders)
+
+    def test_deletion_drops_mappings_pointing_to_deleted_folder(self):
+        """Si on supprime B, le mapping 'data: B' doit disparaître."""
+        propose_changes(
+            profile="p", run_id="del-2",
+            deletions=[{"path": "B", "rationale": "vide"}],
+        )
+        rundir = self.tmp / "profiles" / "p" / ".cache" / "refonte" / "del-2" / "proposed"
+        mapping = yaml.safe_load((rundir / "theme_mapping-proposed.yaml").read_text())
+        # "data" pointait sur B → drop
+        self.assertNotIn("data", mapping)
+        # "python programming" pointait sur A/Python → toujours là
+        self.assertEqual(mapping["python programming"], "A/Python")
+
+    def test_rationale_md_includes_deletions_section(self):
+        propose_changes(
+            profile="p", run_id="del-3",
+            deletions=[{"path": "Z", "rationale": "à supprimer"}],
+        )
+        rationale = (self.tmp / "profiles" / "p" / ".cache" / "refonte" / "del-3"
+                     / "proposed" / "refonte-rationale.md").read_text()
+        self.assertIn("SUPPRESSIONS (1)", rationale)
+        self.assertIn("Z", rationale)
 
 
 if __name__ == "__main__":

--- a/tests/auto/test_agent_refonte_proposition.py
+++ b/tests/auto/test_agent_refonte_proposition.py
@@ -47,7 +47,8 @@ def _make_profile(profiles_root: Path, name: str, *, target: Path,
 
 
 def _seed_diagnostic_run(profiles_root: Path, profile: str, run_id: str,
-                         status: str = "done") -> None:
+                         status: str = "done",
+                         report_md: str | None = None) -> None:
     """Crée un faux run de Phase A done (avec report.md minimal)."""
     rundir = profiles_root / profile / ".cache" / "refonte" / run_id
     rundir.mkdir(parents=True, exist_ok=True)
@@ -57,13 +58,13 @@ def _seed_diagnostic_run(profiles_root: Path, profile: str, run_id: str,
         "completed_at": "2026-05-25T00:01:00+00:00",
         "llm_calls": 7,
     }))
-    (rundir / "report.md").write_text(
+    (rundir / "report.md").write_text(report_md or (
         "# Diagnostic taxonomy — profil `" + profile + "` — 2026-05-25\n\n"
         "## Stats globales\n- 3 dossiers\n\n"
         "## Anomalies détectées (par priorité)\n\n"
         "### Mappings manquants critiques (1 cas)\n"
         "- **Rust** (50 fichiers) → dossier cible évident : `A/Rust`\n"
-    )
+    ))
 
 
 class _FakeLLM:
@@ -492,6 +493,83 @@ class TestProposeChangesWithDeletions(_ProposBase):
                      / "proposed" / "refonte-rationale.md").read_text()
         self.assertIn("SUPPRESSIONS (1)", rationale)
         self.assertIn("Z", rationale)
+
+
+class TestInitNodeOrphanInjection(_ProposBase):
+    """_init_node : appel direct find_orphan_themes + fusion suggestions markdown."""
+
+    def _init_state(self, profile: str = "p", diag_id: str = "diag-init") -> dict:
+        from agents.refonte.proposition import _init_node
+        _seed_diagnostic_run(
+            self.profiles_root, profile, diag_id,
+            report_md=(
+                "# Diagnostic\n\n"
+                "### Mappings orphelins prioritaires\n"
+                "- **Functional Analysis** (176 fichiers) → dossier cible : "
+                "`A/MATH/Analyse`\n"
+                "- **Group Theory** (112 fichiers) → cible : `A/MATH/Algebre`\n"
+            ),
+        )
+        return _init_node({
+            "profile": profile, "run_id": "b-init",
+            "diagnostic_run_id": diag_id,
+        })
+
+    def test_uses_find_orphan_themes_when_available(self):
+        """Si find_orphan_themes renvoie 200 entrées, on les injecte toutes
+        avec les suggestions du markdown pour le top 30 et None pour le reste."""
+        fake_orphans = [
+            {"theme": "Functional Analysis", "count": 176, "is_orphan": True,
+             "sample_titles": ["Rudin", "Brezis"]},
+            {"theme": "Group Theory", "count": 112, "is_orphan": True,
+             "sample_titles": []},
+            {"theme": "Long Tail Theme", "count": 12, "is_orphan": True,
+             "sample_titles": []},
+        ]
+        with mock.patch(
+            "agents.refonte.proposition.find_orphan_themes",
+            return_value=fake_orphans,
+        ):
+            state = self._init_state()
+        human_msg = state["messages"][1].content
+        # Les 3 thèmes doivent apparaître
+        self.assertIn("Functional Analysis", human_msg)
+        self.assertIn("Group Theory", human_msg)
+        self.assertIn("Long Tail Theme", human_msg)
+        # Le markdown suggère un target pour Functional Analysis / Group Theory
+        self.assertIn("A/MATH/Analyse", human_msg)
+        self.assertIn("A/MATH/Algebre", human_msg)
+        # Long Tail Theme n'a PAS de suggestion → le champ doit être absent
+        # pour cette entrée (le LLM choisira)
+        self.assertIn("target_folder_suggested", human_msg)
+        # n=3 affiché
+        self.assertIn("(n=3)", human_msg)
+
+    def test_falls_back_to_markdown_when_find_orphan_fails(self):
+        """Si find_orphan_themes échoue (pas de vision_cache), on retombe
+        sur le parsing markdown au lieu de partir avec une liste vide."""
+        with mock.patch(
+            "agents.refonte.proposition.find_orphan_themes",
+            side_effect=FileNotFoundError("vision_cache absent"),
+        ):
+            state = self._init_state()
+        human_msg = state["messages"][1].content
+        # Le fallback markdown a injecté les 2 entrées du diagnostic
+        self.assertIn("Functional Analysis", human_msg)
+        self.assertIn("Group Theory", human_msg)
+        self.assertIn("A/MATH/Analyse", human_msg)
+
+    def test_falls_back_when_find_orphan_returns_empty(self):
+        """find_orphan_themes peut renvoyer [] (pas d'orphelin OU pas de cache).
+        Dans ce cas on prend le markdown comme source."""
+        with mock.patch(
+            "agents.refonte.proposition.find_orphan_themes",
+            return_value=[],
+        ):
+            state = self._init_state()
+        human_msg = state["messages"][1].content
+        self.assertIn("Functional Analysis", human_msg)
+        self.assertIn("Group Theory", human_msg)
 
 
 if __name__ == "__main__":

--- a/tests/auto/test_agent_refonte_proposition.py
+++ b/tests/auto/test_agent_refonte_proposition.py
@@ -1,0 +1,315 @@
+#!/usr/bin/env python3
+"""Tests pour Phase B (Proposition) — tool propose_changes + graphe.
+
+3 axes :
+  1. propose_changes : applique correctement créations/fusions/renommages/mappings
+  2. Graph compile + invoke avec FakeLLM, propose_changes appelé une fois → done
+  3. Refus d'inputs invalides (profile vide, diagnostic_run_id absent, diagnostic non-done)
+"""
+
+import json
+import os
+import shutil
+import sys
+import tempfile
+import time
+import unittest
+from pathlib import Path
+from unittest import mock
+
+import yaml
+from langchain_core.messages import AIMessage, ToolMessage
+
+PROJECT_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+sys.path.insert(0, PROJECT_ROOT)
+
+from agents.refonte.proposition import build_proposition_graph  # noqa: E402
+from agents.refonte.proposition_tools import propose_changes  # noqa: E402
+from dashboard import data  # noqa: E402
+from dashboard import taxonomy as tax
+
+# ─── Fixtures ──────────────────────────────────────────────────────────────
+
+
+def _make_profile(profiles_root: Path, name: str, *, target: Path,
+                  folders: list[str], mapping: dict[str, str]) -> None:
+    pdir = profiles_root / name
+    pdir.mkdir(parents=True, exist_ok=True)
+    (pdir / "profile.yaml").write_text(yaml.safe_dump({"name": name, "target": str(target)}))
+    (pdir / "tree.yaml").write_text(yaml.safe_dump({"folders": folders}))
+    (pdir / "theme_mapping.yaml").write_text(yaml.safe_dump(mapping))
+    target.mkdir(parents=True, exist_ok=True)
+
+
+def _seed_diagnostic_run(profiles_root: Path, profile: str, run_id: str,
+                         status: str = "done") -> None:
+    """Crée un faux run de Phase A done (avec report.md minimal)."""
+    rundir = profiles_root / profile / ".cache" / "refonte" / run_id
+    rundir.mkdir(parents=True, exist_ok=True)
+    (rundir / "status.json").write_text(json.dumps({
+        "run_id": run_id, "profile": profile, "status": status, "phase": "A",
+        "started_at": "2026-05-25T00:00:00+00:00",
+        "completed_at": "2026-05-25T00:01:00+00:00",
+        "llm_calls": 7,
+    }))
+    (rundir / "report.md").write_text(
+        "# Diagnostic taxonomy — profil `" + profile + "` — 2026-05-25\n\n"
+        "## Stats globales\n- 3 dossiers\n\n"
+        "## Anomalies détectées (par priorité)\n\n"
+        "### Mappings manquants critiques (1 cas)\n"
+        "- **Rust** (50 fichiers) → dossier cible évident : `A/Rust`\n"
+    )
+
+
+class _FakeLLM:
+    """LLM scripté retournant une séquence prédéfinie d'AIMessage."""
+
+    def __init__(self, responses):
+        self.responses = list(responses)
+        self.invocations: list[list] = []
+
+    def bind_tools(self, _tools):
+        return self
+
+    def invoke(self, messages):
+        self.invocations.append(list(messages))
+        if not self.responses:
+            return AIMessage(content="(fake LLM: no more)")
+        return self.responses.pop(0)
+
+
+def _ai_tool_call(name: str, args: dict) -> AIMessage:
+    return AIMessage(
+        content="",
+        tool_calls=[{"name": name, "args": args, "id": "call_" + name, "type": "tool_call"}],
+    )
+
+
+class _ProposBase(unittest.TestCase):
+    def setUp(self):
+        self.tmp = Path(tempfile.mkdtemp(prefix="klodo_phaseb_"))
+        self.profiles_root = self.tmp / "profiles"
+        self.profiles_root.mkdir()
+        self.target = self.tmp / "biblio"
+        self._patcher = mock.patch.object(data, "get_project_root", return_value=self.tmp)
+        self._patcher.start()
+        tax.reset_cache()
+        _make_profile(
+            self.profiles_root, "p",
+            target=self.target,
+            folders=["A", "A/Python", "B"],
+            mapping={"python programming": "A/Python", "data": "B"},
+        )
+
+    def tearDown(self):
+        self._patcher.stop()
+        tax.reset_cache()
+        shutil.rmtree(self.tmp, ignore_errors=True)
+
+
+# ─── 1. propose_changes : sémantique ───────────────────────────────────────
+
+
+class TestProposeChanges(_ProposBase):
+    def test_writes_three_artifacts(self):
+        result = propose_changes(
+            profile="p",
+            run_id="r-1",
+            creations=[{"path": "A/Rust", "rationale": "Rust orphelin"}],
+            mappings_added=[
+                {"theme": "rust", "folder": "A/Rust", "rationale": "thème orphelin"},
+            ],
+        )
+        # Les 3 fichiers existent
+        for key in ("tree_proposed_path", "mapping_proposed_path", "rationale_path"):
+            self.assertTrue(Path(result[key]).exists(), f"{key} missing on disk")
+        # Compte cohérent
+        self.assertEqual(result["n_creations"], 1)
+        self.assertEqual(result["n_mappings_added"], 1)
+
+    def test_creations_added_to_tree(self):
+        propose_changes(
+            profile="p", run_id="r-2",
+            creations=[{"path": "A/Rust", "rationale": "x"}],
+        )
+        tree_path = self.tmp / "profiles" / "p" / ".cache" / "refonte" / "r-2" / "proposed" / "tree-proposed.yaml"
+        folders = yaml.safe_load(tree_path.read_text())["folders"]
+        self.assertIn("A/Rust", folders)
+        self.assertIn("A", folders)  # existant préservé
+
+    def test_renaming_replaces_in_tree_and_mapping(self):
+        propose_changes(
+            profile="p", run_id="r-3",
+            renamings=[{"old_path": "A/Python", "new_path": "A/Python3", "rationale": "x"}],
+        )
+        rundir = self.tmp / "profiles" / "p" / ".cache" / "refonte" / "r-3" / "proposed"
+        folders = yaml.safe_load((rundir / "tree-proposed.yaml").read_text())["folders"]
+        mapping = yaml.safe_load((rundir / "theme_mapping-proposed.yaml").read_text())
+        self.assertIn("A/Python3", folders)
+        self.assertNotIn("A/Python", folders)
+        # Le mapping existant qui pointait sur A/Python doit suivre
+        self.assertEqual(mapping["python programming"], "A/Python3")
+
+    def test_fusion_consolidates_in_tree_and_mapping(self):
+        propose_changes(
+            profile="p", run_id="r-4",
+            fusions=[
+                {"sources": ["A", "B"], "target": "ALL", "rationale": "tout fusionné"},
+            ],
+        )
+        rundir = self.tmp / "profiles" / "p" / ".cache" / "refonte" / "r-4" / "proposed"
+        folders = yaml.safe_load((rundir / "tree-proposed.yaml").read_text())["folders"]
+        mapping = yaml.safe_load((rundir / "theme_mapping-proposed.yaml").read_text())
+        self.assertIn("ALL", folders)
+        self.assertNotIn("A", folders)
+        self.assertNotIn("B", folders)
+        # Les mappings sur A et B doivent pointer sur ALL
+        # (sauf "python programming" qui pointait sur A/Python qui n'est pas dans les sources)
+        self.assertEqual(mapping["data"], "ALL")
+
+    def test_rationale_md_has_sections(self):
+        propose_changes(
+            profile="p", run_id="r-5",
+            creations=[{"path": "X", "rationale": "x"}],
+            fusions=[{"sources": ["A"], "target": "X", "rationale": "y"}],
+            renamings=[{"old_path": "B", "new_path": "C", "rationale": "z"}],
+            mappings_added=[{"theme": "t1", "folder": "X", "rationale": "w"}],
+        )
+        rationale = (self.tmp / "profiles" / "p" / ".cache" / "refonte" / "r-5"
+                     / "proposed" / "refonte-rationale.md").read_text()
+        self.assertIn("CRÉATIONS (1)", rationale)
+        self.assertIn("FUSIONS (1)", rationale)
+        self.assertIn("RENOMMAGES (1)", rationale)
+        self.assertIn("MAPPINGS AJOUTÉS (1)", rationale)
+
+
+# ─── 2. Graphe Phase B avec FakeLLM ────────────────────────────────────────
+
+
+class TestPropositionGraph(_ProposBase):
+    def test_happy_path_calls_propose_then_finalizes(self):
+        _seed_diagnostic_run(self.profiles_root, "p", "diag-1")
+        fake = _FakeLLM([
+            # 1er analyze : appelle propose_changes
+            _ai_tool_call("propose_changes", {
+                "creations": [{"path": "A/Rust", "rationale": "thème orphelin"}],
+                "mappings_added": [
+                    {"theme": "rust", "folder": "A/Rust", "rationale": "cf diagnostic"},
+                ],
+            }),
+            # 2e analyze : LLM termine sans tool_call
+            AIMessage(content="Proposition envoyée."),
+        ])
+        graph = build_proposition_graph(profile="p", run_id="b-1", llm=fake, max_llm_calls=5)
+        result = graph.invoke({
+            "profile": "p", "run_id": "b-1", "diagnostic_run_id": "diag-1",
+        })
+        self.assertEqual(result["status"], "done")
+        self.assertEqual(result["proposal_summary"]["n_creations"], 1)
+        self.assertEqual(result["proposal_summary"]["n_mappings_added"], 1)
+        # Le proposal_dir contient bien les 3 artefacts
+        pdir = Path(result["proposal_dir"])
+        for fname in ("tree-proposed.yaml", "theme_mapping-proposed.yaml",
+                      "refonte-rationale.md"):
+            self.assertTrue((pdir / fname).exists())
+        # ToolMessage retourné dans l'historique
+        tool_msgs = [m for m in result["messages"] if isinstance(m, ToolMessage)]
+        self.assertEqual(len(tool_msgs), 1)
+        self.assertEqual(tool_msgs[0].name, "propose_changes")
+
+    def test_no_propose_call_returns_error(self):
+        """Si l'agent termine sans jamais appeler propose_changes → status=error."""
+        _seed_diagnostic_run(self.profiles_root, "p", "diag-2")
+        fake = _FakeLLM([
+            AIMessage(content="Je n'ai rien à proposer."),  # pas de tool_call
+        ])
+        graph = build_proposition_graph(profile="p", run_id="b-2", llm=fake, max_llm_calls=5)
+        result = graph.invoke({
+            "profile": "p", "run_id": "b-2", "diagnostic_run_id": "diag-2",
+        })
+        self.assertEqual(result["status"], "error")
+        self.assertIn("propose_changes", result["error"])
+
+    def test_missing_profile_short_circuits(self):
+        fake = _FakeLLM([])
+        graph = build_proposition_graph(profile="p", run_id="b-3", llm=fake, max_llm_calls=5)
+        result = graph.invoke({"run_id": "b-3", "diagnostic_run_id": "anything"})
+        self.assertEqual(result["status"], "error")
+        self.assertIn("profile", result["error"].lower())
+        self.assertEqual(len(fake.invocations), 0)
+
+    def test_missing_diagnostic_run_id_short_circuits(self):
+        fake = _FakeLLM([])
+        graph = build_proposition_graph(profile="p", run_id="b-4", llm=fake, max_llm_calls=5)
+        result = graph.invoke({"profile": "p", "run_id": "b-4"})
+        self.assertEqual(result["status"], "error")
+        self.assertIn("diagnostic_run_id", result["error"])
+
+    def test_unknown_diagnostic_returns_error(self):
+        fake = _FakeLLM([])
+        graph = build_proposition_graph(profile="p", run_id="b-5", llm=fake, max_llm_calls=5)
+        result = graph.invoke({
+            "profile": "p", "run_id": "b-5", "diagnostic_run_id": "ghost-id",
+        })
+        self.assertEqual(result["status"], "error")
+        self.assertIn("Rapport de diagnostic introuvable", result["error"])
+
+
+# ─── 3. Backend dashboard start_proposition ────────────────────────────────
+
+
+class TestStartProposition(_ProposBase):
+    def test_rejects_missing_profile(self):
+        from dashboard import agent_refonte
+        with self.assertRaises(ValueError) as ctx:
+            agent_refonte.start_proposition("", "any-id")
+        self.assertIn("profile", str(ctx.exception).lower())
+
+    def test_rejects_unknown_diagnostic(self):
+        from dashboard import agent_refonte
+        with self.assertRaises(FileNotFoundError) as ctx:
+            agent_refonte.start_proposition("p", "ghost-run")
+        self.assertIn("diagnostic run not found", str(ctx.exception).lower())
+
+    def test_rejects_diagnostic_not_done(self):
+        from dashboard import agent_refonte
+        _seed_diagnostic_run(self.profiles_root, "p", "diag-pending", status="pending")
+        with self.assertRaises(ValueError) as ctx:
+            agent_refonte.start_proposition("p", "diag-pending")
+        self.assertIn("'pending'", str(ctx.exception))
+
+    def test_happy_path_returns_run_id_and_thread_runs(self):
+        """Avec un graphe mocké, start_proposition retourne et le thread écrit."""
+        from dashboard import agent_refonte
+        _seed_diagnostic_run(self.profiles_root, "p", "diag-3")
+
+        # Fake graph used by _run_proposition via import
+        class _FakeGraph:
+            def stream(self, state, stream_mode="values"):
+                yield {**state, "llm_calls": 0}
+                yield {
+                    **state,
+                    "llm_calls": 2,
+                    "status": "done",
+                    "proposal_dir": "/tmp/fake",
+                    "proposal_summary": {"n_creations": 1, "n_mappings_added": 0},
+                }
+
+        with mock.patch(
+            "agents.refonte.proposition.build_proposition_graph",
+            return_value=_FakeGraph(),
+        ):
+            result = agent_refonte.start_proposition("p", "diag-3")
+            self.assertEqual(result["status"], "pending")
+            self.assertEqual(result["phase"], "B")
+            self.assertEqual(result["diagnostic_run_id"], "diag-3")
+            self.assertTrue(result["run_id"])
+            # Attendre que le thread écrive le status final
+            time.sleep(0.4)
+            status = agent_refonte.get_status("p", result["run_id"])
+            self.assertEqual(status["status"], "done")
+            self.assertEqual(status["proposal_summary"]["n_creations"], 1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/auto/test_agent_refonte_simulator.py
+++ b/tests/auto/test_agent_refonte_simulator.py
@@ -1,0 +1,239 @@
+#!/usr/bin/env python3
+"""Tests pour le simulateur reclassify de Phase B.
+
+Module Python pur (no LLM). Couvre :
+  - Pas de target FS → summary vide gracieusement
+  - Fichier qui changerait de dossier avec le mapping proposé
+  - Fichier qui resterait stable (déjà au bon endroit)
+  - Fichier sans theme observé → no_prediction
+  - CSV + summary.json bien produits avec les bonnes colonnes
+"""
+
+import csv
+import json
+import os
+import shutil
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+import yaml
+
+PROJECT_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+sys.path.insert(0, PROJECT_ROOT)
+
+from agents.refonte.simulator import simulate_reclassify  # noqa: E402
+from dashboard import data  # noqa: E402
+from dashboard import taxonomy as tax
+
+# ─── Fixtures ──────────────────────────────────────────────────────────────
+
+
+def _make_profile(profiles_root: Path, name: str, *, target: Path,
+                  folders: list[str], mapping: dict[str, str]) -> None:
+    pdir = profiles_root / name
+    pdir.mkdir(parents=True, exist_ok=True)
+    (pdir / "profile.yaml").write_text(yaml.safe_dump({"name": name, "target": str(target)}))
+    (pdir / "tree.yaml").write_text(yaml.safe_dump({"folders": folders}))
+    (pdir / "theme_mapping.yaml").write_text(yaml.safe_dump(mapping))
+    target.mkdir(parents=True, exist_ok=True)
+
+
+def _seed_vision_cache(profiles_root: Path, profile: str, entries: dict) -> None:
+    """Écrit un vision_cache.json avec les entrées fournies."""
+    cache_dir = profiles_root / profile / ".cache"
+    cache_dir.mkdir(parents=True, exist_ok=True)
+    (cache_dir / "vision_cache.json").write_text(json.dumps(entries))
+
+
+def _write_proposed_mapping(proposal_dir: Path, mapping: dict[str, str]) -> None:
+    """Écrit le mapping-proposed.yaml dans un dossier proposed/."""
+    proposal_dir.mkdir(parents=True, exist_ok=True)
+    (proposal_dir / "theme_mapping-proposed.yaml").write_text(
+        yaml.safe_dump(mapping, allow_unicode=True)
+    )
+
+
+class _SimBase(unittest.TestCase):
+    """Setup commun : un profil sur disque + vision_cache + target avec quelques files."""
+
+    def setUp(self):
+        self.tmp = Path(tempfile.mkdtemp(prefix="klodo_sim_"))
+        self.profiles_root = self.tmp / "profiles"
+        self.profiles_root.mkdir()
+        self.target = self.tmp / "biblio"
+        self._patcher = mock.patch.object(data, "get_project_root", return_value=self.tmp)
+        self._patcher.start()
+        tax.reset_cache()
+
+    def tearDown(self):
+        self._patcher.stop()
+        tax.reset_cache()
+        shutil.rmtree(self.tmp, ignore_errors=True)
+
+
+# ─── Tests ─────────────────────────────────────────────────────────────────
+
+
+class TestSimulateReclassify(_SimBase):
+    def test_target_missing_returns_empty(self):
+        """Profil sans target → summary vide gracieusement."""
+        # Profile with target set but pointing to nonexistent directory
+        nonexistent = self.tmp / "doesnotexist"
+        profile_dir = self.profiles_root / "p"
+        profile_dir.mkdir()
+        (profile_dir / "profile.yaml").write_text(yaml.safe_dump({
+            "name": "p", "target": str(nonexistent),
+        }))
+        proposal_dir = self.tmp / "proposed"
+        _write_proposed_mapping(proposal_dir, {})
+        result = simulate_reclassify("p", proposal_dir)
+        self.assertEqual(result["n_files"], 0)
+        self.assertIn("summary_path", result)
+
+    def test_file_would_move_with_proposed_mapping(self):
+        """Un fichier classé via le current mapping irait ailleurs avec le proposed."""
+        _make_profile(
+            self.profiles_root, "p",
+            target=self.target,
+            folders=["OLD", "NEW"],
+            mapping={"machine learning": "OLD"},
+        )
+        # Place un fichier dans OLD/ avec le bon nom de base
+        old_dir = self.target / "OLD"
+        old_dir.mkdir()
+        pdf = old_dir / "ml_book.pdf"
+        pdf.write_bytes(b"%PDF-1.4\nfake\n" + b"\x00" * 100)
+        # vision_cache : clé = MD5 truqué (on patche compute_cache_key pour le test)
+        with mock.patch("lib.vision_cache.compute_cache_key", return_value="HASH-ML"):
+            _seed_vision_cache(self.profiles_root, "p", {
+                "HASH-ML": {
+                    "result": {
+                        "title": "Machine Learning Book",
+                        "theme": "machine learning",
+                        "confidence": 0.95,
+                    },
+                    "model": "test",
+                    "prompt_version": "v1",
+                },
+            })
+            # Mapping proposed : machine learning → NEW (au lieu de OLD)
+            proposal_dir = self.tmp / "proposed"
+            _write_proposed_mapping(proposal_dir, {"machine learning": "NEW"})
+            result = simulate_reclassify("p", proposal_dir)
+        self.assertEqual(result["n_files"], 1)
+        self.assertEqual(result["n_moving"], 1)
+        self.assertEqual(result["n_stable"], 0)
+        # Top destination = NEW (1 fichier entrant)
+        self.assertEqual(result["top_destinations"][0]["folder"], "NEW")
+        self.assertEqual(result["top_destinations"][0]["n_incoming"], 1)
+
+    def test_file_stable_when_proposed_matches_current(self):
+        """Un fichier qui irait au même endroit que son dossier actuel = stable."""
+        _make_profile(
+            self.profiles_root, "p",
+            target=self.target,
+            folders=["A"],
+            mapping={"data": "A"},
+        )
+        a_dir = self.target / "A"
+        a_dir.mkdir()
+        pdf = a_dir / "data.pdf"
+        pdf.write_bytes(b"%PDF-1.4\n" + b"\x00" * 100)
+        with mock.patch("lib.vision_cache.compute_cache_key", return_value="HASH-D"):
+            _seed_vision_cache(self.profiles_root, "p", {
+                "HASH-D": {
+                    "result": {"title": "x", "theme": "data", "confidence": 0.9},
+                    "model": "test", "prompt_version": "v1",
+                },
+            })
+            proposal_dir = self.tmp / "proposed"
+            _write_proposed_mapping(proposal_dir, {"data": "A"})  # même que current
+            result = simulate_reclassify("p", proposal_dir)
+        self.assertEqual(result["n_moving"], 0)
+        self.assertEqual(result["n_stable"], 1)
+
+    def test_file_no_prediction_when_no_theme(self):
+        """Un fichier sans theme dans vision_cache et nom de fichier non-significatif → no_prediction."""
+        _make_profile(
+            self.profiles_root, "p",
+            target=self.target,
+            folders=["A"],
+            mapping={"theme1": "A"},
+        )
+        pdf = self.target / "xyz123.pdf"  # nom non-significatif (pas d'isbn, pas de keywords)
+        pdf.write_bytes(b"%PDF-1.4\n" + b"\x00" * 100)
+        # Pas d'entrée dans vision_cache (compute_cache_key → None ou pas en cache)
+        with mock.patch("lib.vision_cache.compute_cache_key", return_value=None):
+            _seed_vision_cache(self.profiles_root, "p", {})
+            proposal_dir = self.tmp / "proposed"
+            _write_proposed_mapping(proposal_dir, {"theme1": "A"})
+            result = simulate_reclassify("p", proposal_dir)
+        # Le fichier ne peut pas être classé → no_prediction
+        self.assertEqual(result["n_files"], 1)
+        self.assertEqual(result["n_no_prediction"], 1)
+
+    def test_csv_has_correct_structure(self):
+        """Le CSV produit a les bonnes colonnes et 1 ligne par fichier."""
+        _make_profile(
+            self.profiles_root, "p",
+            target=self.target,
+            folders=["A", "B"],
+            mapping={"t1": "A"},
+        )
+        for name in ("f1.pdf", "f2.pdf", "f3.pdf"):
+            (self.target / name).write_bytes(b"%PDF-1.4\n" + b"\x00" * 100)
+        with mock.patch("lib.vision_cache.compute_cache_key", return_value=None):
+            _seed_vision_cache(self.profiles_root, "p", {})
+            proposal_dir = self.tmp / "proposed"
+            _write_proposed_mapping(proposal_dir, {"t1": "B"})
+            result = simulate_reclassify("p", proposal_dir)
+        csv_path = Path(result["csv_path"])
+        self.assertTrue(csv_path.exists())
+        with csv_path.open() as f:
+            rows = list(csv.DictReader(f))
+        self.assertEqual(len(rows), 3)
+        # Colonnes attendues
+        expected_cols = {
+            "rel_path", "current_folder", "proposed_folder", "changed",
+            "source", "top_theme", "confidence", "score",
+        }
+        self.assertEqual(set(rows[0].keys()), expected_cols)
+
+    def test_summary_json_written_alongside_csv(self):
+        """Le simulation-summary.json est écrit dans le même dossier sim/."""
+        _make_profile(
+            self.profiles_root, "p",
+            target=self.target,
+            folders=["A"],
+            mapping={},
+        )
+        proposal_dir = self.tmp / "proposed"
+        _write_proposed_mapping(proposal_dir, {})
+        result = simulate_reclassify("p", proposal_dir)
+        summary_path = Path(result["summary_path"])
+        self.assertTrue(summary_path.exists())
+        data_ = json.loads(summary_path.read_text())
+        # Le summary.json contient les mêmes clés que le retour
+        self.assertEqual(data_["n_files"], result["n_files"])
+        self.assertEqual(data_["n_moving"], result["n_moving"])
+
+    def test_missing_proposed_mapping_raises(self):
+        """proposal_dir sans theme_mapping-proposed.yaml → FileNotFoundError."""
+        _make_profile(
+            self.profiles_root, "p",
+            target=self.target,
+            folders=["A"],
+            mapping={},
+        )
+        proposal_dir = self.tmp / "empty-proposed"
+        proposal_dir.mkdir()  # dossier existe mais pas de yaml dedans
+        with self.assertRaises(FileNotFoundError) as ctx:
+            simulate_reclassify("p", proposal_dir)
+        self.assertIn("theme_mapping-proposed.yaml manquant", str(ctx.exception))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Phase B de l'agent Refonte : à partir d'un diagnostic Phase A, génère une proposition de refonte taxonomy (créations / fusions / renommages / suppressions / mappings) + simulation reclassify + UI dédiée.

- **B.1** scaffolding du graphe Phase B + 1er prompt système
- **B.2** simulateur reclassify (mesure de l'impact sur la classification)
- **B.3** UI Phase B (bouton "Proposer une refonte" + 3 onglets Rationale/Diff/Impact)
- **B.3-bis** pré-extraction d'orphelins + prompt impératif (fixe les propositions vides)
- **B.3-ter** support des deletions + parsers sous-utilisés/catch-all + prompt par anomalie
- **Phase B agressive** : `find_orphan_themes(top_n=200)` direct au lieu de parser le markdown (couverture 28% → 100% des orphelins ≥ count 10)
- **Stratégie agressive sur les créations** : count ≥ 30 → folder dédié sauf homonymie (vs 4 créations seulement avant)
- **Switch LLM par défaut** : DeepSeek-V3.2 → GLM-4.7 (DeepSeek `APIConnectionError` récurrent côté SiliconFlow)
- **streaming=True** pour empêcher le disconnect serveur SiliconFlow à 90s (cause racine du timeout)
- **Suppression de runs** via × sur les cards (modale `showConfirm` + toast, charte dashboard)
- **Polish visuel** : H2 du rationale colorés par type + collapse, refonte des run cards (avatar phase circulaire + dot status pulsant)

## Métriques

- 916 tests verts (dont +85 spécifiques Phase B : proposition, simulator, endpoint, parsers)
- ruff clean
- Cible run réel sur profil `default` (18k fichiers) : 200 mappings + 4-50 créations en ~3-5 min selon load SiliconFlow

## Highlights techniques

- LangGraph `init → analyze → finalize` avec safeguards (anti-hallucination, anti-zombie, retry zero)
- Factory tools (`make_proposition_tools(profile, run_id)`) pour cacher le state au LLM
- Pré-extraction structurée (orphelins / sous-utilisés / catch-all) injectée en JSON dans le HumanMessage
- Fallback markdown si `find_orphan_themes` échoue (vision_cache absent)
- Endpoint `DELETE /api/agent/refonte/runs/<id>` avec validation UUID4 + refus des runs busy
- CSS grid layout pour les run cards, gradient phase A/B, animation pulse running

## Test plan

- [ ] Lancer un Phase A diagnostic sur `default`
- [ ] Cliquer "Proposer une refonte" → vérifier que B produit 30+ créations et 150+ mappings
- [ ] Vérifier les 3 onglets : Rationale (markdown coloré), Diff tree (créations en vert, suppressions en rouge), Impact reclassify (sample de moves)
- [ ] Supprimer un run via × → modal du dashboard apparaît + toast vert
- [ ] Lancer un B sans diagnostic A done → erreur explicite

🤖 Generated with [Claude Code](https://claude.com/claude-code)