### PR TITLE
feat(theme-dedupli): chantier dédupli sémantique des thèmes LLM (modes syntactic / semantic / source)

### DIFF
--- a/dashboard/app.py
+++ b/dashboard/app.py
@@ -2435,6 +2435,20 @@ async def api_dedupli_cancel(request: Request):
         return JSONResponse({"error": str(exc)}, status_code=409)
 
 
+@app.post("/api/taxonomy/dedupli/restore")
+async def api_dedupli_restore(request: Request):
+    """Supprime theme-canon.json pour revenir aux thèmes bruts."""
+    from fastapi.responses import JSONResponse
+    body = await request.json()
+    profile = (body.get("profile") or "").strip()
+    try:
+        return JSONResponse(dedupli.restore_initial_themes(profile))
+    except ValueError as exc:
+        return JSONResponse({"error": str(exc)}, status_code=400)
+    except RuntimeError as exc:
+        return JSONResponse({"error": str(exc)}, status_code=409)
+
+
 @app.get("/api/taxonomy/dedupli/clusters")
 async def api_dedupli_clusters(profile: str, multi_only: bool = True):
     """Liste les clusters depuis theme-canon.json (triés par count cumulé)."""

--- a/dashboard/app.py
+++ b/dashboard/app.py
@@ -24,6 +24,16 @@ if _func_dir not in sys.path:
 
 app = FastAPI(title="Klodo Dashboard")
 
+# Au démarrage : invalide les runs dédupli qui étaient encore en "running"
+# côté status.json (= thread daemon perdu par construction au reboot).
+# Sans ça, le 409 "déjà en cours" bloque les relances et il faut effacer
+# status.json à la main. Cf. dashboard/dedupli.reset_running_at_boot.
+try:
+    dedupli.reset_running_at_boot()
+except Exception:  # noqa: BLE001
+    # Échec non bloquant — au pire le user verra un zombie à reaper (2 min)
+    pass
+
 
 def _is_safe_file_path(file_path: str) -> bool:
     """Validate that a file path is inside allowed directories (prevent path traversal)."""

--- a/dashboard/app.py
+++ b/dashboard/app.py
@@ -2410,6 +2410,22 @@ async def api_dedupli_status(profile: str):
     return JSONResponse(dedupli.get_status(profile))
 
 
+@app.post("/api/taxonomy/dedupli/cancel")
+async def api_dedupli_cancel(request: Request):
+    """Demande l'annulation d'un run dédupli en cours."""
+    from fastapi.responses import JSONResponse
+    body = await request.json()
+    profile = (body.get("profile") or "").strip()
+    try:
+        return JSONResponse(dedupli.cancel_dedupli(profile))
+    except ValueError as exc:
+        return JSONResponse({"error": str(exc)}, status_code=400)
+    except FileNotFoundError as exc:
+        return JSONResponse({"error": str(exc)}, status_code=404)
+    except RuntimeError as exc:
+        return JSONResponse({"error": str(exc)}, status_code=409)
+
+
 @app.get("/api/taxonomy/dedupli/clusters")
 async def api_dedupli_clusters(profile: str, multi_only: bool = True):
     """Liste les clusters depuis theme-canon.json (triés par count cumulé)."""

--- a/dashboard/app.py
+++ b/dashboard/app.py
@@ -15,7 +15,7 @@ from fastapi.responses import StreamingResponse
 from fastapi.staticfiles import StaticFiles
 from fastapi.templating import Jinja2Templates
 
-from dashboard import agent_refonte, baseline, data, taxonomy
+from dashboard import agent_refonte, baseline, data, dedupli, taxonomy
 
 # Ensure functional test db module is importable
 _func_dir = str(data.get_project_root() / "tests" / "functional")
@@ -2362,6 +2362,69 @@ async def api_agent_refonte_delete_run(run_id: str, profile: str):
         return JSONResponse({"error": str(exc)}, status_code=404)
     except agent_refonte.RunBusyError as exc:
         return JSONResponse({"error": str(exc)}, status_code=409)
+
+
+# ════════════════════════════════════════════════════════════════════════
+#  Taxonomie — Onglet Dédupli des thèmes
+# ════════════════════════════════════════════════════════════════════════
+
+
+@app.post("/api/taxonomy/dedupli/build")
+async def api_dedupli_build(request: Request):
+    """Lance un build de canonisation en arrière-plan (~10-15 min sur 15k thèmes)."""
+    from fastapi.responses import JSONResponse
+    body = await request.json()
+    profile = (body.get("profile") or "").strip()
+    threshold = int(body.get("threshold") or 92)
+    if threshold < 50 or threshold > 100:
+        return JSONResponse(
+            {"error": "threshold must be between 50 and 100"}, status_code=400,
+        )
+    try:
+        result = dedupli.start_dedupli(profile, threshold=threshold)
+        return JSONResponse(result)
+    except ValueError as exc:
+        return JSONResponse({"error": str(exc)}, status_code=400)
+    except FileNotFoundError as exc:
+        return JSONResponse({"error": str(exc)}, status_code=404)
+    except RuntimeError as exc:
+        return JSONResponse({"error": str(exc)}, status_code=409)
+
+
+@app.get("/api/taxonomy/dedupli/status")
+async def api_dedupli_status(profile: str):
+    """Lit l'état du build (polling depuis le frontend)."""
+    from fastapi.responses import JSONResponse
+    if not profile:
+        return JSONResponse({"error": "profile query param is required"}, status_code=400)
+    return JSONResponse(dedupli.get_status(profile))
+
+
+@app.get("/api/taxonomy/dedupli/clusters")
+async def api_dedupli_clusters(profile: str, multi_only: bool = True):
+    """Liste les clusters depuis theme-canon.json (triés par count cumulé)."""
+    from fastapi.responses import JSONResponse
+    if not profile:
+        return JSONResponse({"error": "profile query param is required"}, status_code=400)
+    clusters = dedupli.list_clusters(profile, multi_only=multi_only)
+    return JSONResponse({"profile": profile, "clusters": clusters})
+
+
+@app.put("/api/taxonomy/dedupli/cluster")
+async def api_dedupli_update_cluster(request: Request):
+    """Édition manuelle d'un cluster — réécrit theme-canon.json en place."""
+    from fastapi.responses import JSONResponse
+    body = await request.json()
+    profile = (body.get("profile") or "").strip()
+    if not profile:
+        return JSONResponse({"error": "profile is required"}, status_code=400)
+    try:
+        updated = dedupli.update_cluster(profile, body)
+        return JSONResponse({"profile": profile, "cluster": updated})
+    except ValueError as exc:
+        return JSONResponse({"error": str(exc)}, status_code=400)
+    except FileNotFoundError as exc:
+        return JSONResponse({"error": str(exc)}, status_code=404)
 
 
 # ──────────── Phase B : Proposition ────────────

--- a/dashboard/app.py
+++ b/dashboard/app.py
@@ -2381,17 +2381,26 @@ async def api_agent_refonte_delete_run(run_id: str, profile: str):
 
 @app.post("/api/taxonomy/dedupli/build")
 async def api_dedupli_build(request: Request):
-    """Lance un build de canonisation en arrière-plan (~10-15 min sur 15k thèmes)."""
+    """Lance un build de canonisation en arrière-plan.
+
+    Body:
+      profile: str (required)
+      threshold: int = 92 (50..100)
+      mode: "syntactic" | "semantic" = "syntactic"
+        - syntactic : Phases 1+2+3 (variantes ortho)
+        - semantic  : C-light (vocabulaire LLM, capture synonymes éloignés)
+    """
     from fastapi.responses import JSONResponse
     body = await request.json()
     profile = (body.get("profile") or "").strip()
     threshold = int(body.get("threshold") or 92)
+    mode = (body.get("mode") or "syntactic").strip()
     if threshold < 50 or threshold > 100:
         return JSONResponse(
             {"error": "threshold must be between 50 and 100"}, status_code=400,
         )
     try:
-        result = dedupli.start_dedupli(profile, threshold=threshold)
+        result = dedupli.start_dedupli(profile, threshold=threshold, mode=mode)
         return JSONResponse(result)
     except ValueError as exc:
         return JSONResponse({"error": str(exc)}, status_code=400)

--- a/dashboard/dedupli.py
+++ b/dashboard/dedupli.py
@@ -29,8 +29,9 @@ from typing import Any
 from dashboard import data
 
 # Seuil au-delà duquel un run "running" est considéré orphelin (zombie).
-# Le judging d'un gros cluster peut prendre 30s+, donc 5 min de marge.
-_ZOMBIE_THRESHOLD_S = 5 * 60
+# Avec parallélisation 8 workers, on_progress est appelé toutes les 1-2s
+# en moyenne — 2 min sans update est très conservateur (≥ 60 updates ratés).
+_ZOMBIE_THRESHOLD_S = 2 * 60
 
 
 def _dedupli_dir(profile: str) -> Path:
@@ -71,7 +72,7 @@ def _write_status(profile: str, payload: dict[str, Any]) -> None:
 
 
 def _reap_zombie(profile: str) -> None:
-    """Marque comme `error` un run zombie (running sans update >5min).
+    """Marque comme `error` un run zombie (running sans update >threshold).
 
     Cas typique : dashboard redémarré pendant un run. Le thread daemon
     meurt mais status.json reste "running" éternellement.
@@ -97,6 +98,44 @@ def _reap_zombie(profile: str) -> None:
         ),
     })
     _write_status(profile, status)
+
+
+def reset_running_at_boot() -> None:
+    """Marque comme `error` tous les runs `running`/`pending` au démarrage
+    du dashboard.
+
+    Justification : tout thread daemon est mort par construction quand le
+    process redémarre. Inutile d'attendre _ZOMBIE_THRESHOLD_S pour le
+    constater — on connaît la vérité tout de suite. Appelé une fois au
+    boot par dashboard.app.
+
+    Parcours tous les profils sous profiles/<X>/.cache/dedupli/status.json
+    et reset ceux qui sont en running/pending.
+    """
+    profiles_root = data.get_project_root() / "profiles"
+    if not profiles_root.is_dir():
+        return
+    for profile_dir in profiles_root.iterdir():
+        if not profile_dir.is_dir():
+            continue
+        status_path = profile_dir / ".cache" / "dedupli" / "status.json"
+        if not status_path.exists():
+            continue
+        try:
+            status = json.loads(status_path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError):
+            continue
+        if status.get("status") not in ("running", "pending"):
+            continue
+        status.update({
+            "status": "error",
+            "completed_at": _now_iso(),
+            "error": "Dashboard redémarré pendant le run (thread daemon perdu).",
+        })
+        try:
+            _write_status(profile_dir.name, status)
+        except OSError:
+            pass
 
 
 def get_status(profile: str) -> dict[str, Any]:

--- a/dashboard/dedupli.py
+++ b/dashboard/dedupli.py
@@ -188,6 +188,7 @@ def get_status(profile: str) -> dict[str, Any]:
                 "raw_count": canon.get("raw_count", 0),
                 "canonical_count": canon.get("canonical_count", 0),
                 "threshold": canon.get("threshold"),
+                "mode": canon.get("mode"),
                 "n_clusters": len(canon.get("clusters", [])),
             }
         except (OSError, json.JSONDecodeError):
@@ -318,7 +319,12 @@ def _save_canon_atomic(path: Path, canon: dict[str, Any]) -> None:
     tmp.replace(path)
 
 
-def start_dedupli(profile: str, *, threshold: int = 92) -> dict[str, Any]:
+def start_dedupli(
+    profile: str,
+    *,
+    threshold: int = 92,
+    mode: str = "syntactic",
+) -> dict[str, Any]:
     """Démarre un build de canonisation en background thread.
 
     Refuse si un run est déjà en cours (status running/pending non zombie).
@@ -326,17 +332,21 @@ def start_dedupli(profile: str, *, threshold: int = 92) -> dict[str, Any]:
     Args:
         profile: Profil cible (doit exister).
         threshold: Seuil de clustering fuzzy (défaut 92).
+        mode: "syntactic" (Phases 1-3) ou "semantic" (C-light avec vocabulaire
+              LLM). Cf. lib.theme_canon.build_canon_table pour le détail.
 
     Returns:
         {"profile": ..., "status": "pending", "started_at": ...}
 
     Raises:
-        ValueError: profile vide.
+        ValueError: profile vide ou mode invalide.
         FileNotFoundError: profile inexistant.
         RuntimeError: un run est déjà actif.
     """
     if not profile:
         raise ValueError("profile is required")
+    if mode not in ("syntactic", "semantic"):
+        raise ValueError(f"mode must be 'syntactic' or 'semantic', got {mode!r}")
     profile_path = data.get_project_root() / "profiles" / profile
     if not profile_path.is_dir():
         raise FileNotFoundError(f"profile not found: {profile}")
@@ -356,19 +366,20 @@ def start_dedupli(profile: str, *, threshold: int = 92) -> dict[str, Any]:
         "completed_at": None,
         "error": None,
         "threshold": threshold,
+        "mode": mode,
     }
     _write_status(profile, payload)
 
     thread = threading.Thread(
         target=_run_dedupli,
-        args=(profile, threshold),
+        args=(profile, threshold, mode),
         daemon=True,
     )
     thread.start()
     return {"profile": profile, "status": "pending", "started_at": payload["started_at"]}
 
 
-def _run_dedupli(profile: str, threshold: int) -> None:
+def _run_dedupli(profile: str, threshold: int, mode: str = "syntactic") -> None:
     """Cœur du thread daemon : appelle build_canon_table + persiste status."""
     # Imports lazy — évite de charger langchain au démarrage du dashboard
     from agents.llm import get_agent_llm
@@ -396,6 +407,7 @@ def _run_dedupli(profile: str, threshold: int) -> None:
             profile, llm,
             threshold=threshold,
             on_progress=on_progress,
+            mode=mode,
         )
         status = _read_status(profile) or {}
         status.update({

--- a/dashboard/dedupli.py
+++ b/dashboard/dedupli.py
@@ -156,6 +156,9 @@ def restore_initial_themes(profile: str) -> dict[str, Any]:
     réutilisé pour un futur build).
 
     Refuse si un run dédupli est en cours pour éviter une race.
+    Invalide le snapshot taxonomy après suppression pour que les onglets
+    (Mappings, Refonte, etc.) repartent sur l'agrégation non-canonisée
+    sans clic manuel sur "Recharger le snapshot".
 
     Raises:
         ValueError: profile vide.
@@ -173,7 +176,23 @@ def restore_initial_themes(profile: str) -> dict[str, Any]:
     existed = canon_path.exists()
     if existed:
         canon_path.unlink()
+        _invalidate_taxonomy_snapshot(profile)
     return {"profile": profile, "restored": existed}
+
+
+def _invalidate_taxonomy_snapshot(profile: str) -> None:
+    """Invalide le snapshot taxonomy en RAM (best-effort, ne raise pas).
+
+    Appelé après un build dédupli réussi ou un restore : les onglets
+    Mappings / Catégories / Refonte agrègent les thèmes depuis ce
+    snapshot mémoizé, sinon ils continuent d'afficher les counts
+    d'avant le changement de canon.
+    """
+    try:
+        from dashboard import taxonomy as _tax
+        _tax.reset_cache(profile)
+    except Exception:  # noqa: BLE001
+        pass
 
 
 def cancel_dedupli(profile: str) -> dict[str, Any]:
@@ -453,6 +472,10 @@ def _run_dedupli(profile: str, threshold: int, mode: str = "syntactic") -> None:
         # Nettoie le flag (au cas où il aurait été posé tardivement)
         status.pop("cancel_requested", None)
         _write_status(profile, status)
+        # Invalide le snapshot taxonomy pour propager la nouvelle
+        # canonisation aux onglets Mappings / Catégories / Refonte
+        # sans clic manuel "Recharger le snapshot".
+        _invalidate_taxonomy_snapshot(profile)
     except _CancelledError:
         status = _read_status(profile) or {}
         status.update({

--- a/dashboard/dedupli.py
+++ b/dashboard/dedupli.py
@@ -375,8 +375,10 @@ def start_dedupli(
     """
     if not profile:
         raise ValueError("profile is required")
-    if mode not in ("syntactic", "semantic"):
-        raise ValueError(f"mode must be 'syntactic' or 'semantic', got {mode!r}")
+    if mode not in ("syntactic", "semantic", "source"):
+        raise ValueError(
+            f"mode must be 'syntactic', 'semantic' or 'source', got {mode!r}"
+        )
     profile_path = data.get_project_root() / "profiles" / profile
     if not profile_path.is_dir():
         raise FileNotFoundError(f"profile not found: {profile}")

--- a/dashboard/dedupli.py
+++ b/dashboard/dedupli.py
@@ -1,0 +1,339 @@
+"""Backend dashboard pour le chantier Dédupli des thèmes (Phase 5 UI).
+
+Wrappe l'invocation de `lib.theme_canon.build_canon_table` dans un thread,
+persiste l'avancement dans `profiles/<p>/.cache/dedupli/status.json`, et
+expose des helpers synchrones pour les endpoints FastAPI :
+  - start_dedupli(profile) — lance un build async
+  - get_status(profile)    — lit l'avancement
+  - list_clusters(profile) — liste les clusters issus de theme-canon.json
+  - update_cluster(profile, payload) — édition manuelle (members/splits/canonical)
+
+État persisté dans `dedupli/status.json` :
+  {
+    "status": "pending|running|done|error",
+    "phase": "extracting|clustering|judging|done",
+    "progress": {"done": N, "total": M},
+    "started_at": ..., "completed_at": ..., "error": ...
+  }
+"""
+
+from __future__ import annotations
+
+import json
+import threading
+import traceback
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+from dashboard import data
+
+# Seuil au-delà duquel un run "running" est considéré orphelin (zombie).
+# Le judging d'un gros cluster peut prendre 30s+, donc 5 min de marge.
+_ZOMBIE_THRESHOLD_S = 5 * 60
+
+
+def _dedupli_dir(profile: str) -> Path:
+    base = data.get_project_root() / "profiles" / profile / ".cache" / "dedupli"
+    base.mkdir(parents=True, exist_ok=True)
+    return base
+
+
+def _status_path(profile: str) -> Path:
+    return _dedupli_dir(profile) / "status.json"
+
+
+def _canon_path(profile: str) -> Path:
+    return data.get_project_root() / "profiles" / profile / ".cache" / "theme-canon.json"
+
+
+def _now_iso() -> str:
+    return datetime.now(UTC).isoformat()
+
+
+def _read_status(profile: str) -> dict[str, Any] | None:
+    path = _status_path(profile)
+    if not path.exists():
+        return None
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return None
+
+
+def _write_status(profile: str, payload: dict[str, Any]) -> None:
+    path = _status_path(profile)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(payload, ensure_ascii=False, indent=2),
+        encoding="utf-8",
+    )
+
+
+def _reap_zombie(profile: str) -> None:
+    """Marque comme `error` un run zombie (running sans update >5min).
+
+    Cas typique : dashboard redémarré pendant un run. Le thread daemon
+    meurt mais status.json reste "running" éternellement.
+    """
+    status = _read_status(profile)
+    if not status or status.get("status") not in ("running", "pending"):
+        return
+    path = _status_path(profile)
+    try:
+        mtime = datetime.fromtimestamp(path.stat().st_mtime, tz=UTC)
+    except OSError:
+        return
+    age = (datetime.now(UTC) - mtime).total_seconds()
+    if age < _ZOMBIE_THRESHOLD_S:
+        return
+    status.update({
+        "status": "error",
+        "completed_at": _now_iso(),
+        "error": (
+            f"Run orphelin : aucun progrès depuis {int(age)}s. "
+            "Probablement tué par un redémarrage du dashboard. Relance "
+            "la dédupli."
+        ),
+    })
+    _write_status(profile, status)
+
+
+def get_status(profile: str) -> dict[str, Any]:
+    """Lit le status courant (+ reap si nécessaire). Inclut un résumé du
+    canon si présent (raw_count, canonical_count, built_at)."""
+    _reap_zombie(profile)
+    status = _read_status(profile) or {"status": "idle"}
+    # Enrichit avec un résumé du canon si présent
+    canon_path = _canon_path(profile)
+    if canon_path.exists():
+        try:
+            canon = json.loads(canon_path.read_text(encoding="utf-8"))
+            status["canon_summary"] = {
+                "built_at": canon.get("built_at"),
+                "raw_count": canon.get("raw_count", 0),
+                "canonical_count": canon.get("canonical_count", 0),
+                "threshold": canon.get("threshold"),
+                "n_clusters": len(canon.get("clusters", [])),
+            }
+        except (OSError, json.JSONDecodeError):
+            pass
+    return status
+
+
+def list_clusters(profile: str, *, multi_only: bool = True) -> list[dict[str, Any]]:
+    """Liste les clusters depuis theme-canon.json.
+
+    Args:
+        multi_only: Si True, ne renvoie que les clusters avec ≥ 2 raw_members
+                    (les singletons sont sans intérêt pour la review).
+
+    Returns:
+        Liste de clusters triée par count_cumulative décroissant. Format :
+            {canonical, members, splits, raw_members, count_cumulative}
+    """
+    path = _canon_path(profile)
+    if not path.exists():
+        return []
+    try:
+        canon = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return []
+    clusters = canon.get("clusters", [])
+    if not isinstance(clusters, list):
+        return []
+    if multi_only:
+        clusters = [c for c in clusters if len(c.get("raw_members", [])) >= 2]
+    clusters.sort(key=lambda c: -int(c.get("count_cumulative") or 0))
+    return clusters
+
+
+def update_cluster(profile: str, payload: dict[str, Any]) -> dict[str, Any]:
+    """Édition manuelle d'un cluster — réécrit theme-canon.json en place.
+
+    Le cluster est identifié par la liste `raw_members` (canonique pour la
+    recherche). Le caller passe le nouveau canonical + nouveaux members +
+    nouveaux splits. Le mapping est régénéré pour ce cluster.
+
+    Args:
+        profile: Profil cible.
+        payload: {
+            "raw_members": list[str],   # identifiant du cluster
+            "canonical": str,
+            "members": list[str],
+            "splits": list[{"theme": str, "reason": str}]
+        }
+
+    Returns:
+        Le cluster mis à jour.
+
+    Raises:
+        FileNotFoundError: theme-canon.json absent.
+        ValueError: cluster introuvable ou payload invalide.
+    """
+    raw_members = payload.get("raw_members") or []
+    if not raw_members:
+        raise ValueError("raw_members is required (cluster identifier)")
+    new_canonical = (payload.get("canonical") or "").strip()
+    if not new_canonical:
+        raise ValueError("canonical must be a non-empty string")
+    new_members = list(payload.get("members") or [])
+    new_splits = list(payload.get("splits") or [])
+
+    canon_path = _canon_path(profile)
+    if not canon_path.exists():
+        raise FileNotFoundError(f"theme-canon.json not found for profile {profile!r}")
+    canon = json.loads(canon_path.read_text(encoding="utf-8"))
+    clusters = canon.get("clusters", [])
+
+    # Trouve le cluster par signature raw_members (set, indépendant ordre)
+    target_set = set(raw_members)
+    idx = next(
+        (i for i, c in enumerate(clusters)
+         if set(c.get("raw_members", [])) == target_set),
+        None,
+    )
+    if idx is None:
+        raise ValueError(f"cluster with raw_members={raw_members!r} not found")
+
+    # Validation : tous les members/splits doivent être dans raw_members
+    raw_set = set(raw_members)
+    member_set = set(new_members)
+    split_set = {s.get("theme") for s in new_splits if isinstance(s, dict)}
+    if not member_set.issubset(raw_set):
+        raise ValueError(
+            f"members not in raw_members: {member_set - raw_set!r}"
+        )
+    if not split_set.issubset(raw_set):
+        raise ValueError(
+            f"splits not in raw_members: {split_set - raw_set!r}"
+        )
+
+    # Met à jour le cluster
+    updated = clusters[idx]
+    updated["canonical"] = new_canonical
+    updated["members"] = new_members
+    updated["splits"] = new_splits
+
+    # Régénère le mapping pour ce cluster :
+    #   members → canonical
+    #   splits → identité
+    #   filet de sécurité : raw_member non listé → identité
+    mapping = canon.setdefault("mapping", {})
+    for raw in raw_members:
+        if raw in member_set:
+            mapping[raw] = new_canonical
+        else:
+            # split OU orphelin du cluster → identité
+            mapping[raw] = raw
+
+    # Met à jour le compteur canonical_count
+    canon["canonical_count"] = len(set(mapping.values()))
+    canon["raw_count"] = len(mapping)
+
+    _save_canon_atomic(canon_path, canon)
+    return updated
+
+
+def _save_canon_atomic(path: Path, canon: dict[str, Any]) -> None:
+    tmp = path.with_suffix(".tmp")
+    tmp.write_text(
+        json.dumps(canon, ensure_ascii=False, indent=2),
+        encoding="utf-8",
+    )
+    tmp.replace(path)
+
+
+def start_dedupli(profile: str, *, threshold: int = 92) -> dict[str, Any]:
+    """Démarre un build de canonisation en background thread.
+
+    Refuse si un run est déjà en cours (status running/pending non zombie).
+
+    Args:
+        profile: Profil cible (doit exister).
+        threshold: Seuil de clustering fuzzy (défaut 92).
+
+    Returns:
+        {"profile": ..., "status": "pending", "started_at": ...}
+
+    Raises:
+        ValueError: profile vide.
+        FileNotFoundError: profile inexistant.
+        RuntimeError: un run est déjà actif.
+    """
+    if not profile:
+        raise ValueError("profile is required")
+    profile_path = data.get_project_root() / "profiles" / profile
+    if not profile_path.is_dir():
+        raise FileNotFoundError(f"profile not found: {profile}")
+
+    _reap_zombie(profile)
+    current = _read_status(profile)
+    if current and current.get("status") in ("running", "pending"):
+        raise RuntimeError(
+            f"un run est déjà en cours (status={current.get('status')})"
+        )
+
+    payload = {
+        "status": "pending",
+        "phase": "extracting",
+        "progress": {"done": 0, "total": 0},
+        "started_at": _now_iso(),
+        "completed_at": None,
+        "error": None,
+        "threshold": threshold,
+    }
+    _write_status(profile, payload)
+
+    thread = threading.Thread(
+        target=_run_dedupli,
+        args=(profile, threshold),
+        daemon=True,
+    )
+    thread.start()
+    return {"profile": profile, "status": "pending", "started_at": payload["started_at"]}
+
+
+def _run_dedupli(profile: str, threshold: int) -> None:
+    """Cœur du thread daemon : appelle build_canon_table + persiste status."""
+    # Imports lazy — évite de charger langchain au démarrage du dashboard
+    from agents.llm import get_agent_llm
+    from lib.theme_canon import build_canon_table
+
+    def on_progress(done: int, total: int, phase: str) -> None:
+        # Mise à jour incrémentale du status (consommée par le polling UI)
+        status = _read_status(profile) or {}
+        status.update({
+            "status": "running",
+            "phase": phase,
+            "progress": {"done": done, "total": total},
+        })
+        _write_status(profile, status)
+
+    try:
+        llm = get_agent_llm()
+        on_progress(0, 0, "extracting")
+        table = build_canon_table(
+            profile, llm,
+            threshold=threshold,
+            on_progress=on_progress,
+        )
+        status = _read_status(profile) or {}
+        status.update({
+            "status": "done",
+            "phase": "done",
+            "completed_at": _now_iso(),
+            "raw_count": table.get("raw_count"),
+            "canonical_count": table.get("canonical_count"),
+            "n_clusters": len(table.get("clusters", [])),
+        })
+        _write_status(profile, status)
+    except Exception as exc:  # noqa: BLE001 — on persiste l'erreur dans status
+        status = _read_status(profile) or {}
+        status.update({
+            "status": "error",
+            "completed_at": _now_iso(),
+            "error": f"{type(exc).__name__}: {exc}",
+            "traceback": traceback.format_exc()[-2000:],
+        })
+        _write_status(profile, status)

--- a/dashboard/dedupli.py
+++ b/dashboard/dedupli.py
@@ -146,6 +146,36 @@ class _CancelledError(Exception):
     """
 
 
+def restore_initial_themes(profile: str) -> dict[str, Any]:
+    """Supprime theme-canon.json pour revenir aux thèmes bruts du vision_cache.
+
+    `theme-canon.json` est consommé en runtime par
+    `dashboard.taxonomy._aggregate_themes_llm`. Sa suppression rétablit
+    instantanément le comportement d'origine sans toucher au vision_cache
+    (source de vérité immuable) ni au cache canonicalizer (peut être
+    réutilisé pour un futur build).
+
+    Refuse si un run dédupli est en cours pour éviter une race.
+
+    Raises:
+        ValueError: profile vide.
+        RuntimeError: un run est en cours (running/pending).
+    """
+    if not profile:
+        raise ValueError("profile is required")
+    _reap_zombie(profile)
+    status = _read_status(profile)
+    if status and status.get("status") in ("running", "pending"):
+        raise RuntimeError(
+            "un run est en cours — annule-le d'abord avant de restaurer"
+        )
+    canon_path = _canon_path(profile)
+    existed = canon_path.exists()
+    if existed:
+        canon_path.unlink()
+    return {"profile": profile, "restored": existed}
+
+
 def cancel_dedupli(profile: str) -> dict[str, Any]:
     """Demande l'annulation d'un run en cours.
 

--- a/dashboard/dedupli.py
+++ b/dashboard/dedupli.py
@@ -138,6 +138,41 @@ def reset_running_at_boot() -> None:
             pass
 
 
+class _CancelledError(Exception):
+    """Levée par le callback on_progress quand le user a demandé un cancel.
+
+    Capturée par _run_dedupli pour faire transitionner le status vers
+    "cancelled" proprement.
+    """
+
+
+def cancel_dedupli(profile: str) -> dict[str, Any]:
+    """Demande l'annulation d'un run en cours.
+
+    Pose `cancel_requested=True` dans status.json — le thread daemon lit
+    ce flag dans son callback on_progress et raise _CancelledError au
+    prochain check. Les appels LLM déjà en vol terminent (pas de kill
+    brutal), mais aucun nouveau n'est lancé.
+
+    Raises:
+        ValueError: profile vide.
+        FileNotFoundError: aucun run actuel ou status absent.
+        RuntimeError: le run n'est pas en running/pending (déjà done/error/cancelled).
+    """
+    if not profile:
+        raise ValueError("profile is required")
+    status = _read_status(profile)
+    if not status:
+        raise FileNotFoundError(f"no dedupli status for profile {profile!r}")
+    if status.get("status") not in ("running", "pending"):
+        raise RuntimeError(
+            f"cannot cancel: status is {status.get('status')!r}"
+        )
+    status["cancel_requested"] = True
+    _write_status(profile, status)
+    return {"profile": profile, "status": "cancelling"}
+
+
 def get_status(profile: str) -> dict[str, Any]:
     """Lit le status courant (+ reap si nécessaire). Inclut un résumé du
     canon si présent (raw_count, canonical_count, built_at)."""
@@ -342,6 +377,11 @@ def _run_dedupli(profile: str, threshold: int) -> None:
     def on_progress(done: int, total: int, phase: str) -> None:
         # Mise à jour incrémentale du status (consommée par le polling UI)
         status = _read_status(profile) or {}
+        # Check cancellation : si le user a demandé un cancel, on raise
+        # immédiatement. La closure remonte jusqu'à _run_dedupli qui
+        # transitionne le status à "cancelled" et exit.
+        if status.get("cancel_requested"):
+            raise _CancelledError()
         status.update({
             "status": "running",
             "phase": phase,
@@ -366,6 +406,18 @@ def _run_dedupli(profile: str, threshold: int) -> None:
             "canonical_count": table.get("canonical_count"),
             "n_clusters": len(table.get("clusters", [])),
         })
+        # Nettoie le flag (au cas où il aurait été posé tardivement)
+        status.pop("cancel_requested", None)
+        _write_status(profile, status)
+    except _CancelledError:
+        status = _read_status(profile) or {}
+        status.update({
+            "status": "cancelled",
+            "phase": "cancelled",
+            "completed_at": _now_iso(),
+            "error": None,
+        })
+        status.pop("cancel_requested", None)
         _write_status(profile, status)
     except Exception as exc:  # noqa: BLE001 — on persiste l'erreur dans status
         status = _read_status(profile) or {}
@@ -375,4 +427,5 @@ def _run_dedupli(profile: str, threshold: int) -> None:
             "error": f"{type(exc).__name__}: {exc}",
             "traceback": traceback.format_exc()[-2000:],
         })
+        status.pop("cancel_requested", None)
         _write_status(profile, status)

--- a/dashboard/static/js/taxonomy_rename.js
+++ b/dashboard/static/js/taxonomy_rename.js
@@ -342,6 +342,9 @@
     if (view === 'refonte' && window.taxRefontePanel) {
       window.taxRefontePanel.activate();
     }
+    if (view === 'dedupli' && window.taxDedupliPanel) {
+      window.taxDedupliPanel.activate();
+    }
   }
 
   // ── Filters bar ──────────────────────────────────────────────────────

--- a/dashboard/taxonomy.py
+++ b/dashboard/taxonomy.py
@@ -195,6 +195,12 @@ def _aggregate_themes_llm(profile: str, mapping: dict) -> tuple[list[dict], dict
 
     Each theme entry: {theme, count, confidence_avg, mapped_to, is_orphan,
                        sample_titles}.
+
+    Si `profiles/<p>/.cache/theme-canon.json` existe (produit par
+    `lib.theme_canon.build_canon_table`), les raw_themes sont résolus
+    vers leur canonical avant cumul. Cumule donc les counts des
+    variantes orthographiques d'un même concept. Sinon comportement
+    historique (key = lowercase raw).
     """
     cache_path = _vision_cache_path(profile)
     if not cache_path.exists():
@@ -204,7 +210,12 @@ def _aggregate_themes_llm(profile: str, mapping: dict) -> tuple[list[dict], dict
     except (OSError, json.JSONDecodeError):
         return [], {"total_themes_llm": 0, "orphans": 0, "mapped": 0}
 
-    # Aggregate: per-theme (lowercased key) count + conf sum + sample titles
+    # Import lazy — lib.theme_canon dépend de lib.theme_judge qui importe
+    # langchain ; on évite de charger ça au démarrage du dashboard.
+    from lib.theme_canon import canonicalize, load_canon_table
+    canon_table = load_canon_table(profile)
+
+    # Aggregate: per-canonical key count + conf sum + sample titles
     agg: dict[str, dict] = {}
     sample_titles: dict[str, list[str]] = defaultdict(list)
     for entry in cache.values():
@@ -215,8 +226,12 @@ def _aggregate_themes_llm(profile: str, mapping: dict) -> tuple[list[dict], dict
         for t, conf in _iter_themes({"x": entry}):
             if conf < _MIN_CONFIDENCE:
                 continue
-            key = t.lower()
-            slot = agg.setdefault(key, {"theme": t, "count": 0, "conf_sum": 0.0})
+            # Résolution canonisation → cumule les variantes orthographiques
+            canonical = canonicalize(t, canon_table)
+            key = canonical.lower()
+            slot = agg.setdefault(
+                key, {"theme": canonical, "count": 0, "conf_sum": 0.0}
+            )
             slot["count"] += 1
             slot["conf_sum"] += conf
             if title and len(sample_titles[key]) < 3 and title not in sample_titles[key]:

--- a/dashboard/templates/partials/tax_dedupli_panel.html
+++ b/dashboard/templates/partials/tax_dedupli_panel.html
@@ -12,6 +12,11 @@
         <button id="tax-dedupli-cancel" class="btn-danger tax-dedupli-launch" style="display:none;">
             🛑 Annuler
         </button>
+        <button id="tax-dedupli-restore" class="btn-secondary tax-dedupli-launch"
+                title="Supprime theme-canon.json — rétablit les thèmes bruts du vision_cache (réversible : tu peux relancer un build après)."
+                style="display:none;">
+            🔄 Restaurer thèmes initiaux
+        </button>
         <label class="filter-label" for="tax-dedupli-mode">Mode</label>
         <select id="tax-dedupli-mode" class="filter-select"
                 title="Syntactique = variantes ortho seules. Sémantique = synonymes via vocabulaire LLM.">
@@ -223,6 +228,7 @@
 (function() {
     const startBtn = document.getElementById('tax-dedupli-start');
     const cancelBtn = document.getElementById('tax-dedupli-cancel');
+    const restoreBtn = document.getElementById('tax-dedupli-restore');
     const thresholdInput = document.getElementById('tax-dedupli-threshold');
     const modeSelect = document.getElementById('tax-dedupli-mode');
     const statusEl = document.getElementById('tax-dedupli-status');
@@ -312,7 +318,7 @@
         }
     }
 
-    function setButtons(running, cancelling) {
+    function setButtons(running, cancelling, hasCanon) {
         // En cours et pas encore en cancellation → Annuler dispo
         if (running && !cancelling) {
             startBtn.style.display = 'none';
@@ -333,13 +339,20 @@
         // Mode + threshold figés pendant un run
         if (modeSelect) modeSelect.disabled = running;
         thresholdInput.disabled = running;
+        // Restaurer visible uniquement quand un canon existe ET qu'on ne tourne pas
+        if (restoreBtn) {
+            restoreBtn.style.display = (!running && hasCanon) ? '' : 'none';
+        }
     }
 
     function renderStatus(s) {
+        const hasCanon = !!s.canon_summary;
         if (s.status === 'idle') {
-            setStatus('État : non lancé');
+            setStatus(hasCanon
+                ? 'État : canon existant (relancer écrasera)'
+                : 'État : non lancé');
             hideProgress();
-            setButtons(false, false);
+            setButtons(false, false, hasCanon);
             return;
         }
         if (s.status === 'running' || s.status === 'pending') {
@@ -351,7 +364,7 @@
                     ? 'Annulation en cours… (les appels LLM en vol terminent puis on stoppe)'
                     : `En cours — phase: ${s.phase || '…'}`
             );
-            setButtons(true, cancelling);
+            setButtons(true, cancelling, hasCanon);
             return;
         }
         if (s.status === 'done') {
@@ -365,20 +378,20 @@
                 `✓ Terminé (${modeLabel}) — ${cs.raw_count || 0} → ${cs.canonical_count || 0} `
               + `(${reduction}% réduction · ${cs.n_clusters || 0} clusters)`
             );
-            setButtons(false, false);
+            setButtons(false, false, hasCanon);
             return;
         }
         if (s.status === 'cancelled') {
             hideProgress();
             const p = s.progress || {};
             setStatus(`⏹ Annulé — ${p.done || 0} / ${p.total || 0} clusters traités avant arrêt`);
-            setButtons(false, false);
+            setButtons(false, false, hasCanon);
             return;
         }
         if (s.status === 'error') {
             hideProgress();
             setStatus('❌ Erreur : ' + (s.error || 'unknown'));
-            setButtons(false, false);
+            setButtons(false, false, hasCanon);
             return;
         }
     }
@@ -556,8 +569,49 @@
         }
     }
 
+    async function restoreInitial() {
+        const profile = currentProfile();
+        const ok = await showConfirm({
+            title: 'Restaurer les thèmes initiaux ?',
+            body: 'Supprime theme-canon.json — la taxonomie revient aux thèmes bruts du vision_cache. '
+                + 'Le cache des décisions LLM (theme-canonicalizer.json) reste, donc tu pourras '
+                + 'relancer un build plus tard sans repayer les appels LLM déjà faits.',
+            confirmLabel: 'Restaurer',
+            cancelLabel: 'Annuler',
+            variant: 'danger',
+        }).catch(() => window.confirm('Restaurer les thèmes initiaux ?'));
+        if (!ok) return;
+        try {
+            const r = await fetch('/api/taxonomy/dedupli/restore', {
+                method: 'POST',
+                headers: {'Content-Type': 'application/json'},
+                body: JSON.stringify({profile}),
+            });
+            if (!r.ok) {
+                const err = await r.json().catch(() => ({}));
+                alert('Erreur : ' + (err.error || r.status));
+                return;
+            }
+            // Reset l'UI : status redevient idle (pas de canon_summary)
+            pollStatus();
+            // Vide la zone clusters / detail
+            clustersEl.innerHTML = '<p class="muted small">Thèmes initiaux restaurés. '
+                                 + 'Lance un build pour réessayer.</p>';
+            detailEl.innerHTML = '';
+        } catch (e) {
+            alert('Erreur réseau : ' + e.message);
+        }
+    }
+
+    // showConfirm partagé via window (déclaré dans taxonomy.html)
+    function showConfirm(opts) {
+        if (window.showConfirm) return window.showConfirm(opts);
+        return Promise.resolve(window.confirm(`${opts.title || ''}\n\n${opts.body || ''}`));
+    }
+
     startBtn.addEventListener('click', startBuild);
     cancelBtn.addEventListener('click', cancelBuild);
+    if (restoreBtn) restoreBtn.addEventListener('click', restoreInitial);
 
     // Activation : exposé pour activateSubtab() dans taxonomy_rename.js
     window.taxDedupliPanel = {

--- a/dashboard/templates/partials/tax_dedupli_panel.html
+++ b/dashboard/templates/partials/tax_dedupli_panel.html
@@ -19,9 +19,10 @@
         </button>
         <label class="filter-label" for="tax-dedupli-mode">Mode</label>
         <select id="tax-dedupli-mode" class="filter-select"
-                title="Syntactique = variantes ortho seules. Sémantique = synonymes via vocabulaire LLM.">
+                title="Syntactique = variantes ortho seules. Sémantique = synonymes LLM aveugle. Source = LLM avec contexte titres (le plus précis).">
             <option value="syntactic">Syntactique</option>
-            <option value="semantic" selected>Sémantique (C-light)</option>
+            <option value="semantic">Sémantique (C-light)</option>
+            <option value="source" selected>Source (C.2 — avec titres)</option>
         </select>
         <label class="filter-label" for="tax-dedupli-threshold">Threshold</label>
         <input type="number" id="tax-dedupli-threshold" class="filter-select"
@@ -373,7 +374,8 @@
             const reduction = cs.raw_count && cs.canonical_count
                 ? Math.round((1 - cs.canonical_count / cs.raw_count) * 100)
                 : 0;
-            const modeLabel = cs.mode === 'semantic' ? 'Sémantique' : 'Syntactique';
+            const modeLabel = cs.mode === 'source' ? 'Source'
+                            : (cs.mode === 'semantic' ? 'Sémantique' : 'Syntactique');
             setStatus(
                 `✓ Terminé (${modeLabel}) — ${cs.raw_count || 0} → ${cs.canonical_count || 0} `
               + `(${reduction}% réduction · ${cs.n_clusters || 0} clusters)`

--- a/dashboard/templates/partials/tax_dedupli_panel.html
+++ b/dashboard/templates/partials/tax_dedupli_panel.html
@@ -581,7 +581,7 @@
             confirmLabel: 'Restaurer',
             cancelLabel: 'Annuler',
             variant: 'danger',
-        }).catch(() => window.confirm('Restaurer les thèmes initiaux ?'));
+        });
         if (!ok) return;
         try {
             const r = await fetch('/api/taxonomy/dedupli/restore', {
@@ -605,10 +605,42 @@
         }
     }
 
-    // showConfirm partagé via window (déclaré dans taxonomy.html)
-    function showConfirm(opts) {
-        if (window.showConfirm) return window.showConfirm(opts);
-        return Promise.resolve(window.confirm(`${opts.title || ''}\n\n${opts.body || ''}`));
+    // Duplication assumée du helper (cf. agent_refonte_panel.html /
+    // taxonomy_rename.js) — chaque sous-onglet vit dans son IIFE, on préfère
+    // 30 lignes recopiées à un global. Utilise la modale partagée
+    // #tax-confirm-modal déclarée dans taxonomy.html.
+    function showConfirm({title, body, confirmLabel, cancelLabel, variant}) {
+        return new Promise((resolve) => {
+            const modal = document.getElementById('tax-confirm-modal');
+            const okBtn = document.getElementById('tax-confirm-ok');
+            const cancelBtn = document.getElementById('tax-confirm-cancel');
+            if (!modal || !okBtn || !cancelBtn) {
+                resolve(window.confirm((title || '') + '\n\n' + (body || '')));
+                return;
+            }
+            document.getElementById('tax-confirm-title').textContent = title || 'Confirmer ?';
+            document.getElementById('tax-confirm-body').textContent = body || '';
+            okBtn.textContent = confirmLabel || 'Confirmer';
+            cancelBtn.textContent = cancelLabel || 'Annuler';
+            okBtn.className = (variant === 'danger') ? 'btn-danger' : 'btn-primary';
+            modal.style.display = 'flex';
+
+            function cleanup(result) {
+                modal.style.display = 'none';
+                okBtn.onclick = null;
+                cancelBtn.onclick = null;
+                document.removeEventListener('keydown', onKey);
+                resolve(result);
+            }
+            function onKey(e) {
+                if (e.key === 'Escape') { e.preventDefault(); cleanup(false); }
+                if (e.key === 'Enter')  { e.preventDefault(); cleanup(true); }
+            }
+            okBtn.onclick = () => cleanup(true);
+            cancelBtn.onclick = () => cleanup(false);
+            document.addEventListener('keydown', onKey);
+            setTimeout(() => okBtn.focus(), 50);
+        });
     }
 
     startBtn.addEventListener('click', startBuild);

--- a/dashboard/templates/partials/tax_dedupli_panel.html
+++ b/dashboard/templates/partials/tax_dedupli_panel.html
@@ -9,6 +9,9 @@
         <button id="tax-dedupli-start" class="btn-primary tax-dedupli-launch">
             🚀 Lancer la dédupli
         </button>
+        <button id="tax-dedupli-cancel" class="btn-danger tax-dedupli-launch" style="display:none;">
+            🛑 Annuler
+        </button>
         <label class="filter-label" for="tax-dedupli-threshold">Threshold</label>
         <input type="number" id="tax-dedupli-threshold" class="filter-select"
                value="92" min="50" max="100" style="width:64px;">
@@ -212,6 +215,7 @@
 <script>
 (function() {
     const startBtn = document.getElementById('tax-dedupli-start');
+    const cancelBtn = document.getElementById('tax-dedupli-cancel');
     const thresholdInput = document.getElementById('tax-dedupli-threshold');
     const statusEl = document.getElementById('tax-dedupli-status');
     const progressEl = document.getElementById('tax-dedupli-progress');
@@ -299,16 +303,43 @@
         }
     }
 
+    function setButtons(running, cancelling) {
+        // En cours et pas encore en cancellation → Annuler dispo
+        if (running && !cancelling) {
+            startBtn.style.display = 'none';
+            cancelBtn.style.display = '';
+            cancelBtn.disabled = false;
+        } else if (running && cancelling) {
+            startBtn.style.display = 'none';
+            cancelBtn.style.display = '';
+            cancelBtn.disabled = true;
+            cancelBtn.textContent = '⌛ Annulation…';
+        } else {
+            // Idle / done / error / cancelled
+            startBtn.style.display = '';
+            cancelBtn.style.display = 'none';
+            cancelBtn.disabled = false;
+            cancelBtn.textContent = '🛑 Annuler';
+        }
+    }
+
     function renderStatus(s) {
         if (s.status === 'idle') {
             setStatus('État : non lancé');
             hideProgress();
+            setButtons(false, false);
             return;
         }
         if (s.status === 'running' || s.status === 'pending') {
             const p = s.progress || {};
             showProgress(s.phase || 'running', p.done || 0, p.total || 0);
-            setStatus(`En cours — phase: ${s.phase || '…'}`);
+            const cancelling = !!s.cancel_requested;
+            setStatus(
+                cancelling
+                    ? 'Annulation en cours… (les appels LLM en vol terminent puis on stoppe)'
+                    : `En cours — phase: ${s.phase || '…'}`
+            );
+            setButtons(true, cancelling);
             return;
         }
         if (s.status === 'done') {
@@ -321,11 +352,20 @@
                 `✓ Terminé — ${cs.raw_count || 0} → ${cs.canonical_count || 0} `
               + `(${reduction}% réduction · ${cs.n_clusters || 0} clusters)`
             );
+            setButtons(false, false);
+            return;
+        }
+        if (s.status === 'cancelled') {
+            hideProgress();
+            const p = s.progress || {};
+            setStatus(`⏹ Annulé — ${p.done || 0} / ${p.total || 0} clusters traités avant arrêt`);
+            setButtons(false, false);
             return;
         }
         if (s.status === 'error') {
             hideProgress();
             setStatus('❌ Erreur : ' + (s.error || 'unknown'));
+            setButtons(false, false);
             return;
         }
     }
@@ -480,7 +520,31 @@
             .replace(/'/g, '&#39;');
     }
 
+    async function cancelBuild() {
+        const profile = currentProfile();
+        cancelBtn.disabled = true;
+        try {
+            const r = await fetch('/api/taxonomy/dedupli/cancel', {
+                method: 'POST',
+                headers: {'Content-Type': 'application/json'},
+                body: JSON.stringify({profile}),
+            });
+            if (!r.ok) {
+                const err = await r.json().catch(() => ({}));
+                alert('Erreur : ' + (err.error || r.status));
+                cancelBtn.disabled = false;
+                return;
+            }
+            // Le polling rafraîchira l'état → "Annulation en cours…"
+            pollStatus();
+        } catch (e) {
+            alert('Erreur réseau : ' + e.message);
+            cancelBtn.disabled = false;
+        }
+    }
+
     startBtn.addEventListener('click', startBuild);
+    cancelBtn.addEventListener('click', cancelBuild);
 
     // Activation : exposé pour activateSubtab() dans taxonomy_rename.js
     window.taxDedupliPanel = {

--- a/dashboard/templates/partials/tax_dedupli_panel.html
+++ b/dashboard/templates/partials/tax_dedupli_panel.html
@@ -1,0 +1,501 @@
+{# Partial : onglet Dédupli des thèmes LLM (Phase 5 du chantier dédupli).
+   - Bouton "🚀 Lancer la dédupli" → POST /api/taxonomy/dedupli/build
+   - Polling status pendant le run
+   - Liste des clusters proposés (gauche) + détail éditable (droite)
+   - Édition : renommer canonical, déplacer membres entre members/splits #}
+
+<div class="tax-dedupli-panel">
+    <div class="tax-dedupli-header">
+        <button id="tax-dedupli-start" class="btn-primary tax-dedupli-launch">
+            🚀 Lancer la dédupli
+        </button>
+        <label class="filter-label" for="tax-dedupli-threshold">Threshold</label>
+        <input type="number" id="tax-dedupli-threshold" class="filter-select"
+               value="92" min="50" max="100" style="width:64px;">
+        <div id="tax-dedupli-status" class="tax-dedupli-status">État : non lancé</div>
+    </div>
+
+    <div class="tax-dedupli-progress" id="tax-dedupli-progress" style="display:none;">
+        <div class="tax-dedupli-progress-label">
+            <span id="tax-dedupli-phase">…</span>
+            <span id="tax-dedupli-progress-text"></span>
+        </div>
+        <div class="tax-dedupli-progress-bar">
+            <div class="tax-dedupli-progress-fill" id="tax-dedupli-progress-fill"></div>
+        </div>
+    </div>
+
+    <div class="tax-dedupli-body">
+        <div class="tax-dedupli-clusters" id="tax-dedupli-clusters">
+            <p class="muted small">Aucun build encore. Lance la dédupli ↑.</p>
+        </div>
+        <div class="tax-dedupli-detail" id="tax-dedupli-detail">
+            <p class="muted small">Sélectionne un cluster à gauche pour l'éditer.</p>
+        </div>
+    </div>
+</div>
+
+<style>
+.tax-dedupli-panel {
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+    padding: 12px;
+    height: calc(100vh - 180px);
+    min-height: 480px;
+}
+.tax-dedupli-header {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    flex-wrap: wrap;
+}
+.tax-dedupli-launch {
+    padding: 8px 16px;
+    font-weight: 600;
+}
+.tax-dedupli-status {
+    font-size: 12.5px;
+    color: var(--text-muted);
+    margin-left: 8px;
+    flex: 1;
+}
+.tax-dedupli-progress {
+    padding: 8px 12px;
+    border: 1px solid var(--border);
+    border-radius: 6px;
+    background: var(--bg-secondary);
+}
+.tax-dedupli-progress-label {
+    display: flex;
+    justify-content: space-between;
+    font-size: 12px;
+    color: var(--text-muted);
+    margin-bottom: 6px;
+}
+.tax-dedupli-progress-bar {
+    height: 6px;
+    background: rgba(255, 255, 255, 0.05);
+    border-radius: 3px;
+    overflow: hidden;
+}
+.tax-dedupli-progress-fill {
+    height: 100%;
+    background: linear-gradient(90deg, #4f6ef2, #8b5cf6);
+    transition: width 0.3s ease;
+    width: 0%;
+}
+.tax-dedupli-body {
+    display: grid;
+    grid-template-columns: minmax(280px, 1fr) minmax(380px, 1.4fr);
+    gap: 14px;
+    flex: 1;
+    min-height: 0;
+}
+.tax-dedupli-clusters {
+    border: 1px solid var(--border);
+    border-radius: 6px;
+    overflow-y: auto;
+    padding: 8px;
+    background: var(--bg-secondary);
+}
+.tax-dedupli-detail {
+    border: 1px solid var(--border);
+    border-radius: 6px;
+    overflow-y: auto;
+    padding: 16px;
+    background: var(--bg-secondary);
+}
+.tax-dedupli-cluster-item {
+    padding: 10px 12px;
+    margin-bottom: 6px;
+    border: 1px solid var(--border);
+    border-radius: 5px;
+    cursor: pointer;
+    background: var(--bg-primary);
+    transition: background 0.12s, border-color 0.12s;
+}
+.tax-dedupli-cluster-item:hover {
+    background: var(--bg-tertiary, rgba(255, 255, 255, 0.04));
+    border-color: var(--border-light, #3a3a3a);
+}
+.tax-dedupli-cluster-item.active {
+    border-color: rgba(79, 110, 242, 0.5);
+    background: rgba(79, 110, 242, 0.07);
+}
+.tax-dedupli-cluster-canon {
+    font-weight: 600;
+    font-size: 13px;
+    color: var(--text-primary, #e6e6e6);
+    margin-bottom: 4px;
+}
+.tax-dedupli-cluster-meta {
+    display: flex;
+    gap: 10px;
+    font-size: 11.5px;
+    color: var(--text-muted);
+    align-items: center;
+}
+.tax-dedupli-badge {
+    padding: 1px 6px;
+    border-radius: 3px;
+    font-size: 10.5px;
+    font-weight: 600;
+}
+.tax-dedupli-badge-members {
+    background: rgba(34, 197, 94, 0.18);
+    color: #4ade80;
+}
+.tax-dedupli-badge-splits {
+    background: rgba(249, 115, 22, 0.18);
+    color: #fb923c;
+}
+.tax-dedupli-detail h3 {
+    margin: 0 0 12px;
+    font-size: 14px;
+}
+.tax-dedupli-detail-canon {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+    margin-bottom: 16px;
+}
+.tax-dedupli-detail-canon input {
+    padding: 6px 10px;
+    background: var(--bg-tertiary, #1a1a1a);
+    border: 1px solid var(--border);
+    border-radius: 4px;
+    color: var(--text-primary, #e6e6e6);
+    font-size: 13px;
+}
+.tax-dedupli-detail-list {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+    margin-bottom: 16px;
+}
+.tax-dedupli-detail-list-title {
+    font-size: 11.5px;
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+    color: var(--text-muted);
+    margin-bottom: 4px;
+}
+.tax-dedupli-variant {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: 4px 8px;
+    border-radius: 4px;
+    background: var(--bg-primary);
+    font-size: 12.5px;
+}
+.tax-dedupli-variant input[type="checkbox"] {
+    flex-shrink: 0;
+}
+.tax-dedupli-variant-name {
+    flex: 1;
+    word-break: break-word;
+}
+.tax-dedupli-variant-reason {
+    font-size: 11px;
+    color: var(--text-muted);
+    font-style: italic;
+}
+.tax-dedupli-detail-actions {
+    display: flex;
+    gap: 8px;
+    margin-top: 12px;
+}
+</style>
+
+<script>
+(function() {
+    const startBtn = document.getElementById('tax-dedupli-start');
+    const thresholdInput = document.getElementById('tax-dedupli-threshold');
+    const statusEl = document.getElementById('tax-dedupli-status');
+    const progressEl = document.getElementById('tax-dedupli-progress');
+    const progressPhase = document.getElementById('tax-dedupli-phase');
+    const progressText = document.getElementById('tax-dedupli-progress-text');
+    const progressFill = document.getElementById('tax-dedupli-progress-fill');
+    const clustersEl = document.getElementById('tax-dedupli-clusters');
+    const detailEl = document.getElementById('tax-dedupli-detail');
+
+    let pollTimer = null;
+    let currentCluster = null;  // {raw_members, canonical, members, splits}
+
+    function currentProfile() {
+        const sel = document.getElementById('tax-profile-select');
+        return sel ? sel.value : 'default';
+    }
+
+    function setStatus(text) {
+        statusEl.textContent = text;
+    }
+
+    function showProgress(phase, done, total) {
+        progressEl.style.display = '';
+        progressPhase.textContent = phase || '…';
+        if (total > 0) {
+            const pct = Math.round((done / total) * 100);
+            progressText.textContent = `${done} / ${total} (${pct}%)`;
+            progressFill.style.width = pct + '%';
+        } else {
+            progressText.textContent = '';
+            progressFill.style.width = '0%';
+        }
+    }
+
+    function hideProgress() {
+        progressEl.style.display = 'none';
+    }
+
+    async function startBuild() {
+        const profile = currentProfile();
+        const threshold = parseInt(thresholdInput.value, 10) || 92;
+        startBtn.disabled = true;
+        setStatus('Démarrage…');
+        try {
+            const r = await fetch('/api/taxonomy/dedupli/build', {
+                method: 'POST',
+                headers: {'Content-Type': 'application/json'},
+                body: JSON.stringify({profile, threshold}),
+            });
+            if (!r.ok) {
+                const err = await r.json().catch(() => ({}));
+                setStatus('Erreur : ' + (err.error || r.status));
+                startBtn.disabled = false;
+                return;
+            }
+            setStatus('En cours…');
+            // Polling toutes les 2s
+            if (pollTimer) clearInterval(pollTimer);
+            pollTimer = setInterval(pollStatus, 2000);
+            pollStatus();
+        } catch (e) {
+            setStatus('Erreur réseau : ' + e.message);
+            startBtn.disabled = false;
+        }
+    }
+
+    async function pollStatus() {
+        const profile = currentProfile();
+        try {
+            const r = await fetch(
+                '/api/taxonomy/dedupli/status?profile=' + encodeURIComponent(profile)
+            );
+            if (!r.ok) return;
+            const s = await r.json();
+            renderStatus(s);
+            if (s.status === 'done' || s.status === 'error') {
+                if (pollTimer) { clearInterval(pollTimer); pollTimer = null; }
+                startBtn.disabled = false;
+                if (s.status === 'done') {
+                    loadClusters();
+                }
+            }
+        } catch (e) {
+            // tolère les hiccups réseau
+        }
+    }
+
+    function renderStatus(s) {
+        if (s.status === 'idle') {
+            setStatus('État : non lancé');
+            hideProgress();
+            return;
+        }
+        if (s.status === 'running' || s.status === 'pending') {
+            const p = s.progress || {};
+            showProgress(s.phase || 'running', p.done || 0, p.total || 0);
+            setStatus(`En cours — phase: ${s.phase || '…'}`);
+            return;
+        }
+        if (s.status === 'done') {
+            hideProgress();
+            const cs = s.canon_summary || {};
+            const reduction = cs.raw_count && cs.canonical_count
+                ? Math.round((1 - cs.canonical_count / cs.raw_count) * 100)
+                : 0;
+            setStatus(
+                `✓ Terminé — ${cs.raw_count || 0} → ${cs.canonical_count || 0} `
+              + `(${reduction}% réduction · ${cs.n_clusters || 0} clusters)`
+            );
+            return;
+        }
+        if (s.status === 'error') {
+            hideProgress();
+            setStatus('❌ Erreur : ' + (s.error || 'unknown'));
+            return;
+        }
+    }
+
+    async function loadClusters() {
+        const profile = currentProfile();
+        try {
+            const r = await fetch(
+                '/api/taxonomy/dedupli/clusters?profile=' + encodeURIComponent(profile)
+            );
+            if (!r.ok) throw new Error('HTTP ' + r.status);
+            const data = await r.json();
+            renderClusters(data.clusters || []);
+        } catch (e) {
+            clustersEl.innerHTML = '<p class="muted small">Erreur : ' + e.message + '</p>';
+        }
+    }
+
+    function renderClusters(clusters) {
+        if (!clusters.length) {
+            clustersEl.innerHTML = '<p class="muted small">Aucun cluster multi-variante.</p>';
+            return;
+        }
+        clustersEl.innerHTML = '';
+        for (const c of clusters) {
+            const item = document.createElement('div');
+            item.className = 'tax-dedupli-cluster-item';
+            const nMembers = (c.members || []).length;
+            const nSplits = (c.splits || []).length;
+            item.innerHTML =
+                '<div class="tax-dedupli-cluster-canon">' + escapeHtml(c.canonical || '?') + '</div>'
+              + '<div class="tax-dedupli-cluster-meta">'
+              + '  <span class="tax-dedupli-badge tax-dedupli-badge-members">' + nMembers + ' members</span>'
+              + (nSplits > 0
+                    ? '  <span class="tax-dedupli-badge tax-dedupli-badge-splits">' + nSplits + ' splits</span>'
+                    : '')
+              + '  <span>' + (c.count_cumulative || 0) + ' fichiers</span>'
+              + '</div>';
+            item.addEventListener('click', () => {
+                clustersEl.querySelectorAll('.tax-dedupli-cluster-item.active')
+                         .forEach(el => el.classList.remove('active'));
+                item.classList.add('active');
+                renderDetail(c);
+            });
+            clustersEl.appendChild(item);
+        }
+    }
+
+    function renderDetail(cluster) {
+        currentCluster = JSON.parse(JSON.stringify(cluster));  // deep clone
+        const raw = currentCluster.raw_members || [];
+        const memberSet = new Set(currentCluster.members || []);
+        const splitMap = new Map(
+            (currentCluster.splits || []).map(s => [s.theme, s.reason || ''])
+        );
+
+        const html = [
+            '<h3>Détail du cluster</h3>',
+            '<div class="tax-dedupli-detail-canon">',
+            '  <span class="tax-dedupli-detail-list-title">Canonical</span>',
+            '  <input type="text" id="tax-dedupli-edit-canon" value="'
+                + escapeHtml(currentCluster.canonical || '') + '">',
+            '</div>',
+            '<div class="tax-dedupli-detail-list">',
+            '  <div class="tax-dedupli-detail-list-title">Variantes (' + raw.length + ')</div>',
+            '  <p class="muted small" style="margin:0 0 6px;">'
+            + 'Coche pour fusionner vers le canonical (members). Décoche = split (sous-domaine).'
+            + '</p>',
+        ];
+        for (const variant of raw) {
+            const isMember = memberSet.has(variant);
+            const reason = splitMap.get(variant) || '';
+            html.push(
+                '<label class="tax-dedupli-variant">'
+              + '  <input type="checkbox" data-variant="' + escapeHtml(variant) + '"'
+              + (isMember ? ' checked' : '') + '>'
+              + '  <span class="tax-dedupli-variant-name">' + escapeHtml(variant) + '</span>'
+              + (reason ? '<span class="tax-dedupli-variant-reason">' + escapeHtml(reason) + '</span>' : '')
+              + '</label>'
+            );
+        }
+        html.push('</div>');
+        html.push(
+            '<div class="tax-dedupli-detail-actions">',
+            '  <button id="tax-dedupli-save" class="btn-primary">💾 Sauvegarder</button>',
+            '  <button id="tax-dedupli-cancel" class="btn-secondary">Annuler</button>',
+            '</div>',
+        );
+        detailEl.innerHTML = html.join('\n');
+        document.getElementById('tax-dedupli-save').addEventListener('click', saveCluster);
+        document.getElementById('tax-dedupli-cancel').addEventListener('click', () => {
+            renderDetail(cluster);
+        });
+    }
+
+    async function saveCluster() {
+        if (!currentCluster) return;
+        const newCanon = document.getElementById('tax-dedupli-edit-canon').value.trim();
+        if (!newCanon) {
+            alert('Le canonical ne peut pas être vide.');
+            return;
+        }
+        const raw = currentCluster.raw_members || [];
+        const checkboxes = detailEl.querySelectorAll('input[type="checkbox"][data-variant]');
+        const newMembers = [];
+        const newSplits = [];
+        const splitMap = new Map(
+            (currentCluster.splits || []).map(s => [s.theme, s.reason || ''])
+        );
+        for (const cb of checkboxes) {
+            const v = cb.dataset.variant;
+            if (cb.checked) {
+                newMembers.push(v);
+            } else {
+                newSplits.push({theme: v, reason: splitMap.get(v) || 'séparé manuellement'});
+            }
+        }
+        const profile = currentProfile();
+        try {
+            const r = await fetch('/api/taxonomy/dedupli/cluster', {
+                method: 'PUT',
+                headers: {'Content-Type': 'application/json'},
+                body: JSON.stringify({
+                    profile,
+                    raw_members: raw,
+                    canonical: newCanon,
+                    members: newMembers,
+                    splits: newSplits,
+                }),
+            });
+            if (!r.ok) {
+                const err = await r.json().catch(() => ({}));
+                alert('Erreur : ' + (err.error || r.status));
+                return;
+            }
+            // Refresh la liste pour refléter la mise à jour
+            loadClusters();
+            // Garde le focus sur ce cluster
+            const updated = await r.json();
+            renderDetail(updated.cluster);
+        } catch (e) {
+            alert('Erreur réseau : ' + e.message);
+        }
+    }
+
+    function escapeHtml(s) {
+        return String(s)
+            .replace(/&/g, '&amp;')
+            .replace(/</g, '&lt;')
+            .replace(/>/g, '&gt;')
+            .replace(/"/g, '&quot;')
+            .replace(/'/g, '&#39;');
+    }
+
+    startBtn.addEventListener('click', startBuild);
+
+    // Activation : exposé pour activateSubtab() dans taxonomy_rename.js
+    window.taxDedupliPanel = {
+        activate: () => {
+            pollStatus();
+            loadClusters();
+        },
+        refresh: () => {
+            pollStatus();
+            loadClusters();
+        },
+    };
+
+    // Au load initial, peuple si du canon existe déjà
+    pollStatus();
+    loadClusters();
+})();
+</script>

--- a/dashboard/templates/partials/tax_dedupli_panel.html
+++ b/dashboard/templates/partials/tax_dedupli_panel.html
@@ -12,9 +12,16 @@
         <button id="tax-dedupli-cancel" class="btn-danger tax-dedupli-launch" style="display:none;">
             🛑 Annuler
         </button>
+        <label class="filter-label" for="tax-dedupli-mode">Mode</label>
+        <select id="tax-dedupli-mode" class="filter-select"
+                title="Syntactique = variantes ortho seules. Sémantique = synonymes via vocabulaire LLM.">
+            <option value="syntactic">Syntactique</option>
+            <option value="semantic" selected>Sémantique (C-light)</option>
+        </select>
         <label class="filter-label" for="tax-dedupli-threshold">Threshold</label>
         <input type="number" id="tax-dedupli-threshold" class="filter-select"
-               value="92" min="50" max="100" style="width:64px;">
+               value="92" min="50" max="100" style="width:64px;"
+               title="Seuil fuzzy pour le re-clustering final (90-95 recommandé).">
         <div id="tax-dedupli-status" class="tax-dedupli-status">État : non lancé</div>
     </div>
 
@@ -217,6 +224,7 @@
     const startBtn = document.getElementById('tax-dedupli-start');
     const cancelBtn = document.getElementById('tax-dedupli-cancel');
     const thresholdInput = document.getElementById('tax-dedupli-threshold');
+    const modeSelect = document.getElementById('tax-dedupli-mode');
     const statusEl = document.getElementById('tax-dedupli-status');
     const progressEl = document.getElementById('tax-dedupli-progress');
     const progressPhase = document.getElementById('tax-dedupli-phase');
@@ -257,13 +265,14 @@
     async function startBuild() {
         const profile = currentProfile();
         const threshold = parseInt(thresholdInput.value, 10) || 92;
+        const mode = modeSelect ? modeSelect.value : 'syntactic';
         startBtn.disabled = true;
         setStatus('Démarrage…');
         try {
             const r = await fetch('/api/taxonomy/dedupli/build', {
                 method: 'POST',
                 headers: {'Content-Type': 'application/json'},
-                body: JSON.stringify({profile, threshold}),
+                body: JSON.stringify({profile, threshold, mode}),
             });
             if (!r.ok) {
                 const err = await r.json().catch(() => ({}));
@@ -321,6 +330,9 @@
             cancelBtn.disabled = false;
             cancelBtn.textContent = '🛑 Annuler';
         }
+        // Mode + threshold figés pendant un run
+        if (modeSelect) modeSelect.disabled = running;
+        thresholdInput.disabled = running;
     }
 
     function renderStatus(s) {
@@ -348,8 +360,9 @@
             const reduction = cs.raw_count && cs.canonical_count
                 ? Math.round((1 - cs.canonical_count / cs.raw_count) * 100)
                 : 0;
+            const modeLabel = cs.mode === 'semantic' ? 'Sémantique' : 'Syntactique';
             setStatus(
-                `✓ Terminé — ${cs.raw_count || 0} → ${cs.canonical_count || 0} `
+                `✓ Terminé (${modeLabel}) — ${cs.raw_count || 0} → ${cs.canonical_count || 0} `
               + `(${reduction}% réduction · ${cs.n_clusters || 0} clusters)`
             );
             setButtons(false, false);

--- a/dashboard/templates/taxonomy.html
+++ b/dashboard/templates/taxonomy.html
@@ -17,6 +17,8 @@
                     title="Audit + renommage des fichiers basé sur le titre LLM">Rename</button>
             <button class="tax-subtab" data-view="refonte"
                     title="Agent IA — diagnostic de la taxonomie (lecture seule)">&#129302; Refonte</button>
+            <button class="tax-subtab" data-view="dedupli"
+                    title="Dédupli des thèmes LLM (consolide variantes orthographiques + synonymes)">&#128279; Dédupli</button>
         </div>
         <div class="tax-toolbar">
             <label class="filter-label">Profil</label>
@@ -393,6 +395,12 @@
     {% include "partials/agent_refonte_panel.html" %}
 </div>
 <!-- ────────────────────── End view: Refonte ──────────────────────────────── -->
+
+<!-- ─────────────────────── View: Dédupli ─────────────────────── -->
+<div class="tax-view tax-view-dedupli" data-view="dedupli" style="display:none;">
+    {% include "partials/tax_dedupli_panel.html" %}
+</div>
+<!-- ────────────────────── End view: Dédupli ──────────────────────────────── -->
 
 <!-- 📜 Rename history modal (PR4A) -->
 <div id="tax-rename-history-modal" class="tax-modal-backdrop"

--- a/lib/theme_canon.py
+++ b/lib/theme_canon.py
@@ -217,8 +217,10 @@ def build_canon_table(
         enrichis pour l'UI). Écrite sur disque dans
         `profiles/<p>/.cache/theme-canon.json`.
     """
-    if mode not in ("syntactic", "semantic"):
-        raise ValueError(f"mode must be 'syntactic' or 'semantic', got {mode!r}")
+    if mode not in ("syntactic", "semantic", "source"):
+        raise ValueError(
+            f"mode must be 'syntactic', 'semantic' or 'source', got {mode!r}"
+        )
 
     if on_progress:
         on_progress(0, 0, "extracting")
@@ -241,6 +243,15 @@ def build_canon_table(
 
     if mode == "semantic":
         return _build_canon_table_semantic(
+            profile, llm, themes,
+            threshold=threshold,
+            use_cache=use_judge_cache,
+            vocabulary_top_n=vocabulary_top_n,
+            on_progress=on_progress,
+        )
+
+    if mode == "source":
+        return _build_canon_table_source(
             profile, llm, themes,
             threshold=threshold,
             use_cache=use_judge_cache,
@@ -406,6 +417,129 @@ def _build_canon_table_semantic(
         "clusters": clusters_serialized,
         "mapping": final_mapping,
         "mode": "semantic",
+    }
+    save_canon_table(profile, table)
+    return table
+
+
+def _build_canon_table_source(
+    profile: str,
+    llm: BaseChatModel,
+    themes: dict[str, int],
+    *,
+    threshold: int,
+    use_cache: bool,
+    vocabulary_top_n: int,
+    on_progress: ProgressCallback | None,
+) -> dict[str, Any]:
+    """Pipeline du mode "source" (C.2 — canonisation contextuelle).
+
+    Différence avec semantic (C-light) :
+      - C-light : (raw_theme seul) → LLM décide à l'aveugle
+      - C.2     : (raw_theme + 5 titres représentatifs) → LLM voit le contexte
+
+    Étapes :
+      1. extract_themes_with_titles : pour chaque raw_theme, collecte les
+         5 titres représentatifs depuis vision_cache.json
+      2. build_vocabulary : top-N par fréquence (vocabulary de référence)
+      3. resolve_themes_with_context : LLM produit {raw: canonical} avec
+         les titres comme contexte de désambiguïsation, parallélisé
+      4. Re-clustering du résultat via cluster_themes pour gommer les
+         doublons résiduels (canoniques quasi-identiques entre batches)
+      5. Assemblage final
+    """
+    from lib.theme_canonicalizer import build_vocabulary
+    from lib.theme_resolver import (
+        extract_themes_with_titles,
+        resolve_themes_with_context,
+    )
+
+    if on_progress:
+        on_progress(0, 0, "extracting")
+    themes_titles = extract_themes_with_titles(profile)
+
+    vocabulary = build_vocabulary(themes, top_n=vocabulary_top_n)
+
+    if on_progress:
+        on_progress(0, 0, "resolving")
+
+    def _resolver_progress(done: int, total: int) -> None:
+        if on_progress:
+            on_progress(done, total, "resolving")
+
+    raw_to_canon = resolve_themes_with_context(
+        themes_titles,
+        vocabulary,
+        llm,
+        profile,
+        use_cache=use_cache,
+        on_progress=_resolver_progress,
+    )
+
+    if on_progress:
+        on_progress(0, 0, "reclustering")
+
+    # Re-clustering des canoniques pour gommer les doublons résiduels
+    unique_canons = sorted(set(raw_to_canon.values()))
+    canon_clusters = cluster_themes(unique_canons, threshold=threshold)
+
+    canon_to_final: dict[str, str] = {}
+    for cluster in canon_clusters:
+        members = cluster.get("raw_members", [])
+        if not members:
+            continue
+        final = max(members, key=len)
+        for m in members:
+            canon_to_final[m] = final
+
+    final_mapping: dict[str, str] = {
+        raw: canon_to_final.get(canon, canon)
+        for raw, canon in raw_to_canon.items()
+    }
+
+    grouped: dict[str, list[str]] = {}
+    for raw, final in final_mapping.items():
+        grouped.setdefault(final, []).append(raw)
+
+    clusters_serialized = []
+    for canonical, raw_members in grouped.items():
+        count_cumulative = sum(themes.get(m, 0) for m in raw_members)
+        # Pour la vue UI : sample des titres représentatifs du canonical
+        # (concaténation des titres de ses raw_members, limitée à 5)
+        sample_titles: list[str] = []
+        seen_titles: set[str] = set()
+        for member in raw_members:
+            for title in themes_titles.get(member, []):
+                if title in seen_titles or len(sample_titles) >= 5:
+                    continue
+                seen_titles.add(title)
+                sample_titles.append(title)
+            if len(sample_titles) >= 5:
+                break
+        clusters_serialized.append({
+            "canonical": canonical,
+            "members": list(raw_members),
+            "splits": [],
+            "raw_members": list(raw_members),
+            "count_cumulative": count_cumulative,
+            "sample_titles": sample_titles,
+        })
+    clusters_serialized.sort(key=lambda c: -c["count_cumulative"])
+
+    if on_progress:
+        on_progress(len(themes), len(themes), "done")
+
+    table = {
+        "version": CANON_VERSION,
+        "built_at": _now_iso(),
+        "raw_count": len(final_mapping),
+        "canonical_count": len(set(final_mapping.values())),
+        "threshold": threshold,
+        "vocabulary_top_n": vocabulary_top_n,
+        "vocabulary_size": len(vocabulary),
+        "clusters": clusters_serialized,
+        "mapping": final_mapping,
+        "mode": "source",
     }
     save_canon_table(profile, table)
     return table

--- a/lib/theme_canon.py
+++ b/lib/theme_canon.py
@@ -1,0 +1,279 @@
+"""Pipeline complet de dédupli des thèmes — orchestre Phases 1+2+3 et
+persiste le résultat dans `profiles/<p>/.cache/theme-canon.json`.
+
+Ce module est le point d'entrée du chantier dédupli :
+  - `extract_themes_from_vision_cache(profile)` — extrait {raw: count}
+  - `build_canon_table(profile, llm)` — pipeline end-to-end + persistance
+  - `load_canon_table(profile)` — lecture du mapping pour le branchement
+    dans `dashboard.taxonomy._aggregate_themes_llm`
+  - `canonicalize(theme, canon_table)` — résout 1 raw_theme → canonical
+
+Le fichier `theme-canon.json` produit est consommé en runtime par
+l'aggregator des thèmes : chaque raw_theme est résolu vers son canonical
+avant cumul des counts. Le branchement est opt-in via la présence du
+fichier — pas de feature flag YAML, pas de breaking change.
+
+Format du fichier :
+```json
+{
+  "version": 1,
+  "built_at": "2026-05-27T...",
+  "raw_count": 15376,
+  "canonical_count": 12345,
+  "mapping": {
+    "Machine Learning": "Machine Learning",
+    "Machine learning": "Machine Learning",
+    "Web Application Development": "Web Application Development",
+    "Web application development": "Web Application Development",
+    "iOS Application Development": "iOS Application Development"
+  }
+}
+```
+"""
+
+from __future__ import annotations
+
+import ast
+import json
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+from langchain_core.language_models import BaseChatModel
+
+from lib.theme_judge import JudgeResult, judge_clusters
+from lib.theme_normalizer import cluster_themes
+
+CANON_VERSION = 1
+DEFAULT_CLUSTER_THRESHOLD = 92
+
+
+def _canon_path(profile: str) -> Path:
+    """Chemin du fichier de canonisation pour un profil."""
+    # Import local pour éviter une dépendance circulaire au import-time
+    from dashboard import data
+    return data.get_project_root() / "profiles" / profile / ".cache" / "theme-canon.json"
+
+
+def _vision_cache_path(profile: str) -> Path:
+    from dashboard import data
+    return data.get_project_root() / "profiles" / profile / ".cache" / "vision_cache.json"
+
+
+def _parse_cached_result(raw: Any) -> dict | None:
+    """Décode le champ `result` du vision_cache.
+
+    Historiquement stocké de plusieurs façons :
+      - dict natif (récent)
+      - str JSON
+      - str repr Python (`{'title': '...', ...}`) — legacy
+    """
+    if isinstance(raw, dict):
+        return raw
+    if not isinstance(raw, str):
+        return None
+    s = raw.strip()
+    if not s:
+        return None
+    try:
+        if s.startswith("{'"):
+            parsed = ast.literal_eval(s)
+        else:
+            parsed = json.loads(s)
+    except (ValueError, SyntaxError, json.JSONDecodeError):
+        return None
+    return parsed if isinstance(parsed, dict) else None
+
+
+def extract_themes_from_vision_cache(profile: str) -> dict[str, int]:
+    """Extrait {raw_theme: count} depuis vision_cache.json.
+
+    Pas de filtrage par confidence — la canonisation est indépendante
+    de la confiance (un thème avec faible confidence reste un thème
+    à dédupliquer). Le filtrage par confidence reste géré côté
+    `dashboard.taxonomy._aggregate_themes_llm`.
+
+    Returns:
+        Dict {raw_theme: count_occurrences}. Vide si pas de cache.
+    """
+    path = _vision_cache_path(profile)
+    if not path.exists():
+        return {}
+    try:
+        cache = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return {}
+
+    counts: dict[str, int] = {}
+    for entry in cache.values():
+        if not isinstance(entry, dict):
+            continue
+        result = _parse_cached_result(entry.get("result"))
+        if result is None:
+            continue
+        for t in result.get("themes", []) or []:
+            name = ""
+            if isinstance(t, dict):
+                name = str(t.get("theme") or "").strip()
+            elif isinstance(t, str):
+                name = t.strip()
+            if name:
+                counts[name] = counts.get(name, 0) + 1
+    return counts
+
+
+def assemble_canon_mapping(
+    clusters: list[dict],
+    judgments: list[JudgeResult],
+) -> dict[str, str]:
+    """Construit `{raw_theme: canonical}` à partir des décisions LLM.
+
+    Pour chaque cluster + sa décision :
+      - members (synonymes validés)  → canonical
+      - splits  (sous-domaines)      → eux-mêmes (identité)
+      - variantes non mentionnées dans members ni splits → eux-mêmes
+        (le LLM les a oubliées, on les préserve par défaut)
+
+    Pour les clusters singleton (1 variante) : identity mapping.
+    Pour les clusters auto-mergés : tous les raw_members → canonical
+    choisi par max(len), via le JudgeResult fabriqué dans
+    `judge_clusters` sans appel LLM.
+
+    Args:
+        clusters: Sortie de `cluster_themes()` — liste de dicts avec
+                  `raw_members`.
+        judgments: Liste de `JudgeResult`, même longueur et même ordre
+                   que `clusters`.
+
+    Returns:
+        Dict {raw_theme: canonical}.
+    """
+    if len(clusters) != len(judgments):
+        raise ValueError(
+            f"clusters ({len(clusters)}) et judgments ({len(judgments)}) "
+            "doivent avoir la même longueur"
+        )
+    mapping: dict[str, str] = {}
+    for cluster, judgment in zip(clusters, judgments, strict=True):
+        canonical = judgment.canonical
+        # Membres validés → canonical
+        member_set: set[str] = set()
+        for member in judgment.members:
+            mapping[member] = canonical
+            member_set.add(member)
+        # Splits → identité (le LLM a explicitement séparé)
+        split_set: set[str] = set()
+        for split in judgment.splits:
+            mapping[split.theme] = split.theme
+            split_set.add(split.theme)
+        # Filet de sécurité : si le LLM a oublié une variante (ni
+        # member ni split), on la préserve par défaut (identité). Ça
+        # garantit que toute variante du cluster a au moins une entrée
+        # dans le mapping.
+        for raw in cluster.get("raw_members", []):
+            if raw not in member_set and raw not in split_set:
+                mapping.setdefault(raw, raw)
+    return mapping
+
+
+def build_canon_table(
+    profile: str,
+    llm: BaseChatModel,
+    *,
+    threshold: int = DEFAULT_CLUSTER_THRESHOLD,
+    use_judge_cache: bool = True,
+) -> dict[str, Any]:
+    """Pipeline end-to-end : extraction → clustering → LLM judge → persistance.
+
+    Args:
+        profile: Nom du profil.
+        llm: ChatOpenAI configuré (typiquement get_agent_llm()).
+        threshold: Seuil de similarité Phase 2 (défaut 92).
+        use_judge_cache: Réutilise les décisions LLM persistées dans
+                         theme-judge.json (défaut True).
+
+    Returns:
+        La table de canonisation complète (incluant métadonnées). Écrite
+        sur disque dans `profiles/<p>/.cache/theme-canon.json`.
+    """
+    themes = extract_themes_from_vision_cache(profile)
+    if not themes:
+        # Profil sans vision_cache → table vide mais quand même persistée
+        table = {
+            "version": CANON_VERSION,
+            "built_at": _now_iso(),
+            "raw_count": 0,
+            "canonical_count": 0,
+            "mapping": {},
+        }
+        save_canon_table(profile, table)
+        return table
+
+    clusters = cluster_themes(themes.keys(), threshold=threshold)
+    cluster_lists = [c["raw_members"] for c in clusters]
+    judgments = judge_clusters(
+        cluster_lists, profile, llm, use_cache=use_judge_cache,
+    )
+    mapping = assemble_canon_mapping(clusters, judgments)
+
+    table = {
+        "version": CANON_VERSION,
+        "built_at": _now_iso(),
+        "raw_count": len(mapping),
+        "canonical_count": len(set(mapping.values())),
+        "threshold": threshold,
+        "mapping": mapping,
+    }
+    save_canon_table(profile, table)
+    return table
+
+
+def _now_iso() -> str:
+    return datetime.now(UTC).isoformat()
+
+
+def load_canon_table(profile: str) -> dict[str, str] | None:
+    """Charge le mapping `{raw: canonical}` pour un profil.
+
+    Returns:
+        Le mapping seul (pas les métadonnées). `None` si le fichier
+        n'existe pas ou est corrompu — dans ce cas l'appelant doit
+        fallback sur l'identité (pas de canonisation).
+    """
+    path = _canon_path(profile)
+    if not path.exists():
+        return None
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return None
+    if not isinstance(data, dict):
+        return None
+    mapping = data.get("mapping")
+    if not isinstance(mapping, dict):
+        return None
+    return mapping
+
+
+def save_canon_table(profile: str, table: dict[str, Any]) -> None:
+    """Persiste la table de canonisation sur disque (atomique)."""
+    path = _canon_path(profile)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = path.with_suffix(".tmp")
+    tmp.write_text(
+        json.dumps(table, ensure_ascii=False, indent=2),
+        encoding="utf-8",
+    )
+    tmp.replace(path)
+
+
+def canonicalize(theme: str, canon_table: dict[str, str] | None) -> str:
+    """Résout un raw_theme vers son canonical via la table de canonisation.
+
+    Fallback identity si la table est `None` ou si le thème n'y figure pas.
+    Cette fonction est appelée pour CHAQUE thème agrégé — doit rester
+    hot-path safe.
+    """
+    if not canon_table:
+        return theme
+    return canon_table.get(theme, theme)

--- a/lib/theme_canon.py
+++ b/lib/theme_canon.py
@@ -35,6 +35,7 @@ from __future__ import annotations
 
 import ast
 import json
+from collections.abc import Callable
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
@@ -44,8 +45,12 @@ from langchain_core.language_models import BaseChatModel
 from lib.theme_judge import JudgeResult, judge_clusters
 from lib.theme_normalizer import cluster_themes
 
-CANON_VERSION = 1
+CANON_VERSION = 2
 DEFAULT_CLUSTER_THRESHOLD = 92
+
+# Type alias : callback de progression invoqué après chaque cluster traité.
+# Signature : (clusters_done, clusters_total, phase) → None
+ProgressCallback = Callable[[int, int, str], None]
 
 
 def _canon_path(profile: str) -> Path:
@@ -182,6 +187,7 @@ def build_canon_table(
     *,
     threshold: int = DEFAULT_CLUSTER_THRESHOLD,
     use_judge_cache: bool = True,
+    on_progress: ProgressCallback | None = None,
 ) -> dict[str, Any]:
     """Pipeline end-to-end : extraction → clustering → LLM judge → persistance.
 
@@ -191,11 +197,17 @@ def build_canon_table(
         threshold: Seuil de similarité Phase 2 (défaut 92).
         use_judge_cache: Réutilise les décisions LLM persistées dans
                          theme-judge.json (défaut True).
+        on_progress: Callback `(done, total, phase)` invoqué pendant le run.
+                     Phases : 'extracting' → 'clustering' → 'judging' → 'done'.
+                     Utile pour persister status.json côté dashboard.
 
     Returns:
-        La table de canonisation complète (incluant métadonnées). Écrite
-        sur disque dans `profiles/<p>/.cache/theme-canon.json`.
+        La table de canonisation complète (incluant métadonnées et clusters
+        enrichis pour l'UI). Écrite sur disque dans
+        `profiles/<p>/.cache/theme-canon.json`.
     """
+    if on_progress:
+        on_progress(0, 0, "extracting")
     themes = extract_themes_from_vision_cache(profile)
     if not themes:
         # Profil sans vision_cache → table vide mais quand même persistée
@@ -205,16 +217,53 @@ def build_canon_table(
             "raw_count": 0,
             "canonical_count": 0,
             "mapping": {},
+            "clusters": [],
         }
         save_canon_table(profile, table)
+        if on_progress:
+            on_progress(0, 0, "done")
         return table
 
+    if on_progress:
+        on_progress(0, len(themes), "clustering")
     clusters = cluster_themes(themes.keys(), threshold=threshold)
     cluster_lists = [c["raw_members"] for c in clusters]
+    total_clusters = len(cluster_lists)
+    if on_progress:
+        on_progress(0, total_clusters, "judging")
+
+    # Adaptation du callback : judge_clusters fait (done, total), nous
+    # rajoutons la phase fixe "judging".
+    def _judge_progress(done: int, total: int) -> None:
+        if on_progress:
+            on_progress(done, total, "judging")
+
     judgments = judge_clusters(
-        cluster_lists, profile, llm, use_cache=use_judge_cache,
+        cluster_lists, profile, llm,
+        use_cache=use_judge_cache,
+        on_progress=_judge_progress,
     )
     mapping = assemble_canon_mapping(clusters, judgments)
+
+    # Pour l'UI : chaque cluster avec le canonical décidé + members + splits
+    # + count cumulé (somme des occurrences des raw_themes du cluster).
+    clusters_serialized = []
+    for cluster, judgment in zip(clusters, judgments, strict=True):
+        raw_members = cluster.get("raw_members", [])
+        count_cumulative = sum(themes.get(m, 0) for m in raw_members)
+        clusters_serialized.append({
+            "canonical": judgment.canonical,
+            "members": judgment.members,
+            "splits": [
+                {"theme": s.theme, "reason": s.reason}
+                for s in judgment.splits
+            ],
+            "raw_members": raw_members,
+            "count_cumulative": count_cumulative,
+        })
+
+    if on_progress:
+        on_progress(total_clusters, total_clusters, "done")
 
     table = {
         "version": CANON_VERSION,
@@ -222,6 +271,7 @@ def build_canon_table(
         "raw_count": len(mapping),
         "canonical_count": len(set(mapping.values())),
         "threshold": threshold,
+        "clusters": clusters_serialized,
         "mapping": mapping,
     }
     save_canon_table(profile, table)

--- a/lib/theme_canon.py
+++ b/lib/theme_canon.py
@@ -365,14 +365,22 @@ def _build_canon_table_semantic(
     unique_canons = sorted(set(raw_to_canon.values()))
     canon_clusters = cluster_themes(unique_canons, threshold=threshold)
 
-    # Construit canon_to_final : pour chaque canonical produit par le LLM,
-    # le représentant final de son cluster fuzzy (le plus long du cluster).
+    # Pour le choix du final canonical d'un cluster fuzzy : count cumulé MAX
+    # (le plus représentatif). Tie-break sur longueur décroissante (préfère
+    # le plus court à count égal), puis lexico pour déterminisme.
+    canon_to_count: dict[str, int] = {c: 0 for c in unique_canons}
+    for raw, canon in raw_to_canon.items():
+        canon_to_count[canon] = canon_to_count.get(canon, 0) + themes.get(raw, 0)
+
     canon_to_final: dict[str, str] = {}
     for cluster in canon_clusters:
         members = cluster.get("raw_members", [])
         if not members:
             continue
-        final = max(members, key=len)
+        final = max(
+            members,
+            key=lambda m: (canon_to_count.get(m, 0), -len(m), m),
+        )
         for m in members:
             canon_to_final[m] = final
 
@@ -483,12 +491,30 @@ def _build_canon_table_source(
     unique_canons = sorted(set(raw_to_canon.values()))
     canon_clusters = cluster_themes(unique_canons, threshold=threshold)
 
+    # Pour le choix du final canonical d'un cluster fuzzy : on prend la
+    # variante avec le plus grand count cumulé parmi les raw_themes qui
+    # pointaient vers elle. On évite ainsi de choisir "Web Application
+    # Development with C# and .NET" (un canonical hyper-spécifique apparu
+    # 1× dans un batch) comme représentant d'un cluster contenant
+    # "Web Development" qui est apparu 100 fois.
+    canon_to_count: dict[str, int] = {c: 0 for c in unique_canons}
+    for raw, canon in raw_to_canon.items():
+        canon_to_count[canon] = canon_to_count.get(canon, 0) + themes.get(raw, 0)
+
     canon_to_final: dict[str, str] = {}
     for cluster in canon_clusters:
         members = cluster.get("raw_members", [])
         if not members:
             continue
-        final = max(members, key=len)
+        # canonical = membre avec le count cumulé MAX (le plus représentatif).
+        # Tie-break sur la longueur DÉCROISSANTE (préfère le plus court à
+        # count égal, ex. "Mathematics" vs "Advanced Mathematics" choisit
+        # "Mathematics" en cas d'égalité). Tie final sur l'ordre lexico
+        # pour déterminisme.
+        final = max(
+            members,
+            key=lambda m: (canon_to_count.get(m, 0), -len(m), m),
+        )
         for m in members:
             canon_to_final[m] = final
 

--- a/lib/theme_canon.py
+++ b/lib/theme_canon.py
@@ -484,48 +484,21 @@ def _build_canon_table_source(
         on_progress=_resolver_progress,
     )
 
+    # En mode 'source', PAS de re-clustering fuzzy : le LLM a déjà tranché
+    # chaque thème avec le contexte des titres. Appliquer un cluster_themes
+    # fuzzy par-dessus fusionne des canoniques textuellement proches mais
+    # sémantiquement distincts (observé sur le run du 2026-05-30 :
+    # "C++ Programming" + "C# Programming" + "R Programming" mergés en 1
+    # cluster ; "Web Application Development" absorbe "iOS Application
+    # Development", "Cloud Application Development", etc.).
+    # La sortie LLM est notre source de vérité.
     if on_progress:
-        on_progress(0, 0, "reclustering")
+        on_progress(0, 0, "finalizing")
 
-    # Re-clustering des canoniques pour gommer les doublons résiduels
-    unique_canons = sorted(set(raw_to_canon.values()))
-    canon_clusters = cluster_themes(unique_canons, threshold=threshold)
-
-    # Pour le choix du final canonical d'un cluster fuzzy : on prend la
-    # variante avec le plus grand count cumulé parmi les raw_themes qui
-    # pointaient vers elle. On évite ainsi de choisir "Web Application
-    # Development with C# and .NET" (un canonical hyper-spécifique apparu
-    # 1× dans un batch) comme représentant d'un cluster contenant
-    # "Web Development" qui est apparu 100 fois.
-    canon_to_count: dict[str, int] = {c: 0 for c in unique_canons}
-    for raw, canon in raw_to_canon.items():
-        canon_to_count[canon] = canon_to_count.get(canon, 0) + themes.get(raw, 0)
-
-    canon_to_final: dict[str, str] = {}
-    for cluster in canon_clusters:
-        members = cluster.get("raw_members", [])
-        if not members:
-            continue
-        # canonical = membre avec le count cumulé MAX (le plus représentatif).
-        # Tie-break sur la longueur DÉCROISSANTE (préfère le plus court à
-        # count égal, ex. "Mathematics" vs "Advanced Mathematics" choisit
-        # "Mathematics" en cas d'égalité). Tie final sur l'ordre lexico
-        # pour déterminisme.
-        final = max(
-            members,
-            key=lambda m: (canon_to_count.get(m, 0), -len(m), m),
-        )
-        for m in members:
-            canon_to_final[m] = final
-
-    final_mapping: dict[str, str] = {
-        raw: canon_to_final.get(canon, canon)
-        for raw, canon in raw_to_canon.items()
-    }
-
+    final_mapping: dict[str, str] = dict(raw_to_canon)
     grouped: dict[str, list[str]] = {}
-    for raw, final in final_mapping.items():
-        grouped.setdefault(final, []).append(raw)
+    for raw, canon in final_mapping.items():
+        grouped.setdefault(canon, []).append(raw)
 
     clusters_serialized = []
     for canonical, raw_members in grouped.items():

--- a/lib/theme_canon.py
+++ b/lib/theme_canon.py
@@ -188,24 +188,38 @@ def build_canon_table(
     threshold: int = DEFAULT_CLUSTER_THRESHOLD,
     use_judge_cache: bool = True,
     on_progress: ProgressCallback | None = None,
+    mode: str = "syntactic",
+    vocabulary_top_n: int = 500,
 ) -> dict[str, Any]:
     """Pipeline end-to-end : extraction → clustering → LLM judge → persistance.
+
+    Deux modes disponibles :
+      - `"syntactic"` (défaut) : Phases 1+2+3 — normalisation + clustering
+        fuzzy + LLM judge. Capture variantes orthographiques et acronymes.
+        Réduction observée ~11% sur le profil default.
+      - `"semantic"` (C-light) : vocabulaire bootstrapé + canonisation LLM
+        sémantique. Capture aussi les synonymes éloignés (ML ↔ Machine
+        Learning ↔ AI). Réduction attendue ~70-80%.
 
     Args:
         profile: Nom du profil.
         llm: ChatOpenAI configuré (typiquement get_agent_llm()).
-        threshold: Seuil de similarité Phase 2 (défaut 92).
-        use_judge_cache: Réutilise les décisions LLM persistées dans
-                         theme-judge.json (défaut True).
+        threshold: Seuil de similarité Phase 2 / re-clustering final (défaut 92).
+        use_judge_cache: Réutilise les décisions LLM persistées (défaut True).
         on_progress: Callback `(done, total, phase)` invoqué pendant le run.
-                     Phases : 'extracting' → 'clustering' → 'judging' → 'done'.
-                     Utile pour persister status.json côté dashboard.
+                     Phases (syntactic) : extracting → clustering → judging → done
+                     Phases (semantic)  : extracting → canonicalizing → reclustering → done
+        mode: "syntactic" ou "semantic".
+        vocabulary_top_n: Taille du vocabulaire de référence en mode semantic.
 
     Returns:
         La table de canonisation complète (incluant métadonnées et clusters
         enrichis pour l'UI). Écrite sur disque dans
         `profiles/<p>/.cache/theme-canon.json`.
     """
+    if mode not in ("syntactic", "semantic"):
+        raise ValueError(f"mode must be 'syntactic' or 'semantic', got {mode!r}")
+
     if on_progress:
         on_progress(0, 0, "extracting")
     themes = extract_themes_from_vision_cache(profile)
@@ -218,12 +232,23 @@ def build_canon_table(
             "canonical_count": 0,
             "mapping": {},
             "clusters": [],
+            "mode": mode,
         }
         save_canon_table(profile, table)
         if on_progress:
             on_progress(0, 0, "done")
         return table
 
+    if mode == "semantic":
+        return _build_canon_table_semantic(
+            profile, llm, themes,
+            threshold=threshold,
+            use_cache=use_judge_cache,
+            vocabulary_top_n=vocabulary_top_n,
+            on_progress=on_progress,
+        )
+
+    # Mode syntactique (Phases 1+2+3) — comportement historique
     if on_progress:
         on_progress(0, len(themes), "clustering")
     clusters = cluster_themes(themes.keys(), threshold=threshold)
@@ -273,6 +298,114 @@ def build_canon_table(
         "threshold": threshold,
         "clusters": clusters_serialized,
         "mapping": mapping,
+        "mode": "syntactic",
+    }
+    save_canon_table(profile, table)
+    return table
+
+
+def _build_canon_table_semantic(
+    profile: str,
+    llm: BaseChatModel,
+    themes: dict[str, int],
+    *,
+    threshold: int,
+    use_cache: bool,
+    vocabulary_top_n: int,
+    on_progress: ProgressCallback | None,
+) -> dict[str, Any]:
+    """Pipeline du mode "semantic" (C-light).
+
+    Étapes :
+      1. build_vocabulary : top-N par fréquence comme vocabulaire de référence
+      2. canonicalize_themes : LLM produit {raw_theme: canonical} en parallèle
+      3. Re-clustering du résultat via cluster_themes (Phase 1+2) pour
+         gommer les doublons que le LLM aurait créés dans différents batches
+      4. Assemblage final + serialisation des clusters pour l'UI
+    """
+    from lib.theme_canonicalizer import build_vocabulary, canonicalize_themes
+
+    # Étape 1 : vocabulaire
+    vocabulary = build_vocabulary(themes, top_n=vocabulary_top_n)
+
+    if on_progress:
+        on_progress(0, 0, "canonicalizing")
+
+    # Étape 2 : canonisation LLM
+    def _cano_progress(done: int, total: int) -> None:
+        if on_progress:
+            on_progress(done, total, "canonicalizing")
+
+    raw_to_canon = canonicalize_themes(
+        list(themes.keys()),
+        vocabulary,
+        llm,
+        profile,
+        use_cache=use_cache,
+        on_progress=_cano_progress,
+    )
+
+    if on_progress:
+        on_progress(0, 0, "reclustering")
+
+    # Étape 3 : re-clustering des canoniques produits via Phase 1+2 pour
+    # gommer les doublons résiduels (variantes ortho créées par le LLM).
+    # On clusterise l'ensemble des canoniques uniques.
+    unique_canons = sorted(set(raw_to_canon.values()))
+    canon_clusters = cluster_themes(unique_canons, threshold=threshold)
+
+    # Construit canon_to_final : pour chaque canonical produit par le LLM,
+    # le représentant final de son cluster fuzzy (le plus long du cluster).
+    canon_to_final: dict[str, str] = {}
+    for cluster in canon_clusters:
+        members = cluster.get("raw_members", [])
+        if not members:
+            continue
+        final = max(members, key=len)
+        for m in members:
+            canon_to_final[m] = final
+
+    # Mapping final raw → canonical après fusion
+    final_mapping: dict[str, str] = {
+        raw: canon_to_final.get(canon, canon)
+        for raw, canon in raw_to_canon.items()
+    }
+
+    # Étape 4 : groupes par canonical pour l'UI (équivalent des clusters
+    # du mode syntactique, format identique consommé par le panel).
+    grouped: dict[str, list[str]] = {}
+    for raw, final in final_mapping.items():
+        grouped.setdefault(final, []).append(raw)
+
+    clusters_serialized = []
+    for canonical, raw_members in grouped.items():
+        # Pour le mode sémantique, on n'a pas de "splits" — tous les raws
+        # qui ont été mappés vers ce canonical sont considérés members.
+        count_cumulative = sum(themes.get(m, 0) for m in raw_members)
+        clusters_serialized.append({
+            "canonical": canonical,
+            "members": list(raw_members),
+            "splits": [],
+            "raw_members": list(raw_members),
+            "count_cumulative": count_cumulative,
+        })
+    # Tri par count cumulé décroissant
+    clusters_serialized.sort(key=lambda c: -c["count_cumulative"])
+
+    if on_progress:
+        on_progress(len(themes), len(themes), "done")
+
+    table = {
+        "version": CANON_VERSION,
+        "built_at": _now_iso(),
+        "raw_count": len(final_mapping),
+        "canonical_count": len(set(final_mapping.values())),
+        "threshold": threshold,
+        "vocabulary_top_n": vocabulary_top_n,
+        "vocabulary_size": len(vocabulary),
+        "clusters": clusters_serialized,
+        "mapping": final_mapping,
+        "mode": "semantic",
     }
     save_canon_table(profile, table)
     return table

--- a/lib/theme_canonicalizer.py
+++ b/lib/theme_canonicalizer.py
@@ -1,0 +1,294 @@
+"""Canonisation sémantique des thèmes via LLM avec vocabulaire de référence.
+
+Alternative à Phase 1+2+3 (chantier "C-light" du backlog dédupli) : au lieu
+de regrouper des variantes orthographiques, on demande à un LLM de
+**catégoriser** chaque thème vers un vocabulary contrôlé. Capture les
+synonymes sémantiques (ML ↔ Machine Learning ↔ AI) que la similarité de
+string laisse passer.
+
+Pipeline (orchestré par lib.theme_canon.build_canon_table(mode="semantic")) :
+
+  1. build_vocabulary(themes_by_count, top_n=500)
+     → liste des canoniques de référence (les thèmes les plus fréquents)
+  2. canonicalize_themes(remaining_themes, vocabulary, llm)
+     → mapping {raw_theme: canonical} via batches LLM parallélisés
+  3. (côté theme_canon) re-clustering de la liste des canoniques produits
+     via cluster_themes() pour gommer les doublons résiduels créés par
+     le LLM dans différents batches
+
+Cache idempotent par hash (vocabulary + batch) — ré-jouer ne ré-appelle pas.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import threading
+from collections.abc import Callable, Iterable
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from pathlib import Path
+
+from langchain_core.language_models import BaseChatModel
+from langchain_core.messages import HumanMessage, SystemMessage
+from pydantic import BaseModel, Field
+
+
+class RawCanonicalPair(BaseModel):
+    """Décision LLM pour 1 thème brut."""
+
+    raw: str = Field(description="Le thème brut tel qu'envoyé en input")
+    canonical: str = Field(
+        description="Le canonical choisi (depuis le vocabulaire OU nouveau)"
+    )
+    matched_existing: bool = Field(
+        description="True si canonical est dans le vocabulaire de référence, "
+                    "False si le LLM a dû proposer un nouveau canonical"
+    )
+
+
+class BatchCanonicalization(BaseModel):
+    """Sortie LLM pour un batch de thèmes."""
+
+    mappings: list[RawCanonicalPair] = Field(
+        description="Un mapping par thème en input — l'ordre doit être préservé"
+    )
+
+
+_SYSTEM_PROMPT = """Tu es un expert en taxonomie qui consolide les thèmes \
+d'une bibliothèque PDF technique.
+
+Pour chaque thème brut qu'on te donne, choisis le `canonical` le plus précis :
+  - SOIT un canonical du **vocabulaire de référence** (préfère TOUJOURS cette
+    option quand un canonical existant correspond au sens du thème brut)
+  - SOIT un nouveau canonical (seulement si AUCUN candidate du vocabulaire ne
+    convient sémantiquement) — set `matched_existing=False`
+
+Règles fondamentales :
+  ✓ FUSIONNER (utiliser le canonical du vocabulaire) si :
+    - Variante de casse : "Machine Learning" + "machine learning"
+    - Variante de pluriel : "Neural Networks" + "Neural Network"
+    - Orthographe US/UK : "Optimization" + "Optimisation"
+    - Acronyme = développé : "SEO" + "Search Engine Optimization", "ML" +
+      "Machine Learning", "AI" + "Artificial Intelligence"
+    - Synonyme sémantique : "Stat. Inference" + "Statistical Inference"
+    - Reformulation : "Web Development with Java" + "Java Web Development"
+
+  ✗ NE PAS FUSIONNER (proposer un nouveau canonical) si :
+    - Sous-domaine spécialisé : "Machine Learning" vs "Unsupervised Machine
+      Learning" (sous-domaine distinct)
+    - Version produit : "Windows 10" vs "Windows XP" (produits distincts)
+    - Techno différente : "Java EE Development" vs "JavaFX Development"
+    - Contexte distinct : "Network Security" vs "Computer Security"
+
+PRINCIPE DE PRUDENCE : si tu hésites, préfère **réutiliser un canonical
+existant** plutôt qu'en créer un nouveau. Le but est de consolider, pas de
+fragmenter.
+
+Le `canonical` doit être en Title Case propre (pas en MAJUSCULES, pas en
+minuscules)."""
+
+
+def build_vocabulary(
+    themes_by_count: dict[str, int],
+    *,
+    top_n: int = 500,
+) -> list[str]:
+    """Sélectionne le top-N par fréquence comme vocabulaire de référence.
+
+    L'intuition : les thèmes les plus fréquents sont déjà les "concepts
+    principaux" de la biblio. Les utiliser comme canoniques garantit qu'on
+    fusionne vers des termes humainement reconnaissables (pas vers des
+    raretés).
+
+    Args:
+        themes_by_count: {raw_theme: count_occurrences}.
+        top_n: Taille du vocabulaire (défaut 500).
+
+    Returns:
+        Liste de thèmes (les plus fréquents en premier), bornée à top_n.
+        Doublons retirés en préservant l'ordre.
+    """
+    if not themes_by_count:
+        return []
+    sorted_themes = sorted(
+        themes_by_count.items(),
+        key=lambda kv: (-kv[1], kv[0].lower()),
+    )
+    return [t for t, _ in sorted_themes[:top_n]]
+
+
+def _stable_batch_key(batch: list[str], vocabulary: list[str]) -> str:
+    """Hash stable d'un batch + vocab pour le cache.
+
+    L'ordre du batch importe (le LLM produit des `mappings[]` ordonnés),
+    mais le vocab est trié pour éliminer l'influence de son ordre.
+    """
+    payload = json.dumps(
+        {"batch": batch, "vocab": sorted(vocabulary)},
+        ensure_ascii=False,
+    )
+    return hashlib.sha256(payload.encode("utf-8")).hexdigest()[:16]
+
+
+def _canonicalizer_cache_path(profile: str) -> Path:
+    from dashboard import data
+    return (
+        data.get_project_root()
+        / "profiles" / profile / ".cache" / "theme-canonicalizer.json"
+    )
+
+
+def _load_canonicalizer_cache(profile: str) -> dict[str, dict]:
+    path = _canonicalizer_cache_path(profile)
+    if not path.exists():
+        return {}
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return {}
+
+
+def _save_canonicalizer_cache(profile: str, cache: dict[str, dict]) -> None:
+    path = _canonicalizer_cache_path(profile)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(cache, ensure_ascii=False, indent=2),
+        encoding="utf-8",
+    )
+
+
+def _build_user_prompt(batch: list[str], vocabulary: list[str]) -> str:
+    """Construit le HumanMessage pour un batch."""
+    vocab_block = "\n".join(f"  - {v}" for v in vocabulary)
+    batch_block = "\n".join(f"  - {t!r}" for t in batch)
+    return (
+        f"Vocabulaire de référence ({len(vocabulary)} canoniques) :\n"
+        f"{vocab_block}\n\n"
+        f"Thèmes à canoniser ({len(batch)}) — produis un `mapping` par thème, "
+        "dans l'ordre :\n"
+        f"{batch_block}"
+    )
+
+
+def canonicalize_batch(
+    batch: list[str],
+    vocabulary: list[str],
+    llm: BaseChatModel,
+) -> dict[str, str]:
+    """Appelle le LLM sur un batch et retourne {raw: canonical}.
+
+    Utilise `with_structured_output(BatchCanonicalization,
+    method="function_calling")` — GLM-4.7 ne supporte pas json mode.
+
+    Si le LLM omet certains thèmes du batch (rare), ils sont fallback
+    identité (raw → raw) pour ne pas casser le pipeline.
+    """
+    if not batch:
+        return {}
+    structured_llm = llm.with_structured_output(
+        BatchCanonicalization, method="function_calling",
+    )
+    result = structured_llm.invoke([
+        SystemMessage(content=_SYSTEM_PROMPT),
+        HumanMessage(content=_build_user_prompt(batch, vocabulary)),
+    ])
+    by_raw: dict[str, str] = {}
+    for pair in result.mappings:
+        if pair.raw in by_raw:
+            continue  # déduplique si le LLM répète
+        canonical = (pair.canonical or "").strip() or pair.raw
+        by_raw[pair.raw] = canonical
+    # Filet de sécurité : tout thème oublié → identité
+    for raw in batch:
+        by_raw.setdefault(raw, raw)
+    return by_raw
+
+
+def canonicalize_themes(
+    themes: Iterable[str],
+    vocabulary: list[str],
+    llm: BaseChatModel,
+    profile: str,
+    *,
+    batch_size: int = 30,
+    max_workers: int = 8,
+    use_cache: bool = True,
+    on_progress: Callable[[int, int], None] | None = None,
+) -> dict[str, str]:
+    """Pipeline complet de canonisation sémantique d'une liste de thèmes.
+
+    Pour chaque thème, le LLM choisit un canonical depuis `vocabulary` ou
+    en propose un nouveau. Les thèmes déjà dans `vocabulary` sont mappés
+    vers eux-mêmes (no-op, pas d'appel LLM).
+
+    Args:
+        themes: Tous les thèmes raw à canoniser (peut inclure les
+                vocabulaires — ils sont skip).
+        vocabulary: Le vocabulaire de référence (sortie de build_vocabulary).
+        llm: ChatOpenAI configuré (typiquement get_agent_llm()).
+        profile: Pour la persistance du cache.
+        batch_size: Nombre de thèmes par appel LLM (défaut 30).
+        max_workers: Threads parallèles (défaut 8).
+        use_cache: Désactivable pour les tests.
+        on_progress: Callback `(done, total)`. `total` = nb de batches
+                     (pas de thèmes individuels — trop fine-grained).
+
+    Returns:
+        Dict {raw_theme: canonical} couvrant TOUS les thèmes d'entrée.
+        Les thèmes du vocabulary mappent vers eux-mêmes par construction.
+    """
+    themes_list = [t for t in themes if t]
+    if not themes_list:
+        return {}
+
+    vocab_set = set(vocabulary)
+    # Identity mapping pour les thèmes déjà dans le vocab — pas d'appel LLM
+    result: dict[str, str] = {t: t for t in themes_list if t in vocab_set}
+    to_process = [t for t in themes_list if t not in vocab_set]
+
+    if not to_process:
+        if on_progress is not None:
+            on_progress(0, 0)
+        return result
+
+    # Batches
+    batches: list[list[str]] = [
+        to_process[i:i + batch_size]
+        for i in range(0, len(to_process), batch_size)
+    ]
+    total_batches = len(batches)
+
+    cache = _load_canonicalizer_cache(profile) if use_cache else {}
+    lock = threading.Lock()
+    cache_dirty = False
+    done = 0
+
+    def process_one(batch: list[str]) -> tuple[str, dict[str, str]]:
+        key = _stable_batch_key(batch, vocabulary)
+        if use_cache and key in cache:
+            return key, dict(cache[key])
+        mapping = canonicalize_batch(batch, vocabulary, llm)
+        return key, mapping
+
+    with ThreadPoolExecutor(max_workers=max_workers) as executor:
+        futures = {executor.submit(process_one, b): b for b in batches}
+        for future in as_completed(futures):
+            try:
+                key, batch_mapping = future.result()
+            except Exception:  # noqa: BLE001 — fallback identité
+                batch = futures[future]
+                key = _stable_batch_key(batch, vocabulary)
+                batch_mapping = {t: t for t in batch}
+            with lock:
+                result.update(batch_mapping)
+                if use_cache:
+                    cache[key] = batch_mapping
+                    cache_dirty = True
+                done += 1
+                if on_progress is not None:
+                    on_progress(done, total_batches)
+
+    if cache_dirty and use_cache:
+        _save_canonicalizer_cache(profile, cache)
+
+    return result

--- a/lib/theme_canonicalizer.py
+++ b/lib/theme_canonicalizer.py
@@ -54,38 +54,61 @@ class BatchCanonicalization(BaseModel):
     )
 
 
-_SYSTEM_PROMPT = """Tu es un expert en taxonomie qui consolide les thèmes \
-d'une bibliothèque PDF technique.
+_SYSTEM_PROMPT = """Tu es un expert en taxonomie qui consolide UNIQUEMENT les \
+variantes orthographiques et synonymes EXACTS de thèmes d'une bibliothèque PDF.
 
-Pour chaque thème brut qu'on te donne, choisis le `canonical` le plus précis :
-  - SOIT un canonical du **vocabulaire de référence** (préfère TOUJOURS cette
-    option quand un canonical existant correspond au sens du thème brut)
-  - SOIT un nouveau canonical (seulement si AUCUN candidate du vocabulaire ne
-    convient sémantiquement) — set `matched_existing=False`
+═══════ PRINCIPE FONDAMENTAL ═══════
 
-Règles fondamentales :
-  ✓ FUSIONNER (utiliser le canonical du vocabulaire) si :
-    - Variante de casse : "Machine Learning" + "machine learning"
-    - Variante de pluriel : "Neural Networks" + "Neural Network"
-    - Orthographe US/UK : "Optimization" + "Optimisation"
-    - Acronyme = développé : "SEO" + "Search Engine Optimization", "ML" +
-      "Machine Learning", "AI" + "Artificial Intelligence"
-    - Synonyme sémantique : "Stat. Inference" + "Statistical Inference"
-    - Reformulation : "Web Development with Java" + "Java Web Development"
+Pour chaque thème, par DÉFAUT garde-le tel quel (canonical = raw).
+Ne fusionne que dans les cas listés ci-dessous.
 
-  ✗ NE PAS FUSIONNER (proposer un nouveau canonical) si :
-    - Sous-domaine spécialisé : "Machine Learning" vs "Unsupervised Machine
-      Learning" (sous-domaine distinct)
-    - Version produit : "Windows 10" vs "Windows XP" (produits distincts)
-    - Techno différente : "Java EE Development" vs "JavaFX Development"
-    - Contexte distinct : "Network Security" vs "Computer Security"
+L'erreur la plus grave est la SUR-FUSION (mélanger des concepts distincts).
+Une fragmentation est facilement réparable par l'utilisateur, une
+sur-fusion fait perdre de l'information de façon irréversible.
 
-PRINCIPE DE PRUDENCE : si tu hésites, préfère **réutiliser un canonical
-existant** plutôt qu'en créer un nouveau. Le but est de consolider, pas de
-fragmenter.
+═══════ CAS OÙ TU DOIS FUSIONNER (canonical = entrée du vocabulaire) ═══════
 
-Le `canonical` doit être en Title Case propre (pas en MAJUSCULES, pas en
-minuscules)."""
+UNIQUEMENT si le thème brut est strictement équivalent à un canonical du
+vocabulaire selon ces critères :
+
+  1. Variante de casse SEULE : "Machine Learning" / "machine learning" /
+     "MACHINE LEARNING" → "Machine Learning"
+  2. Variante de pluriel/singulier SEULE : "Neural Networks" / "Neural Network"
+  3. Orthographe US/UK SEULE : "Optimization" / "Optimisation"
+  4. Acronyme strict = développé connu : "ML" ↔ "Machine Learning",
+     "AI" ↔ "Artificial Intelligence", "SEO" ↔ "Search Engine Optimization"
+  5. Reformulation pure SANS perte de sens : "Web Development with Java" ↔
+     "Java Web Development" (mêmes mots dans un autre ordre)
+
+═══════ CAS OÙ TU NE DOIS PAS FUSIONNER (canonical = raw, matched_existing=False) ═══════
+
+✗ Sous-domaine ou spécialisation : "Unsupervised Machine Learning" ne fusionne
+  PAS avec "Machine Learning" (sous-domaine ≠ parent).
+✗ Concept lié mais distinct : "Logic" ne fusionne PAS avec "Mathematics".
+  "Cognitive Science" ne fusionne PAS avec "Artificial Intelligence".
+  "Big Data" ne fusionne PAS avec "Data Science" (méthodologie ≠ volume).
+  "Computer Security" ne fusionne PAS avec "Information Security".
+✗ Inclusion conceptuelle : un thème qui est un EXEMPLE ou un CAS PARTICULIER
+  de l'autre ne fusionne PAS. "Penetration Testing" est un CAS de
+  "Information Security" — garde-le séparé.
+✗ Versions, plateformes, technologies différentes : "iOS Application
+  Development" ne fusionne PAS avec "Mobile Application Development".
+  "Quantum Physics" ne fusionne PAS avec "Quantum Mechanics" (concepts proches
+  mais distincts en physique théorique).
+✗ Compositions : "X for Y" ne fusionne pas avec "X" tout seul. "Statistics
+  for Data Science" reste distinct de "Statistics".
+✗ Titres de livres ou cours présents comme thèmes : laisse tels quels.
+
+═══════ TEST DE FUSION ═══════
+
+Avant de fusionner X → Y, demande-toi : "Si je voulais ranger un livre dans
+un dossier Y, les livres taggés X iraient-ils SANS EXCEPTION dans ce dossier
+ET INVERSEMENT ?". Si non, NE FUSIONNE PAS.
+
+═══════ FORMAT ═══════
+
+Le `canonical` doit être en Title Case propre quand il vient du vocabulaire.
+Quand tu gardes le raw (matched_existing=False), restitue-le tel quel."""
 
 
 def build_vocabulary(

--- a/lib/theme_judge.py
+++ b/lib/theme_judge.py
@@ -187,14 +187,20 @@ def judge_clusters(
     auto_merge_threshold: int = 97,
     use_cache: bool = True,
     on_progress: Callable[[int, int], None] | None = None,
+    max_workers: int = 8,
 ) -> list[JudgeResult]:
-    """Pipeline complet : skip auto + cache + LLM judge.
+    """Pipeline complet : skip auto + cache + LLM judge (parallélisé).
 
     Pour chaque cluster :
       - 1 variante seulement → JudgeResult trivial (members = [variante]).
       - 2+ variantes très proches (similarité ≥ auto_merge_threshold sur
         toutes les paires) → JudgeResult auto-fusionné, pas d'appel LLM.
       - 2+ variantes ambigües → cache lookup, sinon appel LLM, persistance.
+
+    Les appels LLM (le seul travail coûteux) sont parallélisés sur un
+    ThreadPoolExecutor — chaque appel est indépendant (Pydantic structured
+    output sans état partagé). Sur ~700 clusters LLM, parallélisation 8x
+    fait passer un run de ~3h à ~25 min.
 
     Args:
         clusters: Sortie de cluster_themes() — liste de listes de variantes.
@@ -204,48 +210,87 @@ def judge_clusters(
         use_cache: Désactivable pour les tests.
         on_progress: Callback `(done, total)` invoqué après chaque cluster
                      (utile pour status.json en runtime UI/dashboard).
+                     Thread-safe (appelé sous lock).
+        max_workers: Nombre de threads pour les appels LLM (défaut 8).
+                     Mettre 1 pour désactiver la parallélisation (tests).
 
     Returns:
         Liste de JudgeResult, un par cluster d'entrée (ordre préservé).
     """
-    cache = _load_judge_cache(profile) if use_cache else {}
-    results: list[JudgeResult] = []
-    cache_dirty = False
-    total = len(clusters)
+    import threading
+    from concurrent.futures import ThreadPoolExecutor, as_completed
 
+    cache = _load_judge_cache(profile) if use_cache else {}
+    total = len(clusters)
+    results: list[JudgeResult | None] = [None] * total
+    needs_llm: list[tuple[int, list[str], str]] = []  # (index, variants, cache_key)
+
+    # Étape 1 : traitement instantané (singleton / auto-merge / cache hit)
+    # — en série, c'est sub-milliseconde par cluster.
+    done = 0
     for i, variants in enumerate(clusters):
-        # Singleton : décision triviale
         if len(variants) < 2:
-            results.append(JudgeResult(
+            results[i] = JudgeResult(
                 canonical=variants[0] if variants else "",
                 members=list(variants),
-            ))
-        # Skip auto sur cluster très homogène
+            )
+            done += 1
         elif should_auto_merge(variants, threshold=auto_merge_threshold):
-            # Heuristique de canonical : la variante la plus longue (souvent
-            # la plus complète orthographiquement, ex. "Machine Learning" vs
-            # "machine learning")
-            results.append(JudgeResult(
+            results[i] = JudgeResult(
                 canonical=max(variants, key=len),
                 members=list(variants),
-            ))
+            )
+            done += 1
         else:
-            # Cache lookup
             key = _stable_cluster_key(variants)
             if use_cache and key in cache:
-                results.append(JudgeResult(**cache[key]))
+                results[i] = JudgeResult(**cache[key])
+                done += 1
             else:
-                # Appel LLM
-                result = judge_cluster(variants, llm)
+                needs_llm.append((i, variants, key))
+
+    # Notifie la progression après le pré-tri (souvent des dizaines de
+    # milliers de clusters instantanés traités d'un coup).
+    if on_progress is not None:
+        on_progress(done, total)
+
+    if not needs_llm:
+        return results  # type: ignore[return-value] — tous remplis
+
+    # Étape 2 : appels LLM parallélisés
+    lock = threading.Lock()
+    cache_dirty = False
+    done_counter = done  # capturé par closure
+
+    def judge_one(item: tuple[int, list[str], str]) -> tuple[int, str, JudgeResult]:
+        idx, variants, key = item
+        result = judge_cluster(variants, llm)
+        return idx, key, result
+
+    with ThreadPoolExecutor(max_workers=max_workers) as executor:
+        futures = {executor.submit(judge_one, item): item for item in needs_llm}
+        for future in as_completed(futures):
+            try:
+                idx, key, result = future.result()
+            except Exception:  # noqa: BLE001
+                # Sur erreur LLM (timeout, parsing, ...) on enregistre un
+                # JudgeResult fallback identité — le pipeline continue.
+                item = futures[future]
+                idx, variants, key = item
+                result = JudgeResult(
+                    canonical=variants[0] if variants else "",
+                    members=list(variants[:1]),
+                )
+            results[idx] = result
+            with lock:
                 if use_cache:
                     cache[key] = result.model_dump()
                     cache_dirty = True
-                results.append(result)
-
-        if on_progress is not None:
-            on_progress(i + 1, total)
+                done_counter += 1
+                if on_progress is not None:
+                    on_progress(done_counter, total)
 
     if cache_dirty and use_cache:
         _save_judge_cache(profile, cache)
 
-    return results
+    return results  # type: ignore[return-value] — tous remplis

--- a/lib/theme_judge.py
+++ b/lib/theme_judge.py
@@ -21,6 +21,7 @@ from __future__ import annotations
 
 import hashlib
 import json
+from collections.abc import Callable
 from pathlib import Path
 
 from langchain_core.language_models import BaseChatModel
@@ -185,6 +186,7 @@ def judge_clusters(
     *,
     auto_merge_threshold: int = 97,
     use_cache: bool = True,
+    on_progress: Callable[[int, int], None] | None = None,
 ) -> list[JudgeResult]:
     """Pipeline complet : skip auto + cache + LLM judge.
 
@@ -200,6 +202,8 @@ def judge_clusters(
         llm: ChatOpenAI prêt (typiquement get_agent_llm()).
         auto_merge_threshold: Seuil pour skip LLM (défaut 97).
         use_cache: Désactivable pour les tests.
+        on_progress: Callback `(done, total)` invoqué après chaque cluster
+                     (utile pour status.json en runtime UI/dashboard).
 
     Returns:
         Liste de JudgeResult, un par cluster d'entrée (ordre préservé).
@@ -207,18 +211,17 @@ def judge_clusters(
     cache = _load_judge_cache(profile) if use_cache else {}
     results: list[JudgeResult] = []
     cache_dirty = False
+    total = len(clusters)
 
-    for variants in clusters:
+    for i, variants in enumerate(clusters):
         # Singleton : décision triviale
         if len(variants) < 2:
             results.append(JudgeResult(
                 canonical=variants[0] if variants else "",
                 members=list(variants),
             ))
-            continue
-
         # Skip auto sur cluster très homogène
-        if should_auto_merge(variants, threshold=auto_merge_threshold):
+        elif should_auto_merge(variants, threshold=auto_merge_threshold):
             # Heuristique de canonical : la variante la plus longue (souvent
             # la plus complète orthographiquement, ex. "Machine Learning" vs
             # "machine learning")
@@ -226,20 +229,21 @@ def judge_clusters(
                 canonical=max(variants, key=len),
                 members=list(variants),
             ))
-            continue
+        else:
+            # Cache lookup
+            key = _stable_cluster_key(variants)
+            if use_cache and key in cache:
+                results.append(JudgeResult(**cache[key]))
+            else:
+                # Appel LLM
+                result = judge_cluster(variants, llm)
+                if use_cache:
+                    cache[key] = result.model_dump()
+                    cache_dirty = True
+                results.append(result)
 
-        # Cache lookup
-        key = _stable_cluster_key(variants)
-        if use_cache and key in cache:
-            results.append(JudgeResult(**cache[key]))
-            continue
-
-        # Appel LLM
-        result = judge_cluster(variants, llm)
-        if use_cache:
-            cache[key] = result.model_dump()
-            cache_dirty = True
-        results.append(result)
+        if on_progress is not None:
+            on_progress(i + 1, total)
 
     if cache_dirty and use_cache:
         _save_judge_cache(profile, cache)

--- a/lib/theme_judge.py
+++ b/lib/theme_judge.py
@@ -124,8 +124,11 @@ def should_auto_merge(variants: list[str], threshold: int = 97) -> bool:
 def judge_cluster(variants: list[str], llm: BaseChatModel) -> JudgeResult:
     """Appelle le LLM pour trancher members vs splits sur un cluster.
 
-    Utilise `with_structured_output(JudgeResult)` — le LLM est forcé de
-    retourner du JSON conforme au schéma Pydantic, pas de parsing manuel.
+    Utilise `with_structured_output(JudgeResult, method="function_calling")`.
+    On force `function_calling` car le mode JSON par défaut n'est pas
+    supporté par GLM-4.7 sur SiliconFlow (BadRequest 20024 "Json mode is
+    not supported for this model"). Le function calling l'est, comme on
+    l'utilise déjà côté Phase B.
 
     Args:
         variants: Liste des variantes brutes (telles que retournées par
@@ -136,7 +139,7 @@ def judge_cluster(variants: list[str], llm: BaseChatModel) -> JudgeResult:
     Returns:
         JudgeResult avec canonical, members, splits.
     """
-    structured_llm = llm.with_structured_output(JudgeResult)
+    structured_llm = llm.with_structured_output(JudgeResult, method="function_calling")
     user_prompt = (
         f"Voici {len(variants)} variantes candidates à fusion :\n\n"
         f"{json.dumps(variants, ensure_ascii=False, indent=2)}\n\n"

--- a/lib/theme_judge.py
+++ b/lib/theme_judge.py
@@ -1,0 +1,244 @@
+"""LLM judge sur les clusters fuzzy de Phase 2 — tranche les cas ambigus.
+
+Cible : les clusters multi-variantes où `cluster_themes()` a regroupé des
+formes canoniques distinctes par similarité fuzzy. Beaucoup de ces clusters
+contiennent des **sous-domaines** que `token_sort_ratio` confond avec leur
+parent (ex. "Java EE Development" + "JavaFX Development" mélangés).
+
+Pipeline :
+  1. should_auto_merge() : skip LLM si toutes les paires du cluster ont
+     similarité ≥ 97 (vrais doublons orthographiques, fusion sûre).
+  2. judge_cluster(cluster, llm) : 1 appel LLM avec sortie structurée
+     Pydantic → JudgeResult (canonical + members + splits).
+  3. judge_clusters(clusters, profile, llm) : applique 1+2 sur la liste,
+     avec cache idempotent dans `profiles/<p>/.cache/theme-judge.json`.
+
+Le cache est calé sur un hash stable du cluster (tri lexicographique), donc
+re-jouer la dédupli sur les mêmes inputs ne ré-appelle pas le LLM.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+
+from langchain_core.language_models import BaseChatModel
+from langchain_core.messages import HumanMessage, SystemMessage
+from pydantic import BaseModel, Field
+from rapidfuzz import fuzz
+
+
+class JudgeSplit(BaseModel):
+    """Une variante du cluster séparée par le LLM judge."""
+
+    theme: str = Field(description="La variante brute à séparer")
+    reason: str = Field(
+        description="Justification courte (sous-domaine, version, contexte distinct)"
+    )
+
+
+class JudgeResult(BaseModel):
+    """Décision du LLM judge sur un cluster fuzzy.
+
+    Le LLM choisit un canonical propre (Title Case), liste les variantes
+    confirmées comme synonymes, et sépare celles qui sont des
+    sous-domaines distincts.
+    """
+
+    canonical: str = Field(
+        description="Nom canonique propre en Title Case (ex. 'Machine Learning')"
+    )
+    members: list[str] = Field(
+        description="Variantes brutes confirmées comme synonymes du canonical"
+    )
+    splits: list[JudgeSplit] = Field(
+        default_factory=list,
+        description="Variantes à séparer du cluster (sous-domaines distincts)",
+    )
+
+
+_SYSTEM_PROMPT = """Tu es un expert en taxonomie qui déduplique des thèmes d'une bibliothèque PDF technique.
+
+Ton job : on te donne un GROUPE de variantes candidates à fusion. Pour chaque variante, décide si elle représente :
+  - Le MÊME concept que les autres (à fusionner) → "members"
+  - Un SOUS-DOMAINE ou un concept DISTINCT → "splits"
+
+Règles fondamentales (à appliquer strictement) :
+  ✓ FUSIONNER si :
+    - Variante de casse : "Machine Learning" + "machine learning"
+    - Variante de pluriel : "Neural Networks" + "Neural Network"
+    - Orthographe US/UK : "Optimization" + "Optimisation"
+    - Acronyme = développé : "SEO" + "Search Engine Optimization"
+    - Reformulation neutre : "Web Development with Java" + "Java Web Development"
+
+  ✗ SÉPARER (splits) si :
+    - Sous-domaine : "Machine Learning" vs "Unsupervised Machine Learning"
+    - Version produit : "Windows 10" vs "Windows XP"
+    - Techno différente : "Java EE Development" vs "JavaFX Development"
+    - Contexte distinct : "Network Security" vs "Computer Security"
+    - Specialisation : "Game Programming" vs "2D Game Programming"
+
+Choisis le `canonical` en Title Case propre (pas en minuscule, pas en MAJUSCULES).
+
+PRINCIPE DE PRUDENCE : si tu hésites sur une variante, mets-la dans `splits`.
+La sur-fusion est plus dommageable que la sous-fusion — un cluster qui mélange
+des concepts différents fausse durablement la taxonomie."""
+
+
+def _stable_cluster_key(variants: list[str]) -> str:
+    """Hash stable d'un cluster — indépendant de l'ordre des variantes.
+
+    Utilisé comme clé de cache : si on re-juge exactement les mêmes
+    variantes (peu importe l'ordre), on retrouve la décision précédente.
+    """
+    canonical = "|".join(sorted(variants))
+    return hashlib.sha256(canonical.encode("utf-8")).hexdigest()[:16]
+
+
+def should_auto_merge(variants: list[str], threshold: int = 97) -> bool:
+    """True si TOUTES les paires du cluster ont similarité ≥ threshold.
+
+    Skip le LLM pour les évidences (typos purs, variantes de casse ratées
+    par Phase 1 normalisation, orthographe US/UK collée). Threshold 97
+    capture les vrais homonymes sans risque de faux positif.
+
+    Comparaison case-insensitive : "Machine Learning" vs "Machine learning"
+    score 100 ici (la casse finale est tranchée par le LLM judge sur les
+    clusters ambigus, et par max(len) sur les clusters auto-mergés).
+
+    Note : on exige la similarité min sur TOUTES les paires (pas la moyenne)
+    pour qu'un cluster de 5 variantes avec 1 outlier ne soit pas auto-mergé.
+    """
+    n = len(variants)
+    if n < 2:
+        return True
+    lowered = [v.lower().strip() for v in variants]
+    for i in range(n):
+        for j in range(i + 1, n):
+            if fuzz.token_sort_ratio(lowered[i], lowered[j]) < threshold:
+                return False
+    return True
+
+
+def judge_cluster(variants: list[str], llm: BaseChatModel) -> JudgeResult:
+    """Appelle le LLM pour trancher members vs splits sur un cluster.
+
+    Utilise `with_structured_output(JudgeResult)` — le LLM est forcé de
+    retourner du JSON conforme au schéma Pydantic, pas de parsing manuel.
+
+    Args:
+        variants: Liste des variantes brutes (telles que retournées par
+                  le LLM Vision, casse préservée).
+        llm: Instance ChatOpenAI déjà configurée (typiquement issue de
+             agents.llm.get_agent_llm()).
+
+    Returns:
+        JudgeResult avec canonical, members, splits.
+    """
+    structured_llm = llm.with_structured_output(JudgeResult)
+    user_prompt = (
+        f"Voici {len(variants)} variantes candidates à fusion :\n\n"
+        f"{json.dumps(variants, ensure_ascii=False, indent=2)}\n\n"
+        "Tranche : quel canonical, quels members synonymes, quelles "
+        "variantes à séparer (splits)."
+    )
+    return structured_llm.invoke([
+        SystemMessage(content=_SYSTEM_PROMPT),
+        HumanMessage(content=user_prompt),
+    ])
+
+
+def _judge_cache_path(profile: str) -> Path:
+    """Chemin du cache des décisions LLM judge pour un profil."""
+    # Import local pour éviter une dépendance circulaire au import-time
+    from dashboard import data
+    return data.get_project_root() / "profiles" / profile / ".cache" / "theme-judge.json"
+
+
+def _load_judge_cache(profile: str) -> dict[str, dict]:
+    path = _judge_cache_path(profile)
+    if not path.exists():
+        return {}
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return {}
+
+
+def _save_judge_cache(profile: str, cache: dict[str, dict]) -> None:
+    path = _judge_cache_path(profile)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(cache, ensure_ascii=False, indent=2),
+        encoding="utf-8",
+    )
+
+
+def judge_clusters(
+    clusters: list[list[str]],
+    profile: str,
+    llm: BaseChatModel,
+    *,
+    auto_merge_threshold: int = 97,
+    use_cache: bool = True,
+) -> list[JudgeResult]:
+    """Pipeline complet : skip auto + cache + LLM judge.
+
+    Pour chaque cluster :
+      - 1 variante seulement → JudgeResult trivial (members = [variante]).
+      - 2+ variantes très proches (similarité ≥ auto_merge_threshold sur
+        toutes les paires) → JudgeResult auto-fusionné, pas d'appel LLM.
+      - 2+ variantes ambigües → cache lookup, sinon appel LLM, persistance.
+
+    Args:
+        clusters: Sortie de cluster_themes() — liste de listes de variantes.
+        profile: Profil pour le chemin du cache.
+        llm: ChatOpenAI prêt (typiquement get_agent_llm()).
+        auto_merge_threshold: Seuil pour skip LLM (défaut 97).
+        use_cache: Désactivable pour les tests.
+
+    Returns:
+        Liste de JudgeResult, un par cluster d'entrée (ordre préservé).
+    """
+    cache = _load_judge_cache(profile) if use_cache else {}
+    results: list[JudgeResult] = []
+    cache_dirty = False
+
+    for variants in clusters:
+        # Singleton : décision triviale
+        if len(variants) < 2:
+            results.append(JudgeResult(
+                canonical=variants[0] if variants else "",
+                members=list(variants),
+            ))
+            continue
+
+        # Skip auto sur cluster très homogène
+        if should_auto_merge(variants, threshold=auto_merge_threshold):
+            # Heuristique de canonical : la variante la plus longue (souvent
+            # la plus complète orthographiquement, ex. "Machine Learning" vs
+            # "machine learning")
+            results.append(JudgeResult(
+                canonical=max(variants, key=len),
+                members=list(variants),
+            ))
+            continue
+
+        # Cache lookup
+        key = _stable_cluster_key(variants)
+        if use_cache and key in cache:
+            results.append(JudgeResult(**cache[key]))
+            continue
+
+        # Appel LLM
+        result = judge_cluster(variants, llm)
+        if use_cache:
+            cache[key] = result.model_dump()
+            cache_dirty = True
+        results.append(result)
+
+    if cache_dirty and use_cache:
+        _save_judge_cache(profile, cache)
+
+    return results

--- a/lib/theme_normalizer.py
+++ b/lib/theme_normalizer.py
@@ -1,0 +1,179 @@
+"""Normalisation déterministe des thèmes pour dédupliquer les variantes
+orthographiques avant l'aggrégation des counts.
+
+Cible : variantes orthographiques pures (casse, ponctuation, singulier/pluriel,
+qualifiers entre parenthèses, accents), PAS les sous-spécialisations sémantiques
+(Unsupervised Machine Learning ≠ Machine Learning — laissé pour le clustering
+fuzzy + LLM judge dans les phases suivantes).
+
+Stdlib only — pas de dépendance externe. Cas particuliers gérés :
+  - Faux pluriels (Statistics, Mathematics, Physics, Analysis…) → conservés
+  - Acronymes courts → conservés (OS, DS, ML…)
+  - Stopwords FR + EN → strippés
+"""
+
+from __future__ import annotations
+
+import re
+import unicodedata
+from collections.abc import Iterable
+
+# Stopwords FR + EN courants à strip — la liste reste volontairement
+# conservatrice : on ne strip que ce qui ne porte aucun sens (déterminants,
+# prépositions). Pas de verbes (ils peuvent être discriminants).
+_STOPWORDS: frozenset[str] = frozenset({
+    "the", "a", "an", "of", "for", "and", "or", "in", "on", "to",
+    "le", "la", "les", "de", "des", "du", "et", "ou", "en", "au", "aux",
+    "by", "with",
+})
+
+# Mots à NE PAS dépluraliser. Faux pluriels (-ics, -is) et acronymes.
+_KEEP_AS_IS: frozenset[str] = frozenset({
+    # Faux pluriels en -ics
+    "physics", "mathematics", "statistics", "ethics", "robotics",
+    "linguistics", "informatics", "mechanics", "electronics", "optics",
+    "phonetics", "genetics", "economics", "politics", "ceramics",
+    "athletics", "graphics", "logistics", "metrics", "gymnastics",
+    "aerobics", "diagnostics", "academics",
+    # Faux pluriels en -is (singulier = -is, pluriel = -es)
+    "analysis", "thesis", "basis", "crisis", "hypothesis", "diagnosis",
+    "synthesis", "axis", "oasis",
+    # Mots terminant en -s qui n'ont pas de singulier
+    "news", "lens", "series", "species", "means", "physics",
+    # Acronymes ≤ 3 chars
+    "os", "ds", "ms", "us", "css", "iso", "api", "sql", "cli", "gui",
+    "ai", "ml", "nlp", "nn", "rl", "iot", "vr", "ar", "ux", "ui",
+    "rs", "go", "js", "ts",
+})
+
+# Mots dont le pluriel est irrégulier — mapping explicite singulier
+_IRREGULAR_PLURALS: dict[str, str] = {
+    "children": "child",
+    "people": "person",
+    "men": "man",
+    "women": "woman",
+    "feet": "foot",
+    "teeth": "tooth",
+    "geese": "goose",
+    "mice": "mouse",
+    "data": "data",  # data = pluriel de datum mais usage courant = invariant
+    "media": "media",
+    "criteria": "criterion",
+    "phenomena": "phenomenon",
+}
+
+
+def _strip_accents(s: str) -> str:
+    """NFKD + drop combining marks (é → e, ñ → n, ç → c…)."""
+    return "".join(
+        ch for ch in unicodedata.normalize("NFKD", s)
+        if not unicodedata.combining(ch)
+    )
+
+
+def _singularize_word(word: str) -> str:
+    """Dépluralisation d'un mot en minuscules.
+
+    Règles appliquées dans l'ordre :
+      1. Conservation des mots de _KEEP_AS_IS et des mots ≤ 3 chars
+      2. Pluriels irréguliers via _IRREGULAR_PLURALS
+      3. -ies → -y (technologies → technology)
+      4. -sses → -ss (classes → class)
+      5. -shes / -ches → strip 2 chars (bushes → bush, branches → branch)
+      6. -xes / -zes / -ses (≥ 4 chars, précédé d'une consonne) → strip 2
+      7. -s final (sauf -ss, -us, -is, -os) → strip 1
+    """
+    if word in _KEEP_AS_IS or len(word) <= 3:
+        return word
+    if word in _IRREGULAR_PLURALS:
+        return _IRREGULAR_PLURALS[word]
+    if word.endswith("ies") and len(word) > 3:
+        return word[:-3] + "y"
+    if word.endswith("sses"):
+        return word[:-2]
+    if word.endswith(("shes", "ches")):
+        return word[:-2]
+    if word.endswith(("xes", "zes", "ses")) and len(word) >= 4:
+        # boxes → box, quizzes → quiz, kisses → kiss
+        # mais cases → case (e silencieux) — heuristique : si finit par "ses"
+        # précédé d'une voyelle, on ne strip que le s final
+        if word.endswith("ses") and len(word) >= 5 and word[-4] in "aeiouy":
+            return word[:-1]
+        return word[:-2]
+    if word.endswith("s") and not word.endswith(("ss", "us", "is", "os")):
+        return word[:-1]
+    return word
+
+
+_PAREN_RE = re.compile(r"\([^)]*\)")
+_PUNCT_RE = re.compile(r"[^\w\s-]")
+_SPACE_RE = re.compile(r"\s+")
+
+
+def normalize_theme(theme: str) -> str:
+    """Normalise un thème pour dédupli syntactique.
+
+    Transformations appliquées (dans l'ordre) :
+      1. Strip accents (NFKD) — Mathématiques → Mathematiques
+      2. Lowercase
+      3. Strip parenthèses et leur contenu : 'Neural Nets (CS)' → 'neural nets'
+      4. Strip ponctuation sauf espace + tiret
+      5. Collapse les espaces multiples
+      6. Strip stopwords (the, of, le, de…)
+      7. Dépluralise chaque mot (Neural Networks → neural network)
+
+    Args:
+        theme: Le thème brut tel que retourné par le LLM Vision.
+
+    Returns:
+        La forme canonique normalisée (lowercase, mots espacés).
+        Empty string si le thème est vide ou ne contient que du bruit.
+
+    Exemples :
+        normalize_theme("Machine Learning")         == "machine learning"
+        normalize_theme("Machine learning")         == "machine learning"
+        normalize_theme("Neural Networks (CS)")     == "neural network"
+        normalize_theme("Mathématiques Appliquées") == "mathematique appliquee"
+        normalize_theme("Statistics")               == "statistics"  # faux pluriel
+    """
+    if not theme or not isinstance(theme, str):
+        return ""
+    # 1. NFKD + lowercase
+    s = _strip_accents(theme).lower()
+    # 2. Strip parenthèses (et leur contenu)
+    s = _PAREN_RE.sub(" ", s)
+    # 3. Strip ponctuation (garde lettres/chiffres/_/espace/tiret)
+    s = _PUNCT_RE.sub(" ", s)
+    # 4. Tokenize + strip stopwords + dépluralisation
+    words = [
+        _singularize_word(w)
+        for w in _SPACE_RE.split(s.strip())
+        if w and w not in _STOPWORDS
+    ]
+    return " ".join(words)
+
+
+def normalize_themes_batch(themes: Iterable[str]) -> dict[str, str]:
+    """Normalise un lot de thèmes et retourne `{raw_theme: canonical_form}`.
+
+    Préserve l'ordre d'itération de l'input. Skip les thèmes vides.
+    """
+    return {t: normalize_theme(t) for t in themes if t}
+
+
+def group_by_canonical(themes: Iterable[str]) -> dict[str, list[str]]:
+    """Regroupe les thèmes par leur forme canonique.
+
+    Returns:
+        `{canonical_form: [raw_theme, raw_theme, ...]}` — un cluster par
+        forme canonique. Les thèmes qui se normalisent à "" sont skippés.
+    """
+    groups: dict[str, list[str]] = {}
+    for raw in themes:
+        if not raw:
+            continue
+        canon = normalize_theme(raw)
+        if not canon:
+            continue
+        groups.setdefault(canon, []).append(raw)
+    return groups

--- a/lib/theme_normalizer.py
+++ b/lib/theme_normalizer.py
@@ -177,3 +177,146 @@ def group_by_canonical(themes: Iterable[str]) -> dict[str, list[str]]:
             continue
         groups.setdefault(canon, []).append(raw)
     return groups
+
+
+# ─── Phase 2 — Clustering fuzzy ────────────────────────────────────────────
+
+# Seuil de similarité par défaut (token_sort_ratio sur formes canoniques).
+# Calibré sur des cas réels du profil default (15 376 thèmes uniques) :
+#   - 93-98 : vrais doublons (search engine optimization vs optimisation,
+#     web application development vs web and application development)
+#   - 71-80 : sous-domaines (unsupervised machine learning vs machine
+#     learning, statistical learning vs statistical modeling)
+#
+# Échantillonnage qualitatif à threshold 90 : 1 280 clusters multi-variantes
+# (14.7% reduction) mais nombreux faux positifs observés sur les thèmes
+# longs partageant un mot dominant (ex. "Java EE Development" + "JavaFX
+# Development" + "Java ME Development" → fusion incorrecte ; "Windows 10
+# OS" + "Windows XP OS" → fusion incorrecte). token_sort_ratio sur-pondère
+# les mots communs longs.
+#
+# À threshold 92, ces cas évidents disparaissent (1 160 clusters, 11.3% red.)
+# au prix d'un léger sous-ajustement compensé par Phase 3 (LLM judge).
+# Choix : 92 par défaut, le LLM judge tranchera les cas frontières.
+_DEFAULT_CLUSTER_THRESHOLD = 92
+
+
+def cluster_canonical_forms(
+    forms: list[str],
+    *,
+    threshold: int = _DEFAULT_CLUSTER_THRESHOLD,
+    top_k: int = 15,
+) -> list[list[str]]:
+    """Regroupe les formes canoniques par similarité fuzzy via union-find.
+
+    Algorithme : pour chaque forme, `rapidfuzz.process.extract` retourne ses
+    top-k voisins ayant `token_sort_ratio ≥ threshold`. Les paires obtenues
+    déclenchent un union-find. Complexité ~O(n × k) avec k constant.
+
+    Args:
+        forms: Liste de formes canoniques (lowercase, déjà normalisées via
+               `normalize_theme`). Si on lui passe des thèmes bruts, les
+               différences de casse polluent le scoring.
+        threshold: Score minimum pour considérer deux formes équivalentes
+                   (0-100, défaut 90).
+        top_k: Nombre max de voisins examinés par forme (défaut 15). Augmenter
+               si on s'attend à des clusters > 15 variantes.
+
+    Returns:
+        Liste de clusters, chaque cluster = liste des formes qui s'y
+        rattachent. Les formes seules apparaissent comme un cluster de
+        taille 1. L'ordre des clusters et leur composition interne ne sont
+        pas garantis stables.
+    """
+    from rapidfuzz import fuzz, process
+
+    n = len(forms)
+    if n == 0:
+        return []
+
+    # Union-find (path compression, sans union-by-rank — pas nécessaire pour n petit)
+    parent = list(range(n))
+
+    def find(x: int) -> int:
+        while parent[x] != x:
+            parent[x] = parent[parent[x]]
+            x = parent[x]
+        return x
+
+    def union(a: int, b: int) -> None:
+        ra, rb = find(a), find(b)
+        if ra != rb:
+            parent[ra] = rb
+
+    # Pour chaque forme, trouver les voisins ≥ threshold et fusionner
+    for i in range(n):
+        matches = process.extract(
+            forms[i], forms,
+            scorer=fuzz.token_sort_ratio,
+            limit=top_k,
+            score_cutoff=threshold,
+        )
+        for _matched_form, _score, j in matches:
+            if j != i:
+                union(i, j)
+
+    # Reconstruction des clusters
+    by_root: dict[int, list[str]] = {}
+    for i in range(n):
+        by_root.setdefault(find(i), []).append(forms[i])
+    return list(by_root.values())
+
+
+def cluster_themes(
+    raw_themes: Iterable[str],
+    *,
+    threshold: int = _DEFAULT_CLUSTER_THRESHOLD,
+    top_k: int = 15,
+) -> list[dict]:
+    """Pipeline complet : raw_themes → clusters fuzzy.
+
+    Combine Phase 1 (normalisation déterministe via `group_by_canonical`)
+    et Phase 2 (clustering fuzzy sur les formes canoniques). Le bénéfice
+    de Phase 2 par rapport à Phase 1 est de récupérer les variantes qui
+    survivent à la normalisation (typos, mots de tail différents, ordre
+    de tokens).
+
+    Args:
+        raw_themes: Itérable de thèmes bruts (tels que retournés par le LLM).
+        threshold: Score fuzzy minimum (défaut 90, cf. _DEFAULT_CLUSTER_THRESHOLD).
+        top_k: Nombre max de voisins par forme (défaut 15).
+
+    Returns:
+        Liste de clusters, chacun de la forme :
+        ```
+        {
+            "canonical_forms": ["machine learning", "machine learnings"],
+            "raw_members": ["Machine Learning", "Machine learning",
+                            "machine learnings"],
+        }
+        ```
+        Trié par taille décroissante (gros clusters en premier).
+    """
+    # Étage 1 : group_by_canonical (déterministe)
+    by_canon = group_by_canonical(raw_themes)
+    canonical_forms = list(by_canon.keys())
+
+    # Étage 2 : clustering fuzzy sur les formes canoniques
+    fuzzy_clusters = cluster_canonical_forms(
+        canonical_forms, threshold=threshold, top_k=top_k,
+    )
+
+    # Reconstruction : pour chaque cluster fuzzy, agréger les raw_members
+    # de toutes les formes canoniques qui le composent.
+    result: list[dict] = []
+    for cluster_forms in fuzzy_clusters:
+        raw_members: list[str] = []
+        for canon in cluster_forms:
+            raw_members.extend(by_canon[canon])
+        result.append({
+            "canonical_forms": list(cluster_forms),
+            "raw_members": raw_members,
+        })
+    # Tri par nombre total de variantes brutes (impact business)
+    result.sort(key=lambda c: -len(c["raw_members"]))
+    return result

--- a/lib/theme_resolver.py
+++ b/lib/theme_resolver.py
@@ -169,19 +169,48 @@ FUSION OK (vers une entrée du vocabulaire) :
 - Variante casse/pluriel/ortho US-UK seule ("ML" → si vocab a "Machine Learning")
 - Acronyme = développé, CONFIRMÉ par titres ("ML" + titres parlant de Machine
   Learning → fusion. "AI" + titres "Artificial Insemination" → identité.)
-- Reformulation sans perte ("Web Dev with Java" ↔ "Java Web Dev")
+- Reformulation pure sans ajout de qualifier ("Web Dev with Java" peut être
+  fusionné avec "Java Web Dev" car mêmes mots)
 
-NE PAS FUSIONNER (canonical = raw) :
-- Sous-domaines ("Unsupervised Machine Learning" ≠ "Machine Learning")
-- Concepts liés distincts (Logic ≠ Math, Big Data ≠ Data Science, Penetration
-  Testing ≠ Information Security, Quantum Physics ≠ Quantum Mechanics)
-- Versions/plateformes différentes (iOS App Dev ≠ Mobile App Dev)
-- "X for Y" ≠ "X" seul (Statistics for Data Science ≠ Statistics)
+NE PAS FUSIONNER (canonical = raw) — INTERDICTION ABSOLUE pour ces patterns :
 
-Les titres aident à : confirmer un acronyme, désambiguïser un homonyme.
+✗ Toute composition "X with Y", "X with Z" → reste distincte de "X" :
+  "Web Development with .NET" ≠ "Web Development"
+  "Web Development with ASP.NET" ≠ "Web Development"
+  "Mathematics for BCPST" ≠ "Mathematics"
+  "Statistics for Data Science" ≠ "Statistics"
+
+✗ Toute composition "X (Y)" ou "X / Y" → reste distincte de "X" :
+  "Mathematical Analysis (Discrete)" ≠ "Mathematical Analysis"
+  "Artificial Intelligence / Machine Learning" ≠ "Artificial Intelligence"
+
+✗ Tout qualifier ajouté ("Advanced", "Modern", "Applied", "Introduction to",
+  numéro de version) → reste distinct :
+  "Advanced Java Programming" ≠ "Java Programming"
+  "Modern Web Development with JavaScript" ≠ "Web Development"
+  "Java 8 Programming" ≠ "Java Programming"
+  "Python 3 Programming" ≠ "Python Programming"
+
+✗ Sous-domaine ou spécialisation thématique :
+  "Unsupervised Machine Learning" ≠ "Machine Learning"
+  "Cloud Big Data" ≠ "Cloud Computing"
+  "Cloud Application Deployment" ≠ "Cloud Computing"
+
+✗ Concepts liés mais distincts :
+  Logic ≠ Math, Big Data ≠ Data Science, Penetration Testing ≠
+  Information Security, Quantum Physics ≠ Quantum Mechanics
+
+✗ Versions/plateformes différentes :
+  iOS App Dev ≠ Mobile App Dev
+
+Les titres servent à : confirmer un acronyme, désambiguïser un homonyme.
 Si titres ne correspondent pas au sens du canonical → ne fusionne PAS.
 
 PRINCIPE : sur-fusion >> sous-fusion en gravité. En cas de doute → identité.
+Si le raw contient un mot que le canonical ne contient PAS (qualifier ajouté
+type "with", "for", "Advanced", numéro), c'est PROBABLEMENT un sous-domaine
+→ identité par défaut.
+
 Canonical en Title Case quand fusion vers vocab. Sinon raw tel quel."""
 
 

--- a/lib/theme_resolver.py
+++ b/lib/theme_resolver.py
@@ -160,73 +160,29 @@ class BatchResolution(BaseModel):
     )
 
 
-_SYSTEM_PROMPT = """Tu es un expert en taxonomie qui consolide UNIQUEMENT les \
-variantes orthographiques et synonymes EXACTS de thèmes d'une bibliothèque PDF.
+_SYSTEM_PROMPT = """Tu canonises des thèmes de bibliothèque PDF. Pour chaque \
+thème brut, choisis canonical :
 
-═══════ CONTEXTE FOURNI ═══════
+DÉFAUT = raw (matched_existing=False). Ne fusionne QUE pour ces cas :
 
-Pour chaque thème brut, tu reçois jusqu'à 5 titres représentatifs de livres
-de la bibliothèque taggés avec ce thème. Utilise ces titres pour comprendre
-le SENS RÉEL du thème dans son contexte d'usage avant de décider.
+FUSION OK (vers une entrée du vocabulaire) :
+- Variante casse/pluriel/ortho US-UK seule ("ML" → si vocab a "Machine Learning")
+- Acronyme = développé, CONFIRMÉ par titres ("ML" + titres parlant de Machine
+  Learning → fusion. "AI" + titres "Artificial Insemination" → identité.)
+- Reformulation sans perte ("Web Dev with Java" ↔ "Java Web Dev")
 
-═══════ PRINCIPE FONDAMENTAL ═══════
+NE PAS FUSIONNER (canonical = raw) :
+- Sous-domaines ("Unsupervised Machine Learning" ≠ "Machine Learning")
+- Concepts liés distincts (Logic ≠ Math, Big Data ≠ Data Science, Penetration
+  Testing ≠ Information Security, Quantum Physics ≠ Quantum Mechanics)
+- Versions/plateformes différentes (iOS App Dev ≠ Mobile App Dev)
+- "X for Y" ≠ "X" seul (Statistics for Data Science ≠ Statistics)
 
-Par DÉFAUT garde le thème tel quel (canonical = raw, matched_existing=False).
-Ne fusionne que dans les cas listés ci-dessous.
+Les titres aident à : confirmer un acronyme, désambiguïser un homonyme.
+Si titres ne correspondent pas au sens du canonical → ne fusionne PAS.
 
-L'erreur la plus grave est la SUR-FUSION (mélanger des concepts distincts).
-Une fragmentation est facilement réparable par l'utilisateur, une sur-fusion
-fait perdre de l'information de façon irréversible.
-
-═══════ CAS OÙ TU DOIS FUSIONNER (canonical = entrée du vocabulaire) ═══════
-
-UNIQUEMENT si le thème brut ET ses titres montrent qu'il est strictement
-équivalent à un canonical du vocabulaire :
-
-  1. Variante de casse SEULE : "Machine Learning" / "machine learning"
-  2. Variante de pluriel/singulier SEULE : "Neural Networks" / "Neural Network"
-  3. Orthographe US/UK SEULE : "Optimization" / "Optimisation"
-  4. Acronyme strict = développé connu, CONFIRMÉ par les titres : "ML" + titres
-     "Introduction to Machine Learning" → "Machine Learning". MAIS si le thème
-     est "ML" et les titres parlent de "Mailing List", ne fusionne PAS.
-  5. Reformulation pure SANS perte de sens : "Web Development with Java" ↔
-     "Java Web Development" (mêmes mots dans un autre ordre).
-
-═══════ CAS OÙ TU NE DOIS PAS FUSIONNER (canonical = raw) ═══════
-
-✗ Sous-domaine ou spécialisation : "Unsupervised Machine Learning" ≠
-  "Machine Learning". Garde le raw.
-✗ Concept lié mais distinct : "Logic" ≠ "Mathematics". "Cognitive Science"
-  ≠ "Artificial Intelligence". "Big Data" ≠ "Data Science". "Computer
-  Security" ≠ "Information Security". "Penetration Testing" ≠ "Information
-  Security" (cas particulier d'une catégorie n'EST PAS la catégorie).
-✗ Inclusion conceptuelle : "Retro computing" ≠ "History of Science",
-  même si lié.
-✗ Versions, plateformes, technologies différentes : "iOS Application
-  Development" ≠ "Mobile Application Development". "Quantum Physics" ≠
-  "Quantum Mechanics" en physique théorique.
-✗ Compositions "X for Y" ≠ "X" seul : "Statistics for Data Science" reste
-  distinct de "Statistics".
-
-═══════ UTILISATION DES TITRES ═══════
-
-Les titres servent à 3 choses :
-  a) Confirmer un acronyme ambigu : "ML" + "Pattern Recognition and Machine
-     Learning" → confirmé Machine Learning. "AI" + "Artificial Insemination
-     in Cattle" → PAS Artificial Intelligence.
-  b) Désambiguïser un homonyme : "Logic" + titres logique formelle (livres
-     "A First Course in Logic", "Mathematical Logic") → "Logic" reste
-     "Logic" (pas Math, pas Philosophy).
-  c) Détecter un titre individuel mal taggé comme thème : si un thème est
-     exactement le titre d'un livre, garde-le tel quel.
-
-Si les titres NE CORRESPONDENT PAS au sens d'un canonical du vocabulaire,
-ne fusionne PAS.
-
-═══════ FORMAT ═══════
-
-Le `canonical` doit être en Title Case propre quand il vient du vocabulaire.
-Quand tu gardes le raw (matched_existing=False), restitue-le tel quel."""
+PRINCIPE : sur-fusion >> sous-fusion en gravité. En cas de doute → identité.
+Canonical en Title Case quand fusion vers vocab. Sinon raw tel quel."""
 
 
 def _stable_batch_key(
@@ -303,6 +259,29 @@ def _build_user_prompt(
     )
 
 
+def _ensure_non_streaming(llm: BaseChatModel) -> BaseChatModel:
+    """Désactive streaming sur une copie du LLM si besoin (ChatOpenAI seul).
+
+    Justification : en mode `function_calling`, le tool_call complet arrive
+    en bloc → pas de chunks intermédiaires émis pendant la phase de génération.
+    Avec streaming=True (défaut de get_agent_llm pour Phase B), SiliconFlow
+    disconnect serveur-side à ~85-90s si aucun chunk reçu. En streaming=False,
+    le serveur attend de finir et envoie tout d'un coup → pas de timeout.
+
+    Restreint à ChatOpenAI pour ne pas perturber les mocks dans les tests
+    (un MagicMock répond truthy à n'importe quel getattr).
+    """
+    from langchain_openai import ChatOpenAI
+    if not isinstance(llm, ChatOpenAI):
+        return llm
+    if not getattr(llm, "streaming", False):
+        return llm
+    try:
+        return llm.model_copy(update={"streaming": False})
+    except Exception:  # noqa: BLE001
+        return llm
+
+
 def resolve_batch(
     batch: list[tuple[str, list[str]]],
     vocabulary: list[str],
@@ -310,14 +289,15 @@ def resolve_batch(
 ) -> dict[str, str]:
     """Appelle le LLM sur un batch (theme + titres) → {raw: canonical}.
 
-    Utilise `with_structured_output(BatchResolution, method="function_calling")`.
-    GLM-4.7 ne supporte pas json mode → on force function_calling.
+    Utilise `with_structured_output(BatchResolution, method="function_calling")`
+    avec streaming désactivé (cf. _ensure_non_streaming pour le rationale).
 
     Filet de sécurité : si le LLM omet certains thèmes → identité par défaut.
     """
     if not batch:
         return {}
-    structured_llm = llm.with_structured_output(
+    no_stream_llm = _ensure_non_streaming(llm)
+    structured_llm = no_stream_llm.with_structured_output(
         BatchResolution, method="function_calling",
     )
     result = structured_llm.invoke([

--- a/lib/theme_resolver.py
+++ b/lib/theme_resolver.py
@@ -21,8 +21,16 @@ Pipeline (orchestré par lib.theme_canon.build_canon_table(mode="source")) :
 
 from __future__ import annotations
 
+import hashlib
+import json
+import threading
 from collections import defaultdict
-from collections.abc import Iterable
+from collections.abc import Callable, Iterable
+from concurrent.futures import ThreadPoolExecutor, as_completed
+
+from langchain_core.language_models import BaseChatModel
+from langchain_core.messages import HumanMessage, SystemMessage
+from pydantic import BaseModel, Field
 
 from lib.theme_canon import _parse_cached_result, _vision_cache_path
 
@@ -127,3 +135,298 @@ def themes_with_titles_iter(
     déterminisme des batches et du cache."""
     for theme in sorted(themes_titles.keys()):
         yield theme, themes_titles[theme]
+
+
+# ─── D.2 — LLM resolver avec contexte titres ───────────────────────────────
+
+
+class ResolvedTheme(BaseModel):
+    """Décision LLM pour 1 thème (avec ses titres en contexte)."""
+
+    raw: str = Field(description="Le thème brut tel qu'envoyé en input")
+    canonical: str = Field(
+        description="Le canonical choisi (depuis le vocabulaire OU raw lui-même)"
+    )
+    matched_existing: bool = Field(
+        description="True si canonical est dans le vocabulaire de référence"
+    )
+
+
+class BatchResolution(BaseModel):
+    """Sortie LLM pour un batch de thèmes-avec-titres."""
+
+    mappings: list[ResolvedTheme] = Field(
+        description="Un mapping par thème en input — l'ordre doit être préservé"
+    )
+
+
+_SYSTEM_PROMPT = """Tu es un expert en taxonomie qui consolide UNIQUEMENT les \
+variantes orthographiques et synonymes EXACTS de thèmes d'une bibliothèque PDF.
+
+═══════ CONTEXTE FOURNI ═══════
+
+Pour chaque thème brut, tu reçois jusqu'à 5 titres représentatifs de livres
+de la bibliothèque taggés avec ce thème. Utilise ces titres pour comprendre
+le SENS RÉEL du thème dans son contexte d'usage avant de décider.
+
+═══════ PRINCIPE FONDAMENTAL ═══════
+
+Par DÉFAUT garde le thème tel quel (canonical = raw, matched_existing=False).
+Ne fusionne que dans les cas listés ci-dessous.
+
+L'erreur la plus grave est la SUR-FUSION (mélanger des concepts distincts).
+Une fragmentation est facilement réparable par l'utilisateur, une sur-fusion
+fait perdre de l'information de façon irréversible.
+
+═══════ CAS OÙ TU DOIS FUSIONNER (canonical = entrée du vocabulaire) ═══════
+
+UNIQUEMENT si le thème brut ET ses titres montrent qu'il est strictement
+équivalent à un canonical du vocabulaire :
+
+  1. Variante de casse SEULE : "Machine Learning" / "machine learning"
+  2. Variante de pluriel/singulier SEULE : "Neural Networks" / "Neural Network"
+  3. Orthographe US/UK SEULE : "Optimization" / "Optimisation"
+  4. Acronyme strict = développé connu, CONFIRMÉ par les titres : "ML" + titres
+     "Introduction to Machine Learning" → "Machine Learning". MAIS si le thème
+     est "ML" et les titres parlent de "Mailing List", ne fusionne PAS.
+  5. Reformulation pure SANS perte de sens : "Web Development with Java" ↔
+     "Java Web Development" (mêmes mots dans un autre ordre).
+
+═══════ CAS OÙ TU NE DOIS PAS FUSIONNER (canonical = raw) ═══════
+
+✗ Sous-domaine ou spécialisation : "Unsupervised Machine Learning" ≠
+  "Machine Learning". Garde le raw.
+✗ Concept lié mais distinct : "Logic" ≠ "Mathematics". "Cognitive Science"
+  ≠ "Artificial Intelligence". "Big Data" ≠ "Data Science". "Computer
+  Security" ≠ "Information Security". "Penetration Testing" ≠ "Information
+  Security" (cas particulier d'une catégorie n'EST PAS la catégorie).
+✗ Inclusion conceptuelle : "Retro computing" ≠ "History of Science",
+  même si lié.
+✗ Versions, plateformes, technologies différentes : "iOS Application
+  Development" ≠ "Mobile Application Development". "Quantum Physics" ≠
+  "Quantum Mechanics" en physique théorique.
+✗ Compositions "X for Y" ≠ "X" seul : "Statistics for Data Science" reste
+  distinct de "Statistics".
+
+═══════ UTILISATION DES TITRES ═══════
+
+Les titres servent à 3 choses :
+  a) Confirmer un acronyme ambigu : "ML" + "Pattern Recognition and Machine
+     Learning" → confirmé Machine Learning. "AI" + "Artificial Insemination
+     in Cattle" → PAS Artificial Intelligence.
+  b) Désambiguïser un homonyme : "Logic" + titres logique formelle (livres
+     "A First Course in Logic", "Mathematical Logic") → "Logic" reste
+     "Logic" (pas Math, pas Philosophy).
+  c) Détecter un titre individuel mal taggé comme thème : si un thème est
+     exactement le titre d'un livre, garde-le tel quel.
+
+Si les titres NE CORRESPONDENT PAS au sens d'un canonical du vocabulaire,
+ne fusionne PAS.
+
+═══════ FORMAT ═══════
+
+Le `canonical` doit être en Title Case propre quand il vient du vocabulaire.
+Quand tu gardes le raw (matched_existing=False), restitue-le tel quel."""
+
+
+def _stable_batch_key(
+    batch: list[tuple[str, list[str]]],
+    vocabulary: list[str],
+) -> str:
+    """Hash stable d'un batch (theme + titres) + vocab — clé de cache.
+
+    L'ordre du batch importe (le LLM produit mappings[] ordonnés).
+    Le vocab est trié pour éliminer l'influence de son ordre.
+    Les titres dans chaque entrée du batch sont triés pour qu'on hit le
+    cache même si l'ordre de collecte des titres varie d'une run à l'autre.
+    """
+    canonical = [
+        (theme, sorted(titles)) for theme, titles in batch
+    ]
+    payload = json.dumps(
+        {"batch": canonical, "vocab": sorted(vocabulary)},
+        ensure_ascii=False,
+    )
+    return hashlib.sha256(payload.encode("utf-8")).hexdigest()[:16]
+
+
+def _resolver_cache_path(profile: str):
+    from dashboard import data
+    return (
+        data.get_project_root()
+        / "profiles" / profile / ".cache" / "theme-resolver.json"
+    )
+
+
+def _load_resolver_cache(profile: str) -> dict[str, dict]:
+    path = _resolver_cache_path(profile)
+    if not path.exists():
+        return {}
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return {}
+
+
+def _save_resolver_cache(profile: str, cache: dict[str, dict]) -> None:
+    path = _resolver_cache_path(profile)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(cache, ensure_ascii=False, indent=2),
+        encoding="utf-8",
+    )
+
+
+def _build_user_prompt(
+    batch: list[tuple[str, list[str]]],
+    vocabulary: list[str],
+) -> str:
+    """Construit le HumanMessage pour un batch (theme + titres)."""
+    vocab_block = "\n".join(f"  - {v}" for v in vocabulary)
+    entries: list[str] = []
+    for i, (theme, titles) in enumerate(batch, 1):
+        title_lines = "\n".join(f"    - {t!r}" for t in titles)
+        if not title_lines:
+            title_lines = "    (aucun titre disponible)"
+        entries.append(
+            f"Thème {i} : {theme!r}\n"
+            f"  Titres représentatifs ({len(titles)}) :\n"
+            f"{title_lines}"
+        )
+    entries_block = "\n\n".join(entries)
+    return (
+        f"Vocabulaire de référence ({len(vocabulary)} canoniques) :\n"
+        f"{vocab_block}\n\n"
+        f"Thèmes à canoniser ({len(batch)}) — produis un `mapping` par thème "
+        "dans l'ordre :\n\n"
+        f"{entries_block}"
+    )
+
+
+def resolve_batch(
+    batch: list[tuple[str, list[str]]],
+    vocabulary: list[str],
+    llm: BaseChatModel,
+) -> dict[str, str]:
+    """Appelle le LLM sur un batch (theme + titres) → {raw: canonical}.
+
+    Utilise `with_structured_output(BatchResolution, method="function_calling")`.
+    GLM-4.7 ne supporte pas json mode → on force function_calling.
+
+    Filet de sécurité : si le LLM omet certains thèmes → identité par défaut.
+    """
+    if not batch:
+        return {}
+    structured_llm = llm.with_structured_output(
+        BatchResolution, method="function_calling",
+    )
+    result = structured_llm.invoke([
+        SystemMessage(content=_SYSTEM_PROMPT),
+        HumanMessage(content=_build_user_prompt(batch, vocabulary)),
+    ])
+    by_raw: dict[str, str] = {}
+    for pair in result.mappings:
+        if pair.raw in by_raw:
+            continue
+        canonical = (pair.canonical or "").strip() or pair.raw
+        by_raw[pair.raw] = canonical
+    # Filet de sécurité : thème oublié → identité
+    for theme, _ in batch:
+        by_raw.setdefault(theme, theme)
+    return by_raw
+
+
+def resolve_themes_with_context(
+    themes_titles: dict[str, list[str]],
+    vocabulary: list[str],
+    llm: BaseChatModel,
+    profile: str,
+    *,
+    batch_size: int = 30,
+    max_workers: int = 8,
+    use_cache: bool = True,
+    on_progress: Callable[[int, int], None] | None = None,
+) -> dict[str, str]:
+    """Pipeline complet de canonisation contextuelle (C.2).
+
+    Pour chaque thème, le LLM voit le thème + 5 titres représentatifs et
+    décide canonical (depuis vocabulary OU lui-même). Les thèmes déjà dans
+    `vocabulary` sont identité (skip LLM).
+
+    Args:
+        themes_titles: {raw_theme: [title_1, ..., title_5]} — sortie de
+                       extract_themes_with_titles().
+        vocabulary: Vocabulaire de référence (sortie de build_vocabulary
+                    côté theme_canonicalizer).
+        llm: ChatOpenAI configuré.
+        profile: Pour la persistance du cache.
+        batch_size: Thèmes par appel LLM (défaut 30).
+        max_workers: Threads parallèles (défaut 8).
+        use_cache: Désactivable pour les tests.
+        on_progress: Callback `(done_batches, total_batches)`.
+
+    Returns:
+        Dict {raw_theme: canonical} couvrant TOUS les thèmes en entrée.
+    """
+    if not themes_titles:
+        return {}
+
+    vocab_set = set(vocabulary)
+    # Identité pour thèmes déjà dans vocab — pas d'appel LLM
+    result: dict[str, str] = {
+        t: t for t in themes_titles if t in vocab_set
+    }
+    # Itère en ordre lexico stable (déterminisme batches + cache)
+    to_process: list[tuple[str, list[str]]] = [
+        (theme, themes_titles[theme])
+        for theme in sorted(themes_titles.keys())
+        if theme not in vocab_set
+    ]
+
+    if not to_process:
+        if on_progress is not None:
+            on_progress(0, 0)
+        return result
+
+    batches: list[list[tuple[str, list[str]]]] = [
+        to_process[i:i + batch_size]
+        for i in range(0, len(to_process), batch_size)
+    ]
+    total_batches = len(batches)
+
+    cache = _load_resolver_cache(profile) if use_cache else {}
+    lock = threading.Lock()
+    cache_dirty = False
+    done = 0
+
+    def process_one(
+        batch: list[tuple[str, list[str]]],
+    ) -> tuple[str, dict[str, str]]:
+        key = _stable_batch_key(batch, vocabulary)
+        if use_cache and key in cache:
+            return key, dict(cache[key])
+        mapping = resolve_batch(batch, vocabulary, llm)
+        return key, mapping
+
+    with ThreadPoolExecutor(max_workers=max_workers) as executor:
+        futures = {executor.submit(process_one, b): b for b in batches}
+        for future in as_completed(futures):
+            try:
+                key, batch_mapping = future.result()
+            except Exception:  # noqa: BLE001 — fallback identité par batch
+                batch = futures[future]
+                key = _stable_batch_key(batch, vocabulary)
+                batch_mapping = {theme: theme for theme, _ in batch}
+            with lock:
+                result.update(batch_mapping)
+                if use_cache:
+                    cache[key] = batch_mapping
+                    cache_dirty = True
+                done += 1
+                if on_progress is not None:
+                    on_progress(done, total_batches)
+
+    if cache_dirty and use_cache:
+        _save_resolver_cache(profile, cache)
+
+    return result

--- a/lib/theme_resolver.py
+++ b/lib/theme_resolver.py
@@ -1,0 +1,129 @@
+"""C.2 — Canonisation contextuelle des thèmes via LLM texte avec titres en contexte.
+
+Différence avec lib.theme_canonicalizer (C-light "blind") :
+  - C-light : (raw_theme) → canonical, le LLM décide à l'aveugle
+  - C.2 (this) : (raw_theme, N titres représentatifs) → canonical, le LLM
+    désambiguïse en voyant le contexte d'usage du thème dans la bibliothèque.
+
+Le LLM peut ainsi distinguer un thème "Logic" :
+  - Si les livres taggés sont "Foundations of Computer Logic", "Logic
+    Programming with Prolog" → canonical "Logic" (informatique)
+  - Si "Aristotle's Metaphysics", "Philosophy of Logic" → canonical "Logic"
+    aussi mais le LLM voit le contexte philosophique
+  - Pas de confusion avec "Mathematics" (l'erreur principale du run C-light v1)
+
+Pipeline (orchestré par lib.theme_canon.build_canon_table(mode="source")) :
+  1. extract_themes_with_titles(profile) — collecte les 5 titres par thème
+  2. resolve_themes_with_context(themes_titles, vocabulary, llm) — LLM
+  3. (côté theme_canon) re-clustering via cluster_themes pour gommer les
+     doublons de canoniques produits par batches différents
+"""
+
+from __future__ import annotations
+
+from collections import defaultdict
+from collections.abc import Iterable
+
+from lib.theme_canon import _parse_cached_result, _vision_cache_path
+
+# Nombre de titres représentatifs collectés par thème (décision design 2026-05-29)
+TITLES_PER_THEME = 5
+
+
+def extract_themes_with_titles(profile: str) -> dict[str, list[str]]:
+    """Pour chaque raw_theme du vision_cache, collecte jusqu'à 5 titres
+    représentatifs (les premiers rencontrés dans l'ordre du cache).
+
+    Le contexte des titres permet au LLM (en aval) de désambiguïser le
+    sens d'un thème ambigu (Logic, Statistics, Big Data, History, …).
+
+    Args:
+        profile: Nom du profil.
+
+    Returns:
+        Dict {raw_theme: [title_1, ..., title_N]} avec N ≤ 5.
+        Les titres sont uniques par thème et préservent l'ordre du cache.
+        Profils sans vision_cache → dict vide.
+    """
+    path = _vision_cache_path(profile)
+    if not path.exists():
+        return {}
+    import json
+    try:
+        cache = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return {}
+
+    by_theme: dict[str, list[str]] = defaultdict(list)
+    seen: dict[str, set[str]] = defaultdict(set)
+
+    for entry in cache.values():
+        if not isinstance(entry, dict):
+            continue
+        result = _parse_cached_result(entry.get("result"))
+        if not isinstance(result, dict):
+            continue
+        title = str(result.get("title") or "").strip()
+        if not title:
+            continue
+        for t in result.get("themes", []) or []:
+            name = ""
+            if isinstance(t, dict):
+                name = str(t.get("theme") or "").strip()
+            elif isinstance(t, str):
+                name = t.strip()
+            if not name:
+                continue
+            # Skip si on a déjà 5 titres pour ce thème (premier-arrivé)
+            if len(by_theme[name]) >= TITLES_PER_THEME:
+                continue
+            # Skip si ce titre est déjà associé au thème (dédup)
+            if title in seen[name]:
+                continue
+            seen[name].add(title)
+            by_theme[name].append(title)
+
+    return dict(by_theme)
+
+
+def count_themes(profile: str) -> dict[str, int]:
+    """Compte le nombre d'occurrences de chaque raw_theme dans le vision_cache.
+
+    Helper séparé de `extract_themes_with_titles` car les usages diffèrent :
+    le count sert au vocabulary bootstrap (top-N par fréquence), les titres
+    servent au contexte LLM.
+    """
+    path = _vision_cache_path(profile)
+    if not path.exists():
+        return {}
+    import json
+    try:
+        cache = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return {}
+
+    counts: dict[str, int] = {}
+    for entry in cache.values():
+        if not isinstance(entry, dict):
+            continue
+        result = _parse_cached_result(entry.get("result"))
+        if not isinstance(result, dict):
+            continue
+        for t in result.get("themes", []) or []:
+            name = ""
+            if isinstance(t, dict):
+                name = str(t.get("theme") or "").strip()
+            elif isinstance(t, str):
+                name = t.strip()
+            if name:
+                counts[name] = counts.get(name, 0) + 1
+    return counts
+
+
+def themes_with_titles_iter(
+    themes_titles: dict[str, list[str]],
+) -> Iterable[tuple[str, list[str]]]:
+    """Itérateur stable (theme, titles) sur les thèmes — ordre lexico pour
+    déterminisme des batches et du cache."""
+    for theme in sorted(themes_titles.keys()):
+        yield theme, themes_titles[theme]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ dependencies = [
     "pyspellchecker>=0.9.0",
     "langgraph>=0.2.0",
     "langchain-openai>=0.2.0",
+    "rapidfuzz>=3.10.0",
 ]
 
 [tool.ruff]

--- a/tests/auto/test_dedupli_endpoint.py
+++ b/tests/auto/test_dedupli_endpoint.py
@@ -287,6 +287,55 @@ class TestStartDedupli(_DedupliBase):
             time.sleep(0.2)
 
 
+class TestRestoreInitial(_DedupliBase):
+    def _write_canon(self):
+        p = self.tmp / "profiles" / "p" / ".cache" / "theme-canon.json"
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text(json.dumps({"version": 2, "mapping": {"A": "B"}}),
+                     encoding="utf-8")
+        return p
+
+    def test_restore_removes_canon_file(self):
+        p = self._write_canon()
+        self.assertTrue(p.exists())
+        r = self.client.post(
+            "/api/taxonomy/dedupli/restore",
+            json={"profile": "p"},
+        )
+        self.assertEqual(r.status_code, 200)
+        self.assertEqual(r.json()["restored"], True)
+        self.assertFalse(p.exists())
+
+    def test_restore_idempotent_when_no_canon(self):
+        r = self.client.post(
+            "/api/taxonomy/dedupli/restore",
+            json={"profile": "p"},
+        )
+        self.assertEqual(r.status_code, 200)
+        self.assertEqual(r.json()["restored"], False)
+
+    def test_restore_400_if_no_profile(self):
+        r = self.client.post(
+            "/api/taxonomy/dedupli/restore",
+            json={},
+        )
+        self.assertEqual(r.status_code, 400)
+
+    def test_restore_409_if_run_in_progress(self):
+        self._write_canon()
+        status_path = self.tmp / "profiles" / "p" / ".cache" / "dedupli" / "status.json"
+        status_path.parent.mkdir(parents=True, exist_ok=True)
+        status_path.write_text(json.dumps({
+            "status": "running",
+            "started_at": "2026-05-28T00:00:00+00:00",
+        }), encoding="utf-8")
+        r = self.client.post(
+            "/api/taxonomy/dedupli/restore",
+            json={"profile": "p"},
+        )
+        self.assertEqual(r.status_code, 409)
+
+
 class TestCancelDedupli(_DedupliBase):
     def _write_status(self, status_val: str, cancel_requested: bool = False):
         path = self.tmp / "profiles" / "p" / ".cache" / "dedupli" / "status.json"

--- a/tests/auto/test_dedupli_endpoint.py
+++ b/tests/auto/test_dedupli_endpoint.py
@@ -336,6 +336,30 @@ class TestRestoreInitial(_DedupliBase):
         self.assertEqual(r.status_code, 409)
 
 
+class TestSnapshotInvalidation(_DedupliBase):
+    """Vérifie que reset_cache du taxonomy snapshot est invoqué après
+    un build ou un restore — sinon les onglets Mappings / Refonte
+    continueraient d'afficher les counts pré-canonisation."""
+
+    def test_restore_invalidates_snapshot(self):
+        from dashboard import taxonomy as _tax
+        # Seed un canon à supprimer
+        p = self.tmp / "profiles" / "p" / ".cache" / "theme-canon.json"
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text(json.dumps({"version": 2, "mapping": {"A": "B"}}),
+                     encoding="utf-8")
+        with mock.patch.object(_tax, "reset_cache") as mock_reset:
+            dedupli.restore_initial_themes("p")
+            mock_reset.assert_called_once_with("p")
+
+    def test_restore_no_canon_does_not_invalidate(self):
+        """Si pas de canon à supprimer, ne touche pas au cache."""
+        from dashboard import taxonomy as _tax
+        with mock.patch.object(_tax, "reset_cache") as mock_reset:
+            dedupli.restore_initial_themes("p")
+            mock_reset.assert_not_called()
+
+
 class TestCancelDedupli(_DedupliBase):
     def _write_status(self, status_val: str, cancel_requested: bool = False):
         path = self.tmp / "profiles" / "p" / ".cache" / "dedupli" / "status.json"

--- a/tests/auto/test_dedupli_endpoint.py
+++ b/tests/auto/test_dedupli_endpoint.py
@@ -1,0 +1,313 @@
+#!/usr/bin/env python3
+"""Tests des endpoints FastAPI + helpers de dashboard.dedupli — Phase 5 UI.
+
+Mocke lib.theme_canon.build_canon_table pour ne pas dépendre du LLM.
+"""
+
+import json
+import os
+import shutil
+import sys
+import tempfile
+import time
+import unittest
+from pathlib import Path
+from unittest import mock
+
+PROJECT_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+sys.path.insert(0, PROJECT_ROOT)
+
+from fastapi.testclient import TestClient  # noqa: E402
+
+from dashboard import data, dedupli  # noqa: E402
+
+
+def _seed_profile(tmp: Path, name: str = "p") -> None:
+    pdir = tmp / "profiles" / name
+    pdir.mkdir(parents=True, exist_ok=True)
+    (pdir / "profile.yaml").write_text(f"name: {name}\n", encoding="utf-8")
+
+
+def _write_canon(tmp: Path, profile: str, table: dict) -> None:
+    p = tmp / "profiles" / profile / ".cache" / "theme-canon.json"
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text(json.dumps(table, ensure_ascii=False), encoding="utf-8")
+
+
+class _DedupliBase(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        from dashboard.app import app
+        cls.client = TestClient(app)
+
+    def setUp(self):
+        self.tmp = Path(tempfile.mkdtemp(prefix="klodo_dedupli_"))
+        _seed_profile(self.tmp, "p")
+        self._patcher = mock.patch.object(
+            data, "get_project_root", return_value=self.tmp,
+        )
+        self._patcher.start()
+
+    def tearDown(self):
+        self._patcher.stop()
+        shutil.rmtree(self.tmp, ignore_errors=True)
+
+
+class TestGetStatus(_DedupliBase):
+    def test_idle_when_no_run(self):
+        r = self.client.get("/api/taxonomy/dedupli/status?profile=p")
+        self.assertEqual(r.status_code, 200)
+        self.assertEqual(r.json()["status"], "idle")
+
+    def test_canon_summary_included(self):
+        _write_canon(self.tmp, "p", {
+            "version": 2,
+            "built_at": "2026-05-27T00:00:00",
+            "raw_count": 100,
+            "canonical_count": 80,
+            "threshold": 92,
+            "clusters": [{"raw_members": ["a", "b"]}],
+        })
+        r = self.client.get("/api/taxonomy/dedupli/status?profile=p")
+        self.assertEqual(r.status_code, 200)
+        body = r.json()
+        self.assertIn("canon_summary", body)
+        self.assertEqual(body["canon_summary"]["raw_count"], 100)
+        self.assertEqual(body["canon_summary"]["canonical_count"], 80)
+
+
+class TestListClusters(_DedupliBase):
+    def test_empty_when_no_canon(self):
+        r = self.client.get("/api/taxonomy/dedupli/clusters?profile=p")
+        self.assertEqual(r.status_code, 200)
+        self.assertEqual(r.json()["clusters"], [])
+
+    def test_filters_singletons_by_default(self):
+        _write_canon(self.tmp, "p", {
+            "version": 2,
+            "clusters": [
+                {"canonical": "Solo", "raw_members": ["Solo"],
+                 "members": ["Solo"], "splits": [], "count_cumulative": 5},
+                {"canonical": "Pair", "raw_members": ["A", "B"],
+                 "members": ["A", "B"], "splits": [], "count_cumulative": 12},
+            ],
+        })
+        r = self.client.get("/api/taxonomy/dedupli/clusters?profile=p")
+        clusters = r.json()["clusters"]
+        self.assertEqual(len(clusters), 1)
+        self.assertEqual(clusters[0]["canonical"], "Pair")
+
+    def test_multi_only_false_returns_all(self):
+        _write_canon(self.tmp, "p", {
+            "version": 2,
+            "clusters": [
+                {"canonical": "Solo", "raw_members": ["Solo"],
+                 "members": ["Solo"], "splits": [], "count_cumulative": 5},
+                {"canonical": "Pair", "raw_members": ["A", "B"],
+                 "members": ["A", "B"], "splits": [], "count_cumulative": 12},
+            ],
+        })
+        r = self.client.get(
+            "/api/taxonomy/dedupli/clusters?profile=p&multi_only=false"
+        )
+        self.assertEqual(len(r.json()["clusters"]), 2)
+
+    def test_sorted_by_count_desc(self):
+        _write_canon(self.tmp, "p", {
+            "version": 2,
+            "clusters": [
+                {"canonical": "Small", "raw_members": ["a", "b"],
+                 "members": ["a", "b"], "splits": [], "count_cumulative": 3},
+                {"canonical": "Big", "raw_members": ["x", "y"],
+                 "members": ["x", "y"], "splits": [], "count_cumulative": 100},
+            ],
+        })
+        r = self.client.get("/api/taxonomy/dedupli/clusters?profile=p")
+        clusters = r.json()["clusters"]
+        self.assertEqual(clusters[0]["canonical"], "Big")
+        self.assertEqual(clusters[1]["canonical"], "Small")
+
+
+class TestUpdateCluster(_DedupliBase):
+    def _seed_basic_canon(self):
+        _write_canon(self.tmp, "p", {
+            "version": 2,
+            "raw_count": 3,
+            "canonical_count": 1,
+            "mapping": {
+                "Machine Learning": "Machine Learning",
+                "Machine learning": "Machine Learning",
+                "ML": "Machine Learning",
+            },
+            "clusters": [
+                {"canonical": "Machine Learning",
+                 "raw_members": ["Machine Learning", "Machine learning", "ML"],
+                 "members": ["Machine Learning", "Machine learning", "ML"],
+                 "splits": [],
+                 "count_cumulative": 10},
+            ],
+        })
+
+    def test_update_happy_path(self):
+        self._seed_basic_canon()
+        r = self.client.put(
+            "/api/taxonomy/dedupli/cluster",
+            json={
+                "profile": "p",
+                "raw_members": ["Machine Learning", "Machine learning", "ML"],
+                "canonical": "Machine Learning",
+                "members": ["Machine Learning", "Machine learning"],
+                "splits": [{"theme": "ML", "reason": "acronyme distinct"}],
+            },
+        )
+        self.assertEqual(r.status_code, 200)
+        # Vérifie le mapping résultant : ML → ML (split, identité)
+        canon_path = self.tmp / "profiles" / "p" / ".cache" / "theme-canon.json"
+        canon = json.loads(canon_path.read_text())
+        self.assertEqual(canon["mapping"]["ML"], "ML")
+        self.assertEqual(canon["mapping"]["Machine learning"], "Machine Learning")
+
+    def test_rejects_unknown_cluster(self):
+        self._seed_basic_canon()
+        r = self.client.put(
+            "/api/taxonomy/dedupli/cluster",
+            json={
+                "profile": "p",
+                "raw_members": ["Unknown", "Variant"],
+                "canonical": "Anything",
+                "members": ["Unknown"],
+                "splits": [],
+            },
+        )
+        self.assertEqual(r.status_code, 400)
+
+    def test_rejects_member_not_in_raw(self):
+        self._seed_basic_canon()
+        r = self.client.put(
+            "/api/taxonomy/dedupli/cluster",
+            json={
+                "profile": "p",
+                "raw_members": ["Machine Learning", "Machine learning", "ML"],
+                "canonical": "Machine Learning",
+                "members": ["Some Random Theme"],  # pas dans raw
+                "splits": [],
+            },
+        )
+        self.assertEqual(r.status_code, 400)
+
+    def test_rejects_empty_canonical(self):
+        self._seed_basic_canon()
+        r = self.client.put(
+            "/api/taxonomy/dedupli/cluster",
+            json={
+                "profile": "p",
+                "raw_members": ["Machine Learning", "Machine learning", "ML"],
+                "canonical": "",
+                "members": ["Machine Learning"],
+                "splits": [],
+            },
+        )
+        self.assertEqual(r.status_code, 400)
+
+
+class TestStartDedupli(_DedupliBase):
+    def test_rejects_missing_profile(self):
+        r = self.client.post(
+            "/api/taxonomy/dedupli/build",
+            json={"threshold": 92},
+        )
+        self.assertEqual(r.status_code, 400)
+
+    def test_rejects_bad_threshold(self):
+        r = self.client.post(
+            "/api/taxonomy/dedupli/build",
+            json={"profile": "p", "threshold": 200},
+        )
+        self.assertEqual(r.status_code, 400)
+
+    def test_rejects_unknown_profile(self):
+        r = self.client.post(
+            "/api/taxonomy/dedupli/build",
+            json={"profile": "ghost", "threshold": 92},
+        )
+        self.assertEqual(r.status_code, 404)
+
+    def test_happy_path_returns_pending(self):
+        # Mock le pipeline complet
+        with mock.patch("lib.theme_canon.build_canon_table") as mock_build:
+            mock_build.return_value = {
+                "version": 2, "raw_count": 0, "canonical_count": 0,
+                "mapping": {}, "clusters": [],
+            }
+            r = self.client.post(
+                "/api/taxonomy/dedupli/build",
+                json={"profile": "p", "threshold": 92},
+            )
+            self.assertEqual(r.status_code, 200)
+            self.assertEqual(r.json()["status"], "pending")
+            # Laisse le thread daemon terminer
+            time.sleep(0.3)
+
+    def test_concurrent_run_returns_409(self):
+        # On mock _run_dedupli (le cœur du thread) pour bloquer sur un Event
+        # — sinon get_agent_llm() plante (pas de SILICONFLOW_API_KEY en test)
+        # et le status passe instantanément à "error", invalidant le test.
+        import threading as _t
+        gate = _t.Event()
+
+        def slow_run(profile, threshold):
+            # Persiste un status "running" avant de bloquer
+            dedupli._write_status(profile, {
+                "status": "running", "phase": "judging",
+                "progress": {"done": 0, "total": 100},
+                "started_at": dedupli._now_iso(),
+            })
+            gate.wait(timeout=5)
+
+        with mock.patch.object(dedupli, "_run_dedupli", side_effect=slow_run):
+            r1 = self.client.post(
+                "/api/taxonomy/dedupli/build",
+                json={"profile": "p", "threshold": 92},
+            )
+            self.assertEqual(r1.status_code, 200)
+            # Laisse le thread démarrer et écrire le status "running"
+            for _ in range(20):  # max 1s
+                st = dedupli.get_status("p")
+                if st.get("status") in ("running", "pending"):
+                    break
+                time.sleep(0.05)
+            # Tentative 2 pendant que la 1ère est bloquée → 409
+            r2 = self.client.post(
+                "/api/taxonomy/dedupli/build",
+                json={"profile": "p", "threshold": 92},
+            )
+            self.assertEqual(r2.status_code, 409)
+            # Débloque le 1er
+            gate.set()
+            time.sleep(0.2)
+
+
+class TestZombieReap(_DedupliBase):
+    def test_zombie_marked_error(self):
+        # Status "running" avec un mtime ancien
+        from datetime import UTC, datetime, timedelta
+        old = (datetime.now(UTC) - timedelta(minutes=10)).isoformat()
+        status_path = self.tmp / "profiles" / "p" / ".cache" / "dedupli" / "status.json"
+        status_path.parent.mkdir(parents=True, exist_ok=True)
+        status_path.write_text(json.dumps({
+            "status": "running", "started_at": old,
+            "progress": {"done": 5, "total": 100},
+        }), encoding="utf-8")
+        # Forcer mtime ancien
+        import os as _os
+        ts = (datetime.now(UTC) - timedelta(minutes=10)).timestamp()
+        _os.utime(status_path, (ts, ts))
+
+        # get_status reap automatiquement
+        status = dedupli.get_status("p")
+        self.assertEqual(status["status"], "error")
+        self.assertIn("orphelin", status["error"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/auto/test_dedupli_endpoint.py
+++ b/tests/auto/test_dedupli_endpoint.py
@@ -309,5 +309,61 @@ class TestZombieReap(_DedupliBase):
         self.assertIn("orphelin", status["error"])
 
 
+class TestResetRunningAtBoot(_DedupliBase):
+    """Boot reset : tout run en running/pending est marqué error au démarrage,
+    sans attendre le seuil zombie."""
+
+    def _seed_status(self, profile: str, status_val: str) -> None:
+        _seed_profile(self.tmp, profile)
+        path = self.tmp / "profiles" / profile / ".cache" / "dedupli" / "status.json"
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(json.dumps({
+            "status": status_val,
+            "phase": "judging",
+            "progress": {"done": 77, "total": 13635},
+            "started_at": "2026-05-28T19:07:50+00:00",
+        }), encoding="utf-8")
+
+    def test_running_marked_error(self):
+        self._seed_status("p", "running")
+        dedupli.reset_running_at_boot()
+        status = dedupli._read_status("p")
+        self.assertEqual(status["status"], "error")
+        self.assertIn("redémarré", status["error"])
+
+    def test_pending_marked_error(self):
+        self._seed_status("p", "pending")
+        dedupli.reset_running_at_boot()
+        status = dedupli._read_status("p")
+        self.assertEqual(status["status"], "error")
+
+    def test_done_left_intact(self):
+        self._seed_status("p", "done")
+        dedupli.reset_running_at_boot()
+        status = dedupli._read_status("p")
+        self.assertEqual(status["status"], "done")
+
+    def test_error_left_intact(self):
+        self._seed_status("p", "error")
+        dedupli.reset_running_at_boot()
+        status = dedupli._read_status("p")
+        self.assertEqual(status["status"], "error")
+
+    def test_multiple_profiles_reset(self):
+        self._seed_status("p1", "running")
+        self._seed_status("p2", "running")
+        self._seed_status("p3", "done")
+        dedupli.reset_running_at_boot()
+        self.assertEqual(dedupli._read_status("p1")["status"], "error")
+        self.assertEqual(dedupli._read_status("p2")["status"], "error")
+        self.assertEqual(dedupli._read_status("p3")["status"], "done")
+
+    def test_missing_profiles_dir_does_not_raise(self):
+        # Pas de profiles/ → no-op silencieux
+        import shutil as _shutil
+        _shutil.rmtree(self.tmp / "profiles", ignore_errors=True)
+        dedupli.reset_running_at_boot()  # ne doit pas raise
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/auto/test_dedupli_endpoint.py
+++ b/tests/auto/test_dedupli_endpoint.py
@@ -287,6 +287,53 @@ class TestStartDedupli(_DedupliBase):
             time.sleep(0.2)
 
 
+class TestCancelDedupli(_DedupliBase):
+    def _write_status(self, status_val: str, cancel_requested: bool = False):
+        path = self.tmp / "profiles" / "p" / ".cache" / "dedupli" / "status.json"
+        path.parent.mkdir(parents=True, exist_ok=True)
+        s = {
+            "status": status_val,
+            "phase": "judging",
+            "progress": {"done": 50, "total": 100},
+            "started_at": "2026-05-28T19:00:00+00:00",
+        }
+        if cancel_requested:
+            s["cancel_requested"] = True
+        path.write_text(json.dumps(s), encoding="utf-8")
+
+    def test_cancel_sets_flag(self):
+        self._write_status("running")
+        r = self.client.post(
+            "/api/taxonomy/dedupli/cancel",
+            json={"profile": "p"},
+        )
+        self.assertEqual(r.status_code, 200)
+        status = dedupli._read_status("p")
+        self.assertTrue(status["cancel_requested"])
+
+    def test_cancel_404_if_no_status(self):
+        r = self.client.post(
+            "/api/taxonomy/dedupli/cancel",
+            json={"profile": "p"},
+        )
+        self.assertEqual(r.status_code, 404)
+
+    def test_cancel_409_if_not_running(self):
+        self._write_status("done")
+        r = self.client.post(
+            "/api/taxonomy/dedupli/cancel",
+            json={"profile": "p"},
+        )
+        self.assertEqual(r.status_code, 409)
+
+    def test_cancel_400_if_no_profile(self):
+        r = self.client.post(
+            "/api/taxonomy/dedupli/cancel",
+            json={},
+        )
+        self.assertEqual(r.status_code, 400)
+
+
 class TestZombieReap(_DedupliBase):
     def test_zombie_marked_error(self):
         # Status "running" avec un mtime ancien

--- a/tests/auto/test_theme_canon.py
+++ b/tests/auto/test_theme_canon.py
@@ -449,6 +449,98 @@ class TestBuildCanonTableSemanticMode(_CanonBase):
         self.assertEqual(phases[-1], "done")
 
 
+class TestBuildCanonTableSourceMode(_CanonBase):
+    """Mode source (C.2) : contexte titres via LLM."""
+
+    def test_source_uses_resolver_with_titles(self):
+        from lib.theme_canon import build_canon_table
+        from lib.theme_resolver import BatchResolution, ResolvedTheme
+
+        # 3 raws : ML (1 occ + 1 titre), Machine Learning (5 + 1), Logic (1 + 1)
+        self._write_vision_cache([
+            {"result": {"title": "Pattern Recognition and ML",
+                       "themes": [{"theme": "Machine Learning", "confidence": 0.9}]}},
+            {"result": {"title": "ML for Dummies",
+                       "themes": [{"theme": "Machine Learning", "confidence": 0.9}]}},
+            {"result": {"title": "Introduction to ML",
+                       "themes": [{"theme": "ML", "confidence": 0.9}]}},
+            {"result": {"title": "A First Course in Logic",
+                       "themes": [{"theme": "Logic", "confidence": 0.9}]}},
+        ])
+
+        mock_llm = mock.MagicMock()
+        mock_structured = mock.MagicMock()
+        mock_llm.with_structured_output.return_value = mock_structured
+
+        # Vocabulary top_n=1 → "Machine Learning"
+        # to_process = ["ML", "Logic"] (lexico) → LLM voit ML + son titre,
+        # Logic + son titre. ML fusionne, Logic reste identité.
+        mock_structured.invoke.return_value = BatchResolution(mappings=[
+            ResolvedTheme(raw="Logic", canonical="Logic",
+                          matched_existing=False),
+            ResolvedTheme(raw="ML", canonical="Machine Learning",
+                          matched_existing=True),
+        ])
+
+        table = build_canon_table(
+            "p", mock_llm,
+            mode="source",
+            vocabulary_top_n=1,
+            use_judge_cache=False,
+        )
+
+        self.assertEqual(table["mode"], "source")
+        mapping = table["mapping"]
+        self.assertEqual(mapping["Machine Learning"], "Machine Learning")
+        self.assertEqual(mapping["ML"], "Machine Learning")
+        self.assertEqual(mapping["Logic"], "Logic")
+
+        # 2 clusters : Machine Learning (count 2+1=3) + Logic (count 1)
+        clusters = table["clusters"]
+        self.assertEqual(len(clusters), 2)
+        # Vérifie présence des sample_titles dans les clusters
+        ml_cluster = next(c for c in clusters if c["canonical"] == "Machine Learning")
+        self.assertGreater(len(ml_cluster["sample_titles"]), 0)
+
+    def test_source_progress_phases(self):
+        from lib.theme_canon import build_canon_table
+        from lib.theme_resolver import BatchResolution, ResolvedTheme
+
+        self._write_vision_cache([
+            {"result": {"title": "T1", "themes": [{"theme": "A", "confidence": 0.9}]}},
+            {"result": {"title": "T2", "themes": [{"theme": "B", "confidence": 0.9}]}},
+        ])
+
+        mock_llm = mock.MagicMock()
+        mock_structured = mock.MagicMock()
+        mock_llm.with_structured_output.return_value = mock_structured
+        mock_structured.invoke.return_value = BatchResolution(mappings=[
+            ResolvedTheme(raw="B", canonical="A", matched_existing=True),
+        ])
+
+        phases: list[str] = []
+        build_canon_table(
+            "p", mock_llm, mode="source", vocabulary_top_n=1,
+            use_judge_cache=False,
+            on_progress=lambda d, t, phase: phases.append(phase),
+        )
+        self.assertIn("extracting", phases)
+        self.assertIn("resolving", phases)
+        self.assertIn("reclustering", phases)
+        self.assertEqual(phases[-1], "done")
+
+    def test_source_empty_profile(self):
+        from lib.theme_canon import build_canon_table
+        mock_llm = mock.MagicMock()
+        table = build_canon_table(
+            "p", mock_llm, mode="source", vocabulary_top_n=10,
+        )
+        self.assertEqual(table["mapping"], {})
+        self.assertEqual(table["clusters"], [])
+        # Le mode demandé est tagué même quand le profil est vide
+        self.assertEqual(table.get("mode"), "source")
+
+
 class TestSyntacticModeTagged(_CanonBase):
     """Le mode syntactique (défaut) tague aussi mode dans la sortie."""
 

--- a/tests/auto/test_theme_canon.py
+++ b/tests/auto/test_theme_canon.py
@@ -1,0 +1,348 @@
+#!/usr/bin/env python3
+"""Tests pour lib.theme_canon — Phase 4 du chantier dédupli.
+
+Couvre :
+  - extract_themes_from_vision_cache (parsing dict/str JSON/str repr)
+  - assemble_canon_mapping (members/splits/filet de sécurité)
+  - build_canon_table (pipeline end-to-end avec mock LLM)
+  - load/save canon_table (atomique, robuste)
+  - canonicalize (hot path)
+  - Branchement dans dashboard.taxonomy._aggregate_themes_llm
+"""
+
+import json
+import os
+import shutil
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+PROJECT_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+sys.path.insert(0, PROJECT_ROOT)
+
+from dashboard import data  # noqa: E402
+from lib.theme_canon import (  # noqa: E402
+    CANON_VERSION,
+    _parse_cached_result,
+    assemble_canon_mapping,
+    build_canon_table,
+    canonicalize,
+    extract_themes_from_vision_cache,
+    load_canon_table,
+    save_canon_table,
+)
+from lib.theme_judge import JudgeResult, JudgeSplit  # noqa: E402
+
+
+class _CanonBase(unittest.TestCase):
+    def setUp(self):
+        self.tmp = Path(tempfile.mkdtemp(prefix="klodo_canon_"))
+        (self.tmp / "profiles" / "p" / ".cache").mkdir(parents=True)
+        self._patcher = mock.patch.object(
+            data, "get_project_root", return_value=self.tmp,
+        )
+        self._patcher.start()
+
+    def tearDown(self):
+        self._patcher.stop()
+        shutil.rmtree(self.tmp, ignore_errors=True)
+
+    def _write_vision_cache(self, entries: list[dict]) -> None:
+        path = self.tmp / "profiles" / "p" / ".cache" / "vision_cache.json"
+        # vision_cache.json = {hash: {result: str|dict, ...}}
+        cache = {f"hash_{i}": e for i, e in enumerate(entries)}
+        path.write_text(json.dumps(cache, ensure_ascii=False), encoding="utf-8")
+
+
+class TestParseCachedResult(unittest.TestCase):
+    def test_dict_input(self):
+        d = {"title": "Foo", "themes": [{"theme": "Bar"}]}
+        self.assertEqual(_parse_cached_result(d), d)
+
+    def test_json_string(self):
+        s = '{"title": "Foo", "themes": [{"theme": "Bar"}]}'
+        self.assertEqual(_parse_cached_result(s)["title"], "Foo")
+
+    def test_python_repr_string(self):
+        # Legacy format observé dans le vision_cache.json réel
+        s = "{'title': 'Foo', 'themes': [{'theme': 'Bar'}]}"
+        self.assertEqual(_parse_cached_result(s)["title"], "Foo")
+
+    def test_corrupted_input(self):
+        self.assertIsNone(_parse_cached_result("not json"))
+        self.assertIsNone(_parse_cached_result(""))
+        self.assertIsNone(_parse_cached_result(None))
+        self.assertIsNone(_parse_cached_result(42))
+
+
+class TestExtractThemesFromVisionCache(_CanonBase):
+    def test_no_cache_returns_empty(self):
+        self.assertEqual(extract_themes_from_vision_cache("p"), {})
+
+    def test_basic_extraction(self):
+        self._write_vision_cache([
+            {"result": {"title": "A", "themes": [{"theme": "Machine Learning"}]}},
+            {"result": {"title": "B", "themes": [{"theme": "Machine Learning"}]}},
+            {"result": {"title": "C", "themes": [{"theme": "Deep Learning"}]}},
+        ])
+        themes = extract_themes_from_vision_cache("p")
+        self.assertEqual(themes, {"Machine Learning": 2, "Deep Learning": 1})
+
+    def test_handles_string_result(self):
+        # Mix dict + str JSON + str repr (cas réel)
+        self._write_vision_cache([
+            {"result": {"themes": [{"theme": "Foo"}]}},
+            {"result": '{"themes": [{"theme": "Foo"}]}'},
+            {"result": "{'themes': [{'theme': 'Foo'}]}"},
+        ])
+        themes = extract_themes_from_vision_cache("p")
+        self.assertEqual(themes, {"Foo": 3})
+
+    def test_string_themes_supported(self):
+        # Quelques entrées historiques ont des thèmes en str au lieu de dict
+        self._write_vision_cache([
+            {"result": {"themes": ["BareTheme", {"theme": "DictTheme"}]}},
+        ])
+        themes = extract_themes_from_vision_cache("p")
+        self.assertEqual(themes, {"BareTheme": 1, "DictTheme": 1})
+
+    def test_skips_corrupted_entries(self):
+        self._write_vision_cache([
+            {"result": {"themes": [{"theme": "Good"}]}},
+            {"result": "not json"},
+            {"not_an_entry": True},
+            {"result": {"themes": []}},
+        ])
+        themes = extract_themes_from_vision_cache("p")
+        self.assertEqual(themes, {"Good": 1})
+
+    def test_strips_whitespace(self):
+        self._write_vision_cache([
+            {"result": {"themes": [{"theme": "  Foo  "}]}},
+        ])
+        themes = extract_themes_from_vision_cache("p")
+        self.assertEqual(themes, {"Foo": 1})
+
+
+class TestAssembleCanonMapping(unittest.TestCase):
+    def test_members_to_canonical(self):
+        clusters = [{"raw_members": ["Machine Learning", "Machine learning"]}]
+        judgments = [JudgeResult(
+            canonical="Machine Learning",
+            members=["Machine Learning", "Machine learning"],
+        )]
+        mapping = assemble_canon_mapping(clusters, judgments)
+        self.assertEqual(mapping, {
+            "Machine Learning": "Machine Learning",
+            "Machine learning": "Machine Learning",
+        })
+
+    def test_splits_keep_identity(self):
+        clusters = [{"raw_members": ["Machine Learning", "Unsupervised Machine Learning"]}]
+        judgments = [JudgeResult(
+            canonical="Machine Learning",
+            members=["Machine Learning"],
+            splits=[JudgeSplit(theme="Unsupervised Machine Learning",
+                              reason="sous-domaine")],
+        )]
+        mapping = assemble_canon_mapping(clusters, judgments)
+        self.assertEqual(mapping, {
+            "Machine Learning": "Machine Learning",
+            "Unsupervised Machine Learning": "Unsupervised Machine Learning",
+        })
+
+    def test_safety_net_for_forgotten_variants(self):
+        # Le LLM oublie une variante (ni dans members ni dans splits)
+        clusters = [{"raw_members": ["A", "B", "C"]}]
+        judgments = [JudgeResult(
+            canonical="A",
+            members=["A", "B"],
+            # C oublié
+        )]
+        mapping = assemble_canon_mapping(clusters, judgments)
+        self.assertEqual(mapping["A"], "A")
+        self.assertEqual(mapping["B"], "A")
+        self.assertEqual(mapping["C"], "C")  # identité par défaut
+
+    def test_singleton_identity(self):
+        clusters = [{"raw_members": ["Solo Theme"]}]
+        judgments = [JudgeResult(canonical="Solo Theme", members=["Solo Theme"])]
+        mapping = assemble_canon_mapping(clusters, judgments)
+        self.assertEqual(mapping, {"Solo Theme": "Solo Theme"})
+
+    def test_length_mismatch_raises(self):
+        with self.assertRaises(ValueError):
+            assemble_canon_mapping([{"raw_members": ["A"]}], [])
+
+
+class TestLoadSaveCanonTable(_CanonBase):
+    def test_save_then_load(self):
+        table = {
+            "version": CANON_VERSION,
+            "built_at": "2026-05-27T00:00:00",
+            "mapping": {"Foo": "Foo Canonical", "Bar": "Bar"},
+        }
+        save_canon_table("p", table)
+        mapping = load_canon_table("p")
+        self.assertEqual(mapping, {"Foo": "Foo Canonical", "Bar": "Bar"})
+
+    def test_load_missing_returns_none(self):
+        self.assertIsNone(load_canon_table("p"))
+
+    def test_load_corrupted_returns_none(self):
+        path = self.tmp / "profiles" / "p" / ".cache" / "theme-canon.json"
+        path.write_text("not json", encoding="utf-8")
+        self.assertIsNone(load_canon_table("p"))
+
+    def test_load_missing_mapping_field_returns_none(self):
+        path = self.tmp / "profiles" / "p" / ".cache" / "theme-canon.json"
+        path.write_text('{"version": 1}', encoding="utf-8")
+        self.assertIsNone(load_canon_table("p"))
+
+    def test_save_is_atomic(self):
+        # save_canon_table écrit dans .tmp puis renomme — pas de fichier
+        # partiel laissé en cas d'interruption
+        table = {"version": 1, "mapping": {"Foo": "Foo"}}
+        save_canon_table("p", table)
+        path = self.tmp / "profiles" / "p" / ".cache" / "theme-canon.json"
+        self.assertTrue(path.exists())
+        # Pas de fichier .tmp résiduel
+        self.assertFalse(path.with_suffix(".tmp").exists())
+
+
+class TestCanonicalize(unittest.TestCase):
+    def test_resolves_via_table(self):
+        table = {"Machine learning": "Machine Learning"}
+        self.assertEqual(canonicalize("Machine learning", table), "Machine Learning")
+
+    def test_unknown_theme_returns_identity(self):
+        table = {"Foo": "Foo Canonical"}
+        self.assertEqual(canonicalize("Unknown", table), "Unknown")
+
+    def test_none_table_returns_identity(self):
+        self.assertEqual(canonicalize("Whatever", None), "Whatever")
+
+    def test_empty_table_returns_identity(self):
+        self.assertEqual(canonicalize("Whatever", {}), "Whatever")
+
+
+class TestBuildCanonTable(_CanonBase):
+    def test_empty_profile_yields_empty_table(self):
+        mock_llm = mock.MagicMock()
+        table = build_canon_table("p", mock_llm)
+        self.assertEqual(table["mapping"], {})
+        self.assertEqual(table["raw_count"], 0)
+        self.assertEqual(table["canonical_count"], 0)
+        # Pas d'appel LLM si pas de thèmes
+        mock_llm.with_structured_output.assert_not_called()
+
+    def test_with_themes_auto_merge_only(self):
+        # 2 variantes très proches → auto-merge sans LLM
+        self._write_vision_cache([
+            {"result": {"themes": [{"theme": "Machine Learning"}]}},
+            {"result": {"themes": [{"theme": "Machine learning"}]}},
+            {"result": {"themes": [{"theme": "Deep Learning"}]}},
+        ])
+        mock_llm = mock.MagicMock()
+        table = build_canon_table("p", mock_llm, use_judge_cache=False)
+
+        mapping = table["mapping"]
+        # Les 2 ML variantes pointent sur le même canonical
+        self.assertEqual(mapping["Machine Learning"], mapping["Machine learning"])
+        # Deep Learning isolé
+        self.assertEqual(mapping["Deep Learning"], "Deep Learning")
+        # LLM pas appelé (auto-merge)
+        mock_llm.with_structured_output.assert_not_called()
+
+    def test_table_persisted_on_disk(self):
+        self._write_vision_cache([
+            {"result": {"themes": [{"theme": "Foo"}]}},
+        ])
+        mock_llm = mock.MagicMock()
+        build_canon_table("p", mock_llm)
+        path = self.tmp / "profiles" / "p" / ".cache" / "theme-canon.json"
+        self.assertTrue(path.exists())
+        loaded = json.loads(path.read_text())
+        self.assertEqual(loaded["version"], CANON_VERSION)
+        self.assertIn("built_at", loaded)
+        self.assertIn("mapping", loaded)
+
+
+class TestTaxonomyIntegration(_CanonBase):
+    """Vérifie que _aggregate_themes_llm consomme bien theme-canon.json."""
+
+    def setUp(self):
+        super().setUp()
+        # Mock data.get_project_root pour le module dashboard.taxonomy
+        # (utilise déjà self._patcher du _CanonBase)
+        # Profile minimal
+        (self.tmp / "profiles" / "p" / "profile.yaml").write_text("name: p\n")
+
+    def _vision_with_themes(self, themes: list[str]) -> None:
+        entries = [
+            {"result": {"title": f"Doc{i}",
+                       "themes": [{"theme": t, "confidence": 0.9}]}}
+            for i, t in enumerate(themes)
+        ]
+        self._write_vision_cache(entries)
+
+    def test_without_canon_table_baseline_behavior(self):
+        # Sans theme-canon.json → comportement historique
+        # (key = lowercase, on dédoublonne juste la casse)
+        from dashboard.taxonomy import _aggregate_themes_llm
+
+        self._vision_with_themes([
+            "Machine Learning", "Machine learning",  # même casse-lowercase
+            "Deep Learning",
+        ])
+        themes_out, stats = _aggregate_themes_llm("p", {})
+        # 2 thèmes : machine learning (count 2 via lowercasing) + deep learning
+        keys = {t["theme"].lower() for t in themes_out}
+        self.assertEqual(keys, {"machine learning", "deep learning"})
+
+    def test_with_canon_table_consolidates_counts(self):
+        from dashboard.taxonomy import _aggregate_themes_llm
+
+        # 3 doc avec 3 variantes "Optimization" (USA / UK / lowercase)
+        self._vision_with_themes([
+            "Optimization", "Optimisation", "optimization",
+        ])
+        # Écrit une canon_table qui mappe les 3 sur "Optimization"
+        save_canon_table("p", {
+            "version": 1,
+            "mapping": {
+                "Optimization": "Optimization",
+                "Optimisation": "Optimization",
+                "optimization": "Optimization",
+            },
+        })
+        themes_out, stats = _aggregate_themes_llm("p", {})
+        # Un seul thème "Optimization" avec count = 3
+        self.assertEqual(len(themes_out), 1)
+        self.assertEqual(themes_out[0]["theme"], "Optimization")
+        self.assertEqual(themes_out[0]["count"], 3)
+
+    def test_with_canon_table_keeps_splits_separate(self):
+        from dashboard.taxonomy import _aggregate_themes_llm
+
+        self._vision_with_themes([
+            "Machine Learning", "Machine Learning",
+            "Unsupervised Machine Learning",
+        ])
+        save_canon_table("p", {
+            "version": 1,
+            "mapping": {
+                "Machine Learning": "Machine Learning",
+                "Unsupervised Machine Learning": "Unsupervised Machine Learning",
+            },
+        })
+        themes_out, _ = _aggregate_themes_llm("p", {})
+        by_theme = {t["theme"]: t["count"] for t in themes_out}
+        self.assertEqual(by_theme["Machine Learning"], 2)
+        self.assertEqual(by_theme["Unsupervised Machine Learning"], 1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/auto/test_theme_canon.py
+++ b/tests/auto/test_theme_canon.py
@@ -344,5 +344,123 @@ class TestTaxonomyIntegration(_CanonBase):
         self.assertEqual(by_theme["Unsupervised Machine Learning"], 1)
 
 
+class TestBuildCanonTableSemanticMode(_CanonBase):
+    """Mode semantic (C-light) : vocabulaire + canonisation LLM globale."""
+
+    def _write_vision(self, themes_counts: dict[str, int]) -> None:
+        """Crée un vision_cache avec ces occurrences."""
+        entries = []
+        for theme, count in themes_counts.items():
+            for _ in range(count):
+                entries.append(
+                    {"result": {"title": f"Doc-{theme}",
+                                "themes": [{"theme": theme, "confidence": 0.9}]}}
+                )
+        self._write_vision_cache(entries)
+
+    def test_unknown_mode_raises(self):
+        from lib.theme_canon import build_canon_table
+        mock_llm = mock.MagicMock()
+        with self.assertRaises(ValueError):
+            build_canon_table("p", mock_llm, mode="weird")
+
+    def test_semantic_uses_canonicalizer(self):
+        # 3 raws : "ML" (1), "Machine Learning" (5), "AI" (1)
+        # → vocabulary = ["Machine Learning"] (top 1)
+        # → "ML" et "AI" passent au LLM, on script la réponse
+        from lib.theme_canon import build_canon_table
+
+        self._write_vision({
+            "Machine Learning": 5,
+            "ML": 1,
+            "AI": 1,
+        })
+
+        from lib.theme_canonicalizer import (
+            BatchCanonicalization,
+            RawCanonicalPair,
+        )
+        mock_llm = mock.MagicMock()
+        mock_structured = mock.MagicMock()
+        mock_llm.with_structured_output.return_value = mock_structured
+        mock_structured.invoke.return_value = BatchCanonicalization(mappings=[
+            RawCanonicalPair(raw="AI", canonical="Machine Learning",
+                            matched_existing=True),
+            RawCanonicalPair(raw="ML", canonical="Machine Learning",
+                            matched_existing=True),
+        ])
+
+        table = build_canon_table(
+            "p", mock_llm,
+            mode="semantic",
+            vocabulary_top_n=1,  # Top 1 = ["Machine Learning"]
+            use_judge_cache=False,
+        )
+
+        self.assertEqual(table["mode"], "semantic")
+        self.assertEqual(table["vocabulary_size"], 1)
+        # Tous mappent vers "Machine Learning"
+        mapping = table["mapping"]
+        self.assertEqual(mapping["Machine Learning"], "Machine Learning")
+        self.assertEqual(mapping["ML"], "Machine Learning")
+        self.assertEqual(mapping["AI"], "Machine Learning")
+        self.assertEqual(table["canonical_count"], 1)
+
+        # 1 cluster final avec count cumulé = 5 + 1 + 1 = 7
+        self.assertEqual(len(table["clusters"]), 1)
+        self.assertEqual(table["clusters"][0]["canonical"], "Machine Learning")
+        self.assertEqual(table["clusters"][0]["count_cumulative"], 7)
+
+    def test_semantic_empty_profile(self):
+        from lib.theme_canon import build_canon_table
+        mock_llm = mock.MagicMock()
+        table = build_canon_table(
+            "p", mock_llm, mode="semantic", vocabulary_top_n=10,
+        )
+        self.assertEqual(table["mapping"], {})
+        self.assertEqual(table["clusters"], [])
+        self.assertEqual(table["mode"], "semantic")
+
+    def test_semantic_progress_phases(self):
+        from lib.theme_canon import build_canon_table
+
+        self._write_vision({"A": 3, "B": 1})  # vocab=[A], "B" → LLM
+
+        from lib.theme_canonicalizer import (
+            BatchCanonicalization,
+            RawCanonicalPair,
+        )
+        mock_llm = mock.MagicMock()
+        mock_structured = mock.MagicMock()
+        mock_llm.with_structured_output.return_value = mock_structured
+        mock_structured.invoke.return_value = BatchCanonicalization(mappings=[
+            RawCanonicalPair(raw="B", canonical="A", matched_existing=True),
+        ])
+
+        phases: list[str] = []
+        build_canon_table(
+            "p", mock_llm, mode="semantic", vocabulary_top_n=1,
+            on_progress=lambda d, t, phase: phases.append(phase),
+            use_judge_cache=False,
+        )
+        self.assertIn("extracting", phases)
+        self.assertIn("canonicalizing", phases)
+        self.assertIn("reclustering", phases)
+        self.assertEqual(phases[-1], "done")
+
+
+class TestSyntacticModeTagged(_CanonBase):
+    """Le mode syntactique (défaut) tague aussi mode dans la sortie."""
+
+    def test_syntactic_mode_in_table(self):
+        from lib.theme_canon import build_canon_table
+        self._write_vision_cache([
+            {"result": {"themes": [{"theme": "Foo"}]}},
+        ])
+        mock_llm = mock.MagicMock()
+        table = build_canon_table("p", mock_llm)  # défaut syntactic
+        self.assertEqual(table["mode"], "syntactic")
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/auto/test_theme_canon.py
+++ b/tests/auto/test_theme_canon.py
@@ -526,7 +526,9 @@ class TestBuildCanonTableSourceMode(_CanonBase):
         )
         self.assertIn("extracting", phases)
         self.assertIn("resolving", phases)
-        self.assertIn("reclustering", phases)
+        # Mode 'source' n'a pas de re-clustering fuzzy (skip cluster_themes
+        # par-dessus la sortie LLM) — la phase finale est "finalizing".
+        self.assertIn("finalizing", phases)
         self.assertEqual(phases[-1], "done")
 
     def test_source_empty_profile(self):

--- a/tests/auto/test_theme_canonicalizer.py
+++ b/tests/auto/test_theme_canonicalizer.py
@@ -1,0 +1,307 @@
+#!/usr/bin/env python3
+"""Tests pour lib.theme_canonicalizer — C-light du chantier dédupli.
+
+Mocke le LLM (pas de call SiliconFlow), valide :
+  - build_vocabulary : top-N par fréquence, ties par lowercase asc
+  - canonicalize_batch : appel LLM + parsing + fallbacks
+  - canonicalize_themes : batching + parallélisation + cache + ordre
+"""
+
+import os
+import shutil
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+PROJECT_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+sys.path.insert(0, PROJECT_ROOT)
+
+from dashboard import data  # noqa: E402
+from lib.theme_canonicalizer import (  # noqa: E402
+    BatchCanonicalization,
+    RawCanonicalPair,
+    _stable_batch_key,
+    build_vocabulary,
+    canonicalize_batch,
+    canonicalize_themes,
+)
+
+
+class _CanoBase(unittest.TestCase):
+    def setUp(self):
+        self.tmp = Path(tempfile.mkdtemp(prefix="klodo_cano_"))
+        (self.tmp / "profiles" / "p").mkdir(parents=True)
+        self._patcher = mock.patch.object(
+            data, "get_project_root", return_value=self.tmp,
+        )
+        self._patcher.start()
+
+    def tearDown(self):
+        self._patcher.stop()
+        shutil.rmtree(self.tmp, ignore_errors=True)
+
+    def _cache_path(self):
+        return self.tmp / "profiles" / "p" / ".cache" / "theme-canonicalizer.json"
+
+
+class TestBuildVocabulary(unittest.TestCase):
+    def test_basic_top_n(self):
+        counts = {"A": 100, "B": 50, "C": 200, "D": 10}
+        vocab = build_vocabulary(counts, top_n=2)
+        self.assertEqual(vocab, ["C", "A"])  # 200, 100
+
+    def test_top_n_larger_than_input(self):
+        counts = {"A": 5, "B": 3}
+        vocab = build_vocabulary(counts, top_n=100)
+        # Tout est inclus, sans crash
+        self.assertEqual(set(vocab), {"A", "B"})
+
+    def test_ties_sorted_by_lowercase_asc(self):
+        # Egalité de count → tri lexicographique sur lowercase
+        counts = {"Zebra": 10, "apple": 10, "Banana": 10}
+        vocab = build_vocabulary(counts, top_n=3)
+        self.assertEqual(vocab, ["apple", "Banana", "Zebra"])
+
+    def test_empty_input(self):
+        self.assertEqual(build_vocabulary({}), [])
+
+
+class TestStableBatchKey(unittest.TestCase):
+    def test_batch_order_matters(self):
+        # Le batch est ordonné (le LLM produit mappings[] dans l'ordre)
+        # donc la clé doit changer si l'ordre change.
+        k1 = _stable_batch_key(["A", "B", "C"], ["v1", "v2"])
+        k2 = _stable_batch_key(["C", "B", "A"], ["v1", "v2"])
+        self.assertNotEqual(k1, k2)
+
+    def test_vocab_order_irrelevant(self):
+        # Le vocab est trié dans la clé pour ne pas dépendre de son ordre.
+        k1 = _stable_batch_key(["A", "B"], ["v1", "v2"])
+        k2 = _stable_batch_key(["A", "B"], ["v2", "v1"])
+        self.assertEqual(k1, k2)
+
+    def test_length_16(self):
+        self.assertEqual(len(_stable_batch_key(["A"], ["B"])), 16)
+
+
+class TestCanonicalizeBatch(unittest.TestCase):
+    def _mock_llm(self, mappings: list[RawCanonicalPair]):
+        mock_llm = mock.MagicMock()
+        mock_structured = mock.MagicMock()
+        mock_llm.with_structured_output.return_value = mock_structured
+        mock_structured.invoke.return_value = BatchCanonicalization(mappings=mappings)
+        return mock_llm
+
+    def test_happy_path(self):
+        mock_llm = self._mock_llm([
+            RawCanonicalPair(raw="ML", canonical="Machine Learning", matched_existing=True),
+            RawCanonicalPair(raw="machine learning", canonical="Machine Learning",
+                            matched_existing=True),
+        ])
+        result = canonicalize_batch(
+            ["ML", "machine learning"],
+            ["Machine Learning"],
+            mock_llm,
+        )
+        self.assertEqual(result, {
+            "ML": "Machine Learning",
+            "machine learning": "Machine Learning",
+        })
+        # Vérifie qu'on a forcé method=function_calling (GLM-4.7 compat)
+        mock_llm.with_structured_output.assert_called_once_with(
+            BatchCanonicalization, method="function_calling",
+        )
+
+    def test_uses_canonical_function_calling_method(self):
+        # GLM-4.7 ne supporte pas json mode — on doit forcer function_calling
+        mock_llm = self._mock_llm([
+            RawCanonicalPair(raw="A", canonical="A", matched_existing=False),
+        ])
+        canonicalize_batch(["A"], [], mock_llm)
+        _, kwargs = mock_llm.with_structured_output.call_args
+        self.assertEqual(kwargs.get("method"), "function_calling")
+
+    def test_empty_batch(self):
+        mock_llm = mock.MagicMock()
+        result = canonicalize_batch([], ["voc"], mock_llm)
+        self.assertEqual(result, {})
+        # Pas d'appel LLM sur batch vide
+        mock_llm.with_structured_output.assert_not_called()
+
+    def test_safety_net_when_llm_omits_themes(self):
+        # Le LLM renvoie 1 mapping sur 2 demandés → l'autre doit avoir
+        # identité par défaut.
+        mock_llm = self._mock_llm([
+            RawCanonicalPair(raw="A", canonical="X", matched_existing=True),
+        ])
+        result = canonicalize_batch(["A", "B"], ["X"], mock_llm)
+        self.assertEqual(result["A"], "X")
+        self.assertEqual(result["B"], "B")  # filet identité
+
+    def test_empty_canonical_falls_back_to_raw(self):
+        # Le LLM renvoie un canonical vide → identité
+        mock_llm = self._mock_llm([
+            RawCanonicalPair(raw="A", canonical="   ", matched_existing=False),
+        ])
+        result = canonicalize_batch(["A"], [], mock_llm)
+        self.assertEqual(result["A"], "A")
+
+    def test_deduplicates_repeated_raw(self):
+        # Si le LLM répète un raw dans mappings, on garde la 1ère décision
+        mock_llm = self._mock_llm([
+            RawCanonicalPair(raw="A", canonical="X", matched_existing=True),
+            RawCanonicalPair(raw="A", canonical="Y", matched_existing=False),
+        ])
+        result = canonicalize_batch(["A"], ["X"], mock_llm)
+        self.assertEqual(result["A"], "X")
+
+
+class TestCanonicalizeThemes(_CanoBase):
+    def _scripted_llm(self, mapping: dict[str, str]):
+        """LLM qui retourne un canonical par raw selon un dict scripté."""
+        mock_llm = mock.MagicMock()
+        mock_structured = mock.MagicMock()
+        mock_llm.with_structured_output.return_value = mock_structured
+
+        def respond(messages):
+            # Parse le batch depuis le HumanMessage
+            content = messages[1].content
+            # Trouve les lignes "  - 'theme'"
+            import re
+            raws = re.findall(r"^\s*-\s*'([^']+)'", content, re.MULTILINE)
+            pairs = []
+            for raw in raws:
+                canonical = mapping.get(raw, raw)
+                pairs.append(RawCanonicalPair(
+                    raw=raw, canonical=canonical,
+                    matched_existing=canonical != raw,
+                ))
+            return BatchCanonicalization(mappings=pairs)
+
+        mock_structured.invoke.side_effect = respond
+        return mock_llm
+
+    def test_vocabulary_themes_skip_llm(self):
+        mock_llm = mock.MagicMock()
+        result = canonicalize_themes(
+            ["Machine Learning", "Data Science"],
+            vocabulary=["Machine Learning", "Data Science"],
+            llm=mock_llm,
+            profile="p",
+            use_cache=False,
+        )
+        self.assertEqual(result, {
+            "Machine Learning": "Machine Learning",
+            "Data Science": "Data Science",
+        })
+        # Aucun appel LLM (tous dans vocab)
+        mock_llm.with_structured_output.assert_not_called()
+
+    def test_basic_canonicalization(self):
+        llm = self._scripted_llm({
+            "ML": "Machine Learning",
+            "machine learning": "Machine Learning",
+        })
+        result = canonicalize_themes(
+            ["Machine Learning", "ML", "machine learning"],
+            vocabulary=["Machine Learning"],
+            llm=llm,
+            profile="p",
+            batch_size=10,
+            max_workers=1,
+            use_cache=False,
+        )
+        # "Machine Learning" → identity (skip LLM)
+        # "ML" + "machine learning" → "Machine Learning" (LLM)
+        self.assertEqual(result["Machine Learning"], "Machine Learning")
+        self.assertEqual(result["ML"], "Machine Learning")
+        self.assertEqual(result["machine learning"], "Machine Learning")
+
+    def test_batching(self):
+        # 25 thèmes avec batch_size=10 → 3 batches
+        themes = [f"theme_{i}" for i in range(25)]
+        llm = self._scripted_llm({})  # tout → identity
+        result = canonicalize_themes(
+            themes, vocabulary=[], llm=llm, profile="p",
+            batch_size=10, max_workers=1, use_cache=False,
+        )
+        self.assertEqual(len(result), 25)
+
+    def test_cache_persists_across_calls(self):
+        llm = self._scripted_llm({"A": "X"})
+        # 1er appel
+        canonicalize_themes(
+            ["A"], vocabulary=[], llm=llm, profile="p",
+            batch_size=10, max_workers=1, use_cache=True,
+        )
+        self.assertTrue(self._cache_path().exists())
+        # 2e appel : cache hit, LLM jamais ré-appelé
+        llm.with_structured_output.return_value.invoke.reset_mock()
+        canonicalize_themes(
+            ["A"], vocabulary=[], llm=llm, profile="p",
+            batch_size=10, max_workers=1, use_cache=True,
+        )
+        llm.with_structured_output.return_value.invoke.assert_not_called()
+
+    def test_progress_callback(self):
+        themes = [f"theme_{i}" for i in range(15)]
+        llm = self._scripted_llm({})
+        calls: list[tuple[int, int]] = []
+        canonicalize_themes(
+            themes, vocabulary=[], llm=llm, profile="p",
+            batch_size=5,  # → 3 batches
+            max_workers=1, use_cache=False,
+            on_progress=lambda done, total: calls.append((done, total)),
+        )
+        # 3 batches → 3 callbacks min, dont le dernier (3, 3)
+        self.assertGreaterEqual(len(calls), 3)
+        self.assertEqual(calls[-1], (3, 3))
+
+    def test_empty_input(self):
+        mock_llm = mock.MagicMock()
+        self.assertEqual(
+            canonicalize_themes([], ["v"], mock_llm, "p", use_cache=False),
+            {},
+        )
+        mock_llm.with_structured_output.assert_not_called()
+
+    def test_no_themes_outside_vocab(self):
+        # Tous les thèmes sont dans le vocab → identity, pas d'appel LLM
+        mock_llm = mock.MagicMock()
+        result = canonicalize_themes(
+            ["A", "B", "C"], vocabulary=["A", "B", "C"], llm=mock_llm,
+            profile="p", use_cache=False,
+        )
+        self.assertEqual(result, {"A": "A", "B": "B", "C": "C"})
+        mock_llm.with_structured_output.assert_not_called()
+
+    def test_llm_failure_falls_back_to_identity(self):
+        """Si le LLM raise sur un batch, le pipeline retombe sur identité."""
+        mock_llm = mock.MagicMock()
+        mock_structured = mock.MagicMock()
+        mock_llm.with_structured_output.return_value = mock_structured
+        mock_structured.invoke.side_effect = RuntimeError("simulated LLM down")
+
+        themes = ["A", "B", "C"]
+        result = canonicalize_themes(
+            themes, vocabulary=[], llm=mock_llm, profile="p",
+            batch_size=10, max_workers=1, use_cache=False,
+        )
+        # Pas d'exception remontée — tout est en identité
+        self.assertEqual(result, {"A": "A", "B": "B", "C": "C"})
+
+    def test_parallel_workers_preserve_completeness(self):
+        # 50 thèmes en 5 batches de 10 sur 4 workers → tous présents
+        themes = [f"th_{i}" for i in range(50)]
+        llm = self._scripted_llm({})
+        result = canonicalize_themes(
+            themes, vocabulary=[], llm=llm, profile="p",
+            batch_size=10, max_workers=4, use_cache=False,
+        )
+        self.assertEqual(set(result.keys()), set(themes))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/auto/test_theme_judge.py
+++ b/tests/auto/test_theme_judge.py
@@ -1,0 +1,307 @@
+#!/usr/bin/env python3
+"""Tests pour lib.theme_judge — Phase 3 du chantier dédupli.
+
+Mocke le LLM (pas de call SiliconFlow), valide :
+  - should_auto_merge sur cas réels
+  - judge_cluster avec mock structured_output
+  - judge_clusters : skip auto, cache hit/miss, persistance
+"""
+
+import json
+import os
+import shutil
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+PROJECT_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+sys.path.insert(0, PROJECT_ROOT)
+
+from dashboard import data  # noqa: E402
+from lib.theme_judge import (  # noqa: E402
+    JudgeResult,
+    JudgeSplit,
+    _stable_cluster_key,
+    judge_cluster,
+    judge_clusters,
+    should_auto_merge,
+)
+
+
+class TestShouldAutoMerge(unittest.TestCase):
+    def test_singleton_is_trivially_mergeable(self):
+        self.assertTrue(should_auto_merge(["machine learning"]))
+
+    def test_empty(self):
+        self.assertTrue(should_auto_merge([]))
+
+    def test_case_variant_high_similarity(self):
+        # token_sort_ratio('machine learning', 'machine learning') = 100
+        self.assertTrue(should_auto_merge(["machine learning", "machine learning"]))
+
+    def test_plural_variant(self):
+        # 'neural network' vs 'neural networks' : ratio ~96-97
+        # On vérifie selon threshold
+        self.assertTrue(should_auto_merge(["neural network", "neural networks"], threshold=90))
+
+    def test_distinct_subdomain_not_mergeable(self):
+        # 'machine learning' vs 'deep learning' : token_sort_ratio = 55.2
+        self.assertFalse(should_auto_merge(["machine learning", "deep learning"]))
+
+    def test_one_outlier_breaks_auto_merge(self):
+        # 4 variantes très proches + 1 outlier → pas d'auto-merge
+        # (on exige la similarité min sur toutes les paires)
+        variants = [
+            "machine learning",
+            "machine learning",
+            "machine learnings",
+            "deep learning",  # outlier
+        ]
+        self.assertFalse(should_auto_merge(variants))
+
+    def test_threshold_argument(self):
+        # 'neural network' vs 'artificial neural network' : ~72
+        # → auto_merge False à threshold 97, True à threshold 70
+        variants = ["neural network", "artificial neural network"]
+        self.assertFalse(should_auto_merge(variants, threshold=97))
+        self.assertTrue(should_auto_merge(variants, threshold=70))
+
+
+class TestStableClusterKey(unittest.TestCase):
+    def test_order_independent(self):
+        k1 = _stable_cluster_key(["foo", "bar", "baz"])
+        k2 = _stable_cluster_key(["baz", "foo", "bar"])
+        self.assertEqual(k1, k2)
+
+    def test_different_clusters_different_keys(self):
+        k1 = _stable_cluster_key(["foo", "bar"])
+        k2 = _stable_cluster_key(["foo", "baz"])
+        self.assertNotEqual(k1, k2)
+
+    def test_length_16(self):
+        self.assertEqual(len(_stable_cluster_key(["foo"])), 16)
+
+
+class TestJudgeCluster(unittest.TestCase):
+    """Vérifie l'orchestration de l'appel LLM (mocked)."""
+
+    def test_calls_with_structured_output(self):
+        mock_llm = mock.MagicMock()
+        mock_structured = mock.MagicMock()
+        mock_llm.with_structured_output.return_value = mock_structured
+        mock_structured.invoke.return_value = JudgeResult(
+            canonical="Machine Learning",
+            members=["Machine Learning", "Machine learning"],
+        )
+
+        result = judge_cluster(["Machine Learning", "Machine learning"], mock_llm)
+        self.assertEqual(result.canonical, "Machine Learning")
+        self.assertEqual(len(result.members), 2)
+        self.assertEqual(result.splits, [])
+        # Vérifie que le bon schema a été passé
+        mock_llm.with_structured_output.assert_called_once_with(JudgeResult)
+        # Vérifie qu'on a bien passé deux messages (system + human)
+        args = mock_structured.invoke.call_args[0][0]
+        self.assertEqual(len(args), 2)
+
+    def test_handles_splits(self):
+        mock_llm = mock.MagicMock()
+        mock_structured = mock.MagicMock()
+        mock_llm.with_structured_output.return_value = mock_structured
+        mock_structured.invoke.return_value = JudgeResult(
+            canonical="Machine Learning",
+            members=["Machine Learning"],
+            splits=[
+                JudgeSplit(theme="Unsupervised Machine Learning",
+                          reason="sous-domaine"),
+            ],
+        )
+
+        result = judge_cluster(
+            ["Machine Learning", "Unsupervised Machine Learning"],
+            mock_llm,
+        )
+        self.assertEqual(len(result.members), 1)
+        self.assertEqual(len(result.splits), 1)
+        self.assertEqual(result.splits[0].theme, "Unsupervised Machine Learning")
+
+
+class _JudgeBase(unittest.TestCase):
+    """Setup commun : project root temp + profil test."""
+
+    def setUp(self):
+        self.tmp = Path(tempfile.mkdtemp(prefix="klodo_judge_"))
+        (self.tmp / "profiles" / "p").mkdir(parents=True)
+        self._patcher = mock.patch.object(
+            data, "get_project_root", return_value=self.tmp,
+        )
+        self._patcher.start()
+
+    def tearDown(self):
+        self._patcher.stop()
+        shutil.rmtree(self.tmp, ignore_errors=True)
+
+    def _cache_path(self):
+        return self.tmp / "profiles" / "p" / ".cache" / "theme-judge.json"
+
+
+class TestJudgeClustersAutoMerge(_JudgeBase):
+    def test_singleton_yields_trivial_result(self):
+        mock_llm = mock.MagicMock()
+        results = judge_clusters([["Machine Learning"]], "p", mock_llm)
+        self.assertEqual(len(results), 1)
+        self.assertEqual(results[0].canonical, "Machine Learning")
+        self.assertEqual(results[0].members, ["Machine Learning"])
+        # LLM jamais appelé
+        mock_llm.with_structured_output.assert_not_called()
+
+    def test_high_similarity_auto_merged_without_llm(self):
+        mock_llm = mock.MagicMock()
+        results = judge_clusters(
+            [["Machine Learning", "Machine learning"]],
+            "p", mock_llm,
+        )
+        self.assertEqual(len(results), 1)
+        # Canonical = la variante la plus longue (heuristique fallback)
+        self.assertIn(results[0].canonical, {"Machine Learning", "Machine learning"})
+        self.assertEqual(len(results[0].members), 2)
+        # LLM jamais appelé sur ce cluster homogène
+        mock_llm.with_structured_output.assert_not_called()
+
+    def test_ambiguous_cluster_triggers_llm(self):
+        mock_llm = mock.MagicMock()
+        mock_structured = mock.MagicMock()
+        mock_llm.with_structured_output.return_value = mock_structured
+        mock_structured.invoke.return_value = JudgeResult(
+            canonical="Machine Learning",
+            members=["Machine Learning"],
+            splits=[JudgeSplit(theme="Unsupervised Machine Learning",
+                              reason="sous-domaine")],
+        )
+
+        results = judge_clusters(
+            [["Machine Learning", "Unsupervised Machine Learning"]],
+            "p", mock_llm,
+        )
+        self.assertEqual(len(results), 1)
+        self.assertEqual(len(results[0].splits), 1)
+        # LLM appelé une fois
+        mock_llm.with_structured_output.assert_called_once()
+
+
+class TestJudgeClustersCache(_JudgeBase):
+    def test_cache_miss_then_hit(self):
+        mock_llm = mock.MagicMock()
+        mock_structured = mock.MagicMock()
+        mock_llm.with_structured_output.return_value = mock_structured
+        mock_structured.invoke.return_value = JudgeResult(
+            canonical="Foo",
+            members=["Foo Variant A"],
+            splits=[JudgeSplit(theme="Foo Variant B", reason="distinct")],
+        )
+
+        cluster = ["Foo Variant A", "Foo Variant B"]
+
+        # Premier appel : LLM appelé
+        r1 = judge_clusters([cluster], "p", mock_llm)
+        self.assertEqual(mock_structured.invoke.call_count, 1)
+        # Cache écrit sur disque
+        self.assertTrue(self._cache_path().exists())
+
+        # Deuxième appel : cache hit, LLM pas réappelé
+        r2 = judge_clusters([cluster], "p", mock_llm)
+        self.assertEqual(mock_structured.invoke.call_count, 1)  # toujours 1
+        # Même résultat
+        self.assertEqual(r1[0].canonical, r2[0].canonical)
+        self.assertEqual(
+            [s.theme for s in r1[0].splits],
+            [s.theme for s in r2[0].splits],
+        )
+
+    def test_cache_order_independent(self):
+        """Le cache key est calculé sur les variantes triées : deux
+        appels avec le même cluster en ordre différent doivent matcher."""
+        mock_llm = mock.MagicMock()
+        mock_structured = mock.MagicMock()
+        mock_llm.with_structured_output.return_value = mock_structured
+        mock_structured.invoke.return_value = JudgeResult(
+            canonical="X",
+            members=["A", "B"],
+        )
+
+        judge_clusters([["A", "B", "C"]], "p", mock_llm)
+        # Re-juger avec ordre inversé
+        judge_clusters([["C", "B", "A"]], "p", mock_llm)
+        # LLM appelé une seule fois grâce au tri dans la clé
+        self.assertEqual(mock_structured.invoke.call_count, 1)
+
+    def test_use_cache_false_skips_io(self):
+        mock_llm = mock.MagicMock()
+        mock_structured = mock.MagicMock()
+        mock_llm.with_structured_output.return_value = mock_structured
+        mock_structured.invoke.return_value = JudgeResult(
+            canonical="X", members=["A"],
+        )
+
+        judge_clusters([["A", "B", "C"]], "p", mock_llm, use_cache=False)
+        # Pas d'écriture cache
+        self.assertFalse(self._cache_path().exists())
+
+
+class TestJudgeClustersBatch(_JudgeBase):
+    def test_mixed_singletons_homogeneous_ambiguous(self):
+        """Trois clusters de natures différentes en un appel."""
+        mock_llm = mock.MagicMock()
+        mock_structured = mock.MagicMock()
+        mock_llm.with_structured_output.return_value = mock_structured
+        mock_structured.invoke.return_value = JudgeResult(
+            canonical="Java Development",
+            members=["Java Development"],
+            splits=[JudgeSplit(theme="JavaFX Development",
+                              reason="techno UI différente")],
+        )
+
+        clusters = [
+            ["Standalone Theme"],  # singleton
+            ["Machine Learning", "Machine learning"],  # auto-merge
+            ["Java Development", "JavaFX Development"],  # LLM
+        ]
+        results = judge_clusters(clusters, "p", mock_llm)
+
+        self.assertEqual(len(results), 3)
+        # 1) singleton
+        self.assertEqual(results[0].canonical, "Standalone Theme")
+        # 2) auto-merge sans LLM
+        self.assertEqual(len(results[1].members), 2)
+        self.assertEqual(results[1].splits, [])
+        # 3) ambigu : LLM a séparé
+        self.assertEqual(len(results[2].splits), 1)
+        # LLM appelé une SEULE fois (sur le cluster ambigu)
+        self.assertEqual(mock_structured.invoke.call_count, 1)
+
+
+class TestJudgeResultSchema(unittest.TestCase):
+    """Vérifie que le schéma Pydantic est utilisable côté tests."""
+
+    def test_minimal_result(self):
+        r = JudgeResult(canonical="Foo", members=["foo"])
+        self.assertEqual(r.canonical, "Foo")
+        self.assertEqual(r.members, ["foo"])
+        self.assertEqual(r.splits, [])
+
+    def test_full_result_serializable(self):
+        r = JudgeResult(
+            canonical="Foo",
+            members=["foo"],
+            splits=[JudgeSplit(theme="Foo Bar", reason="différent")],
+        )
+        # Round-trip JSON
+        payload = json.loads(r.model_dump_json())
+        self.assertEqual(payload["canonical"], "Foo")
+        self.assertEqual(payload["splits"][0]["theme"], "Foo Bar")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/auto/test_theme_judge.py
+++ b/tests/auto/test_theme_judge.py
@@ -100,8 +100,11 @@ class TestJudgeCluster(unittest.TestCase):
         self.assertEqual(result.canonical, "Machine Learning")
         self.assertEqual(len(result.members), 2)
         self.assertEqual(result.splits, [])
-        # Vérifie que le bon schema a été passé
-        mock_llm.with_structured_output.assert_called_once_with(JudgeResult)
+        # Vérifie que le bon schema + la méthode function_calling sont passés
+        # (GLM-4.7 ne supporte pas le mode JSON par défaut sur SiliconFlow).
+        mock_llm.with_structured_output.assert_called_once_with(
+            JudgeResult, method="function_calling",
+        )
         # Vérifie qu'on a bien passé deux messages (system + human)
         args = mock_structured.invoke.call_args[0][0]
         self.assertEqual(len(args), 2)

--- a/tests/auto/test_theme_judge.py
+++ b/tests/auto/test_theme_judge.py
@@ -285,6 +285,105 @@ class TestJudgeClustersBatch(_JudgeBase):
         self.assertEqual(mock_structured.invoke.call_count, 1)
 
 
+class TestJudgeClustersParallel(_JudgeBase):
+    """Vérifie que la parallélisation produit le bon résultat dans le bon ordre."""
+
+    def test_results_in_input_order_across_workers(self):
+        """Même avec parallélisation, l'ordre des results matche l'ordre des inputs."""
+        mock_llm = mock.MagicMock()
+        mock_structured = mock.MagicMock()
+        mock_llm.with_structured_output.return_value = mock_structured
+
+        # Chaque cluster a son propre JudgeResult identifiable
+        responses = {
+            "alpha": JudgeResult(canonical="ALPHA", members=["alpha-a", "alpha-b"]),
+            "beta":  JudgeResult(canonical="BETA",  members=["beta-a", "beta-b"]),
+            "gamma": JudgeResult(canonical="GAMMA", members=["gamma-a", "gamma-b"]),
+        }
+
+        def respond_by_first_token(messages):
+            # Récupère la 1ère variante du prompt pour décider la réponse
+            content = messages[1].content if len(messages) > 1 else ""
+            for tag in responses:
+                if f'"{tag}-a"' in content:
+                    return responses[tag]
+            return JudgeResult(canonical="?", members=[])
+
+        mock_structured.invoke.side_effect = respond_by_first_token
+
+        clusters = [
+            ["alpha-a", "alpha-b"],
+            ["beta-a", "beta-b"],
+            ["gamma-a", "gamma-b"],
+        ]
+        results = judge_clusters(
+            clusters, "p", mock_llm,
+            use_cache=False, max_workers=4,
+        )
+        # Ordre préservé
+        self.assertEqual(results[0].canonical, "ALPHA")
+        self.assertEqual(results[1].canonical, "BETA")
+        self.assertEqual(results[2].canonical, "GAMMA")
+
+    def test_llm_exception_falls_back_to_identity(self):
+        """Si le LLM raise sur 1 cluster, le pipeline continue."""
+        mock_llm = mock.MagicMock()
+        mock_structured = mock.MagicMock()
+        mock_llm.with_structured_output.return_value = mock_structured
+
+        call_count = [0]
+
+        def maybe_raise(messages):
+            call_count[0] += 1
+            if call_count[0] == 1:
+                raise RuntimeError("simulated LLM failure")
+            return JudgeResult(canonical="OK", members=["ok-a", "ok-b"])
+
+        mock_structured.invoke.side_effect = maybe_raise
+
+        clusters = [
+            ["fail-a", "fail-b"],  # 1er → raise → fallback
+            ["ok-a", "ok-b"],      # 2e → OK
+        ]
+        results = judge_clusters(
+            clusters, "p", mock_llm,
+            use_cache=False, max_workers=1,
+        )
+        # 2 results retournés (pas d'exception remontée)
+        self.assertEqual(len(results), 2)
+        # Le résultat OK est complet, le résultat fail est dégradé en identité
+        canonicals = {r.canonical for r in results}
+        self.assertIn("OK", canonicals)
+
+    def test_progress_callback_thread_safe(self):
+        """Le callback est invoqué (done, total) au moins une fois après le
+        pré-tri et une fois par cluster LLM. Thread-safe via lock interne."""
+        mock_llm = mock.MagicMock()
+        mock_structured = mock.MagicMock()
+        mock_llm.with_structured_output.return_value = mock_structured
+        mock_structured.invoke.return_value = JudgeResult(
+            canonical="X", members=["A"],
+        )
+
+        calls: list[tuple[int, int]] = []
+        clusters = [
+            ["singleton"],                       # → trivial
+            ["match-a", "match-a"],              # → auto-merge
+            ["ambiguous-a", "ambiguous-b"],      # → LLM
+            ["another-a", "another-b-distinct"], # → LLM
+        ]
+        results = judge_clusters(
+            clusters, "p", mock_llm,
+            use_cache=False, max_workers=2,
+            on_progress=lambda done, total: calls.append((done, total)),
+        )
+        self.assertEqual(len(results), 4)
+        # Au moins 1 appel (pré-tri) + 2 LLM = 3 appels min
+        self.assertGreaterEqual(len(calls), 3)
+        # Le dernier doit être (4, 4)
+        self.assertEqual(calls[-1], (4, 4))
+
+
 class TestJudgeResultSchema(unittest.TestCase):
     """Vérifie que le schéma Pydantic est utilisable côté tests."""
 

--- a/tests/auto/test_theme_normalizer.py
+++ b/tests/auto/test_theme_normalizer.py
@@ -1,0 +1,253 @@
+#!/usr/bin/env python3
+"""Tests pour lib.theme_normalizer — Phase 1 du chantier dédupli des thèmes.
+
+Cible : variantes orthographiques pures (casse, ponctuation, singulier/pluriel,
+parenthèses, accents). On NE doit PAS fusionner des sous-domaines distincts
+("Unsupervised Machine Learning" ne doit PAS matcher "Machine Learning" —
+c'est le job du LLM judge à venir en Phase 3).
+
+Cas issus du profil default (vision_cache.json réel) — `Machine Learning` 829
+occurrences face à `Machine learning` 3 occurrences, etc.
+"""
+
+import os
+import sys
+import unittest
+
+PROJECT_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+sys.path.insert(0, PROJECT_ROOT)
+
+from lib.theme_normalizer import (  # noqa: E402
+    group_by_canonical,
+    normalize_theme,
+    normalize_themes_batch,
+)
+
+
+class TestNormalizeBasics(unittest.TestCase):
+    def test_lowercase(self):
+        self.assertEqual(normalize_theme("Machine Learning"), "machine learning")
+
+    def test_already_lowercase(self):
+        self.assertEqual(normalize_theme("machine learning"), "machine learning")
+
+    def test_mixed_case_variants_collapse(self):
+        # Le cas observé : "Machine Learning" (829) vs "Machine learning" (3)
+        self.assertEqual(
+            normalize_theme("Machine Learning"),
+            normalize_theme("Machine learning"),
+        )
+
+    def test_empty_returns_empty(self):
+        self.assertEqual(normalize_theme(""), "")
+        self.assertEqual(normalize_theme(None), "")
+
+    def test_non_string_input(self):
+        self.assertEqual(normalize_theme(42), "")
+        self.assertEqual(normalize_theme(["foo"]), "")
+
+    def test_whitespace_only(self):
+        self.assertEqual(normalize_theme("   "), "")
+
+    def test_collapses_extra_spaces(self):
+        self.assertEqual(normalize_theme("Machine   Learning"), "machine learning")
+        self.assertEqual(normalize_theme("  Python  Programming  "), "python programming")
+
+
+class TestNormalizeAccents(unittest.TestCase):
+    def test_accent_stripped_fr(self):
+        self.assertEqual(
+            normalize_theme("Mathématiques Appliquées"),
+            "mathematique appliquee",
+        )
+
+    def test_accent_stripped_diverse(self):
+        self.assertEqual(normalize_theme("Économétrie"), "econometrie")
+        self.assertEqual(normalize_theme("Naïve Bayes"), "naive baye")
+
+    def test_accent_strip_unifies(self):
+        self.assertEqual(
+            normalize_theme("Économétrie"),
+            normalize_theme("Econometrie"),
+        )
+
+
+class TestNormalizeParentheses(unittest.TestCase):
+    def test_parenthetical_qualifier_stripped(self):
+        # Cas réel : 'Neural Networks (Computer Science)' apparaît avec
+        # juste 'Neural Networks' — la précision parenthétique est noise
+        # pour la dédupli, on l'enlève intentionnellement.
+        self.assertEqual(
+            normalize_theme("Neural Networks (Computer Science)"),
+            "neural network",
+        )
+        self.assertEqual(
+            normalize_theme("Neural Networks (CS)"),
+            "neural network",
+        )
+
+    def test_multiple_parens(self):
+        self.assertEqual(
+            normalize_theme("Algorithm (CS) (advanced)"),
+            "algorithm",
+        )
+
+
+class TestNormalizePunctuation(unittest.TestCase):
+    def test_strip_punctuation(self):
+        self.assertEqual(normalize_theme("C++"), "c")
+        self.assertEqual(normalize_theme("Web 2.0"), "web 2 0")
+
+    def test_hyphen_preserved(self):
+        # Le tiret est sémantique (e-commerce, multi-agent, fine-tuning)
+        self.assertEqual(normalize_theme("E-commerce"), "e-commerce")
+        self.assertEqual(normalize_theme("Multi-Agent Systems"), "multi-agent system")
+
+    def test_slash_treated_as_separator(self):
+        self.assertEqual(normalize_theme("AI/ML"), "ai ml")
+
+
+class TestSingularization(unittest.TestCase):
+    def test_simple_s_plural(self):
+        self.assertEqual(normalize_theme("Networks"), "network")
+        self.assertEqual(normalize_theme("Algorithms"), "algorithm")
+        self.assertEqual(normalize_theme("Neural Networks"), "neural network")
+
+    def test_ies_to_y(self):
+        self.assertEqual(normalize_theme("Technologies"), "technology")
+        self.assertEqual(normalize_theme("Companies"), "company")
+
+    def test_ches_shes_strip_es(self):
+        self.assertEqual(normalize_theme("Branches"), "branch")
+        self.assertEqual(normalize_theme("Bushes"), "bush")
+
+    def test_sses_keeps_ss(self):
+        self.assertEqual(normalize_theme("Classes"), "class")
+        self.assertEqual(normalize_theme("Processes"), "process")
+
+    def test_false_plural_statistics(self):
+        # Cas observé : 'Statistics' (95) — ne PAS le transformer en 'statistic'
+        self.assertEqual(normalize_theme("Statistics"), "statistics")
+        self.assertEqual(normalize_theme("Mathematics"), "mathematics")
+        self.assertEqual(normalize_theme("Physics"), "physics")
+        self.assertEqual(normalize_theme("Robotics"), "robotics")
+        self.assertEqual(normalize_theme("Linguistics"), "linguistics")
+
+    def test_false_plural_analysis(self):
+        # 'Analysis' (≠ 'analyses') — pas de strip du -is
+        self.assertEqual(normalize_theme("Analysis"), "analysis")
+        self.assertEqual(normalize_theme("Thesis"), "thesis")
+        self.assertEqual(normalize_theme("Hypothesis"), "hypothesis")
+
+    def test_irregular_plural(self):
+        self.assertEqual(normalize_theme("Children"), "child")
+        self.assertEqual(normalize_theme("Criteria"), "criterion")
+
+    def test_short_acronyms_preserved(self):
+        # On ne touche pas aux acronymes courts (≤ 3 chars OU dans _KEEP_AS_IS)
+        self.assertEqual(normalize_theme("ML"), "ml")
+        self.assertEqual(normalize_theme("AI"), "ai")
+        self.assertEqual(normalize_theme("OS"), "os")
+        self.assertEqual(normalize_theme("NLP"), "nlp")
+
+    def test_us_suffix_preserved(self):
+        # 'Bus' ne doit pas devenir 'bu'
+        self.assertEqual(normalize_theme("Bus"), "bus")
+        self.assertEqual(normalize_theme("Virus"), "virus")
+
+
+class TestStopwords(unittest.TestCase):
+    def test_strips_english_stopwords(self):
+        self.assertEqual(normalize_theme("Theory of Computation"), "theory computation")
+        self.assertEqual(normalize_theme("Introduction to Algorithms"), "introduction algorithm")
+
+    def test_strips_french_stopwords(self):
+        self.assertEqual(normalize_theme("Théorie des Graphes"), "theorie graphe")
+        self.assertEqual(normalize_theme("Le Machine Learning"), "machine learning")
+
+    def test_does_not_strip_content_words(self):
+        # 'Programming' ne doit pas être stripped
+        self.assertEqual(normalize_theme("Functional Programming"), "functional programming")
+
+
+class TestRealWorldDuplicates(unittest.TestCase):
+    """Cas observés dans le profil default — chaque pair doit collapse."""
+
+    def assert_same_canonical(self, a, b):
+        ca, cb = normalize_theme(a), normalize_theme(b)
+        self.assertEqual(ca, cb, f"{a!r} → {ca!r} != {b!r} → {cb!r}")
+
+    def test_machine_learning_case(self):
+        self.assert_same_canonical("Machine Learning", "Machine learning")
+
+    def test_python_programming_case(self):
+        self.assert_same_canonical("Python Programming", "Python programming")
+
+    def test_neural_networks_plural(self):
+        self.assert_same_canonical("Neural Networks", "Neural Network")
+
+    def test_artificial_neural_networks(self):
+        # Variante avec qualifier — ne PAS fusionner avec Neural Networks
+        ca = normalize_theme("Neural Networks")
+        cb = normalize_theme("Artificial Neural Networks")
+        self.assertNotEqual(ca, cb, "Artificial Neural Networks ≠ Neural Networks (sous-domaine)")
+
+
+class TestSubDomainsNotMerged(unittest.TestCase):
+    """Les sous-domaines (ajoutant des mots qualifiants) ne doivent PAS
+    fusionner avec le terme parent — c'est le job du LLM judge plus tard."""
+
+    def test_unsupervised_ml(self):
+        self.assertNotEqual(
+            normalize_theme("Machine Learning"),
+            normalize_theme("Unsupervised Machine Learning"),
+        )
+
+    def test_deep_learning_specializations(self):
+        self.assertNotEqual(
+            normalize_theme("Deep Learning"),
+            normalize_theme("Deep Learning for Computer Vision"),
+        )
+
+    def test_data_science_specializations(self):
+        self.assertNotEqual(
+            normalize_theme("Data Science"),
+            normalize_theme("Spatial Data Science"),
+        )
+
+
+class TestBatchAndGroup(unittest.TestCase):
+    def test_normalize_themes_batch(self):
+        themes = ["Machine Learning", "Machine learning", "Deep Learning"]
+        out = normalize_themes_batch(themes)
+        self.assertEqual(out["Machine Learning"], "machine learning")
+        self.assertEqual(out["Machine learning"], "machine learning")
+        self.assertEqual(out["Deep Learning"], "deep learning")
+
+    def test_batch_skips_empty(self):
+        out = normalize_themes_batch(["Foo", "", None, "Bar"])  # type: ignore[list-item]
+        self.assertIn("Foo", out)
+        self.assertIn("Bar", out)
+        self.assertNotIn("", out)
+        self.assertNotIn(None, out)
+
+    def test_group_by_canonical(self):
+        themes = [
+            "Machine Learning", "Machine learning",
+            "Neural Networks", "Neural Network",
+            "Deep Learning",
+        ]
+        groups = group_by_canonical(themes)
+        self.assertEqual(set(groups.keys()), {"machine learning", "neural network", "deep learning"})
+        self.assertEqual(set(groups["machine learning"]), {"Machine Learning", "Machine learning"})
+        self.assertEqual(set(groups["neural network"]), {"Neural Networks", "Neural Network"})
+        self.assertEqual(groups["deep learning"], ["Deep Learning"])
+
+    def test_group_skips_empty_canonical(self):
+        # Un input qui se normalise à "" doit être skip
+        groups = group_by_canonical(["   ", "Real Theme"])
+        self.assertEqual(list(groups.keys()), ["real theme"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/auto/test_theme_normalizer.py
+++ b/tests/auto/test_theme_normalizer.py
@@ -18,6 +18,8 @@ PROJECT_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(_
 sys.path.insert(0, PROJECT_ROOT)
 
 from lib.theme_normalizer import (  # noqa: E402
+    cluster_canonical_forms,
+    cluster_themes,
     group_by_canonical,
     normalize_theme,
     normalize_themes_batch,
@@ -247,6 +249,140 @@ class TestBatchAndGroup(unittest.TestCase):
         # Un input qui se normalise à "" doit être skip
         groups = group_by_canonical(["   ", "Real Theme"])
         self.assertEqual(list(groups.keys()), ["real theme"])
+
+
+class TestClusterCanonicalForms(unittest.TestCase):
+    """Phase 2 : clustering fuzzy sur les formes canoniques."""
+
+    def _find_cluster_for(self, clusters, target):
+        for c in clusters:
+            if target in c:
+                return c
+        return None
+
+    def test_singletons_unchanged(self):
+        forms = ["machine learning", "deep learning", "compiler design"]
+        clusters = cluster_canonical_forms(forms)
+        self.assertEqual(len(clusters), 3)
+        for c in clusters:
+            self.assertEqual(len(c), 1)
+
+    def test_clusters_close_forms(self):
+        # Cas réel : "computer system administration" vs "computer systems
+        # administration" — capture les variantes que la singularisation
+        # ne peut pas unifier (Phase 1 voit "system" et "systems" comme
+        # mots distincts au tokenize avant que la dépluralisation entre
+        # en jeu — c'est en réalité géré par Phase 1, mais on garde le
+        # test pour les vrais cas type "Optimization vs Optimisation").
+        forms = [
+            "search engine optimization",
+            "search engine optimisation",  # variante orthographique
+            "machine learning",
+        ]
+        clusters = cluster_canonical_forms(forms, threshold=90)
+        # Les deux SEO doivent être dans le même cluster
+        cluster = self._find_cluster_for(clusters, "search engine optimization")
+        self.assertIn("search engine optimisation", cluster)
+        # Machine learning reste isolé
+        ml_cluster = self._find_cluster_for(clusters, "machine learning")
+        self.assertEqual(ml_cluster, ["machine learning"])
+
+    def test_does_not_merge_subdomains(self):
+        # Sous-domaines distincts : ne doivent PAS fusionner même en fuzzy
+        forms = [
+            "machine learning",
+            "unsupervised machine learning",
+            "deep learning",
+            "statistical learning",
+            "statistical modeling",
+        ]
+        clusters = cluster_canonical_forms(forms, threshold=90)
+        self.assertEqual(len(clusters), 5, f"Expected 5 isolated clusters, got: {clusters}")
+
+    def test_empty_input(self):
+        self.assertEqual(cluster_canonical_forms([]), [])
+
+    def test_threshold_too_low_merges_subdomains(self):
+        # Document du comportement : à threshold 50, des sous-domaines fusionnent
+        # avec token_sort_ratio (c'est pour ça qu'on garde 90 par défaut).
+        forms = ["machine learning", "deep learning"]
+        clusters = cluster_canonical_forms(forms, threshold=50)
+        # token_sort_ratio('machine learning', 'deep learning') = 55.2 → fusionne
+        self.assertEqual(len(clusters), 1)
+        self.assertEqual(set(clusters[0]), {"machine learning", "deep learning"})
+
+    def test_threshold_high_keeps_seo_variants_apart(self):
+        # À threshold 99, seuls les matches quasi-parfaits passent
+        forms = ["search engine optimization", "search engine optimisation"]
+        clusters = cluster_canonical_forms(forms, threshold=99)
+        self.assertEqual(len(clusters), 2)
+
+
+class TestClusterThemes(unittest.TestCase):
+    """Pipeline complet raw_themes → clusters fuzzy (Phase 1 + Phase 2)."""
+
+    def test_basic_pipeline(self):
+        # Mélange : 2 variantes orthographiques + 1 isolé
+        themes = ["Machine Learning", "Machine learning", "Deep Learning"]
+        clusters = cluster_themes(themes)
+        # 2 clusters : machine learning (2 membres), deep learning (1)
+        self.assertEqual(len(clusters), 2)
+        # Le plus gros en premier (tri par taille)
+        self.assertEqual(len(clusters[0]["raw_members"]), 2)
+        self.assertEqual(set(clusters[0]["raw_members"]), {"Machine Learning", "Machine learning"})
+        self.assertEqual(clusters[1]["raw_members"], ["Deep Learning"])
+
+    def test_phase1_handles_pure_case_variants(self):
+        # Avec normalize_theme, "Machine Learning" et "Machine learning"
+        # ont la même forme canonique → un seul cluster, sans recours à
+        # rapidfuzz.
+        themes = ["Machine Learning", "Machine learning"]
+        clusters = cluster_themes(themes)
+        self.assertEqual(len(clusters), 1)
+        self.assertEqual(clusters[0]["canonical_forms"], ["machine learning"])
+
+    def test_phase2_adds_fuzzy_matches(self):
+        # Variantes que Phase 1 ne capture pas mais Phase 2 oui :
+        # "optimization" vs "optimisation" (orthographe US/UK)
+        themes = [
+            "Search Engine Optimization",
+            "Search Engine Optimisation",
+            "Search engine optimisation",
+        ]
+        clusters = cluster_themes(themes)
+        self.assertEqual(len(clusters), 1)
+        self.assertEqual(set(clusters[0]["raw_members"]), {
+            "Search Engine Optimization",
+            "Search Engine Optimisation",
+            "Search engine optimisation",
+        })
+
+    def test_subdomains_stay_separate(self):
+        themes = [
+            "Machine Learning",
+            "Unsupervised Machine Learning",
+            "Deep Learning",
+        ]
+        clusters = cluster_themes(themes)
+        self.assertEqual(len(clusters), 3)
+
+    def test_empty_themes_skipped(self):
+        themes = ["Machine Learning", "", None, "Deep Learning"]
+        clusters = cluster_themes(themes)  # type: ignore[arg-type]
+        self.assertEqual(len(clusters), 2)
+        flat = [m for c in clusters for m in c["raw_members"]]
+        self.assertEqual(set(flat), {"Machine Learning", "Deep Learning"})
+
+    def test_sorted_by_size_desc(self):
+        # Cluster A : 3 membres ; B : 2 ; C : 1
+        themes = [
+            "Statistics", "statistics", "STATISTICS",  # A: 3
+            "Web Development", "web development",       # B: 2
+            "Quantum Computing",                        # C: 1
+        ]
+        clusters = cluster_themes(themes)
+        sizes = [len(c["raw_members"]) for c in clusters]
+        self.assertEqual(sizes, [3, 2, 1])
 
 
 if __name__ == "__main__":

--- a/tests/auto/test_theme_resolver.py
+++ b/tests/auto/test_theme_resolver.py
@@ -22,8 +22,13 @@ sys.path.insert(0, PROJECT_ROOT)
 from dashboard import data  # noqa: E402
 from lib.theme_resolver import (  # noqa: E402
     TITLES_PER_THEME,
+    BatchResolution,
+    ResolvedTheme,
+    _stable_batch_key,
     count_themes,
     extract_themes_with_titles,
+    resolve_batch,
+    resolve_themes_with_context,
     themes_with_titles_iter,
 )
 
@@ -182,6 +187,233 @@ class TestThemesWithTitlesIter(unittest.TestCase):
 
     def test_empty(self):
         self.assertEqual(list(themes_with_titles_iter({})), [])
+
+
+class TestStableBatchKey(unittest.TestCase):
+    def test_batch_order_matters(self):
+        # L'ordre du batch est sémantiquement important (mappings[] ordonné)
+        k1 = _stable_batch_key([("A", ["t1"]), ("B", ["t2"])], ["v1"])
+        k2 = _stable_batch_key([("B", ["t2"]), ("A", ["t1"])], ["v1"])
+        self.assertNotEqual(k1, k2)
+
+    def test_vocab_order_irrelevant(self):
+        k1 = _stable_batch_key([("A", ["t1"])], ["v1", "v2"])
+        k2 = _stable_batch_key([("A", ["t1"])], ["v2", "v1"])
+        self.assertEqual(k1, k2)
+
+    def test_titles_order_irrelevant(self):
+        # Les titres dans une entrée sont triés dans la clé — l'ordre de
+        # collecte des titres ne doit pas invalider le cache.
+        k1 = _stable_batch_key([("A", ["t1", "t2"])], ["v"])
+        k2 = _stable_batch_key([("A", ["t2", "t1"])], ["v"])
+        self.assertEqual(k1, k2)
+
+    def test_length_16(self):
+        self.assertEqual(len(_stable_batch_key([("A", [])], ["B"])), 16)
+
+
+class TestResolveBatch(unittest.TestCase):
+    def _mock_llm(self, mappings: list[ResolvedTheme]):
+        mock_llm = mock.MagicMock()
+        mock_structured = mock.MagicMock()
+        mock_llm.with_structured_output.return_value = mock_structured
+        mock_structured.invoke.return_value = BatchResolution(mappings=mappings)
+        return mock_llm
+
+    def test_happy_path(self):
+        mock_llm = self._mock_llm([
+            ResolvedTheme(raw="ML", canonical="Machine Learning",
+                          matched_existing=True),
+            ResolvedTheme(raw="Logic", canonical="Logic",
+                          matched_existing=False),
+        ])
+        result = resolve_batch(
+            [("ML", ["Intro to ML"]), ("Logic", ["A First Course in Logic"])],
+            ["Machine Learning"],
+            mock_llm,
+        )
+        self.assertEqual(result, {
+            "ML": "Machine Learning",
+            "Logic": "Logic",
+        })
+
+    def test_forces_function_calling(self):
+        # GLM-4.7 ne supporte pas json mode → on doit forcer function_calling
+        mock_llm = self._mock_llm([
+            ResolvedTheme(raw="A", canonical="A", matched_existing=False),
+        ])
+        resolve_batch([("A", ["t1"])], [], mock_llm)
+        _, kwargs = mock_llm.with_structured_output.call_args
+        self.assertEqual(kwargs.get("method"), "function_calling")
+
+    def test_empty_batch(self):
+        mock_llm = mock.MagicMock()
+        self.assertEqual(resolve_batch([], ["v"], mock_llm), {})
+        mock_llm.with_structured_output.assert_not_called()
+
+    def test_safety_net_when_llm_omits_themes(self):
+        # LLM ne renvoie qu'1 mapping sur 2 demandés → l'autre → identité
+        mock_llm = self._mock_llm([
+            ResolvedTheme(raw="A", canonical="X", matched_existing=True),
+        ])
+        result = resolve_batch(
+            [("A", ["t1"]), ("B", ["t2"])], ["X"], mock_llm,
+        )
+        self.assertEqual(result["A"], "X")
+        self.assertEqual(result["B"], "B")
+
+    def test_empty_canonical_falls_back_to_raw(self):
+        mock_llm = self._mock_llm([
+            ResolvedTheme(raw="A", canonical="   ", matched_existing=False),
+        ])
+        result = resolve_batch([("A", ["t"])], [], mock_llm)
+        self.assertEqual(result["A"], "A")
+
+    def test_titles_included_in_prompt(self):
+        """Le user prompt doit inclure les titres en contexte."""
+        captured: list = []
+
+        def capture(messages):
+            captured.append(messages)
+            return BatchResolution(mappings=[
+                ResolvedTheme(raw="A", canonical="A", matched_existing=False),
+            ])
+
+        mock_llm = mock.MagicMock()
+        mock_structured = mock.MagicMock()
+        mock_llm.with_structured_output.return_value = mock_structured
+        mock_structured.invoke.side_effect = capture
+        resolve_batch(
+            [("ML", ["Pattern Recognition and Machine Learning",
+                     "Introduction to ML"])],
+            ["Machine Learning"],
+            mock_llm,
+        )
+        user_msg = captured[0][1].content
+        self.assertIn("Machine Learning", user_msg)  # vocab
+        self.assertIn("ML", user_msg)
+        self.assertIn("Pattern Recognition", user_msg)
+        self.assertIn("Introduction to ML", user_msg)
+
+
+class TestResolveThemesWithContext(_ResolverBase):
+    def _scripted_llm(self, mapping: dict[str, str]):
+        """LLM qui retourne {canonical} d'après un dict scripté pour raw."""
+        mock_llm = mock.MagicMock()
+        mock_structured = mock.MagicMock()
+        mock_llm.with_structured_output.return_value = mock_structured
+
+        def respond(messages):
+            # Le user prompt liste "Thème i : 'X'" → on extrait les X
+            import re
+            content = messages[1].content
+            raws = re.findall(r"^Thème \d+ : '([^']+)'", content, re.MULTILINE)
+            pairs = [
+                ResolvedTheme(
+                    raw=raw,
+                    canonical=mapping.get(raw, raw),
+                    matched_existing=mapping.get(raw, raw) != raw,
+                )
+                for raw in raws
+            ]
+            return BatchResolution(mappings=pairs)
+
+        mock_structured.invoke.side_effect = respond
+        return mock_llm
+
+    def test_empty_input(self):
+        mock_llm = mock.MagicMock()
+        self.assertEqual(
+            resolve_themes_with_context({}, ["v"], mock_llm, "p",
+                                         use_cache=False),
+            {},
+        )
+        mock_llm.with_structured_output.assert_not_called()
+
+    def test_vocab_themes_skip_llm(self):
+        mock_llm = mock.MagicMock()
+        out = resolve_themes_with_context(
+            {"Machine Learning": ["t1"], "Data Science": ["t2"]},
+            ["Machine Learning", "Data Science"],
+            mock_llm, "p", use_cache=False,
+        )
+        self.assertEqual(out, {
+            "Machine Learning": "Machine Learning",
+            "Data Science": "Data Science",
+        })
+        mock_llm.with_structured_output.assert_not_called()
+
+    def test_basic_resolution(self):
+        llm = self._scripted_llm({
+            "ML": "Machine Learning",
+            "machine learning": "Machine Learning",
+        })
+        out = resolve_themes_with_context(
+            {
+                "Machine Learning": ["t1"],
+                "ML": ["Intro to ML"],
+                "machine learning": ["ML for Dummies"],
+            },
+            ["Machine Learning"],
+            llm, "p", batch_size=10, max_workers=1, use_cache=False,
+        )
+        self.assertEqual(out["Machine Learning"], "Machine Learning")
+        self.assertEqual(out["ML"], "Machine Learning")
+        self.assertEqual(out["machine learning"], "Machine Learning")
+
+    def test_cache_persists(self):
+        llm = self._scripted_llm({"A": "X"})
+        themes_titles = {"A": ["title_A"]}
+        # 1er appel : LLM appelé, cache écrit
+        resolve_themes_with_context(
+            themes_titles, [], llm, "p",
+            batch_size=10, max_workers=1, use_cache=True,
+        )
+        cache_path = (
+            self.tmp / "profiles" / "p" / ".cache" / "theme-resolver.json"
+        )
+        self.assertTrue(cache_path.exists())
+        # 2e appel : LLM jamais ré-appelé (cache hit)
+        llm.with_structured_output.return_value.invoke.reset_mock()
+        resolve_themes_with_context(
+            themes_titles, [], llm, "p",
+            batch_size=10, max_workers=1, use_cache=True,
+        )
+        llm.with_structured_output.return_value.invoke.assert_not_called()
+
+    def test_llm_failure_falls_back_to_identity(self):
+        mock_llm = mock.MagicMock()
+        mock_structured = mock.MagicMock()
+        mock_llm.with_structured_output.return_value = mock_structured
+        mock_structured.invoke.side_effect = RuntimeError("LLM down")
+
+        out = resolve_themes_with_context(
+            {"A": ["t1"], "B": ["t2"]}, [], mock_llm, "p",
+            batch_size=10, max_workers=1, use_cache=False,
+        )
+        self.assertEqual(out, {"A": "A", "B": "B"})
+
+    def test_progress_callback(self):
+        themes_titles = {f"T{i}": [f"title_{i}"] for i in range(15)}
+        llm = self._scripted_llm({})
+        calls: list[tuple[int, int]] = []
+        resolve_themes_with_context(
+            themes_titles, [], llm, "p",
+            batch_size=5, max_workers=1, use_cache=False,
+            on_progress=lambda d, t: calls.append((d, t)),
+        )
+        # 15 / 5 = 3 batches → 3 callbacks min, dernier = (3, 3)
+        self.assertGreaterEqual(len(calls), 3)
+        self.assertEqual(calls[-1], (3, 3))
+
+    def test_parallel_workers_preserve_completeness(self):
+        themes_titles = {f"T{i}": [f"t_{i}"] for i in range(50)}
+        llm = self._scripted_llm({})
+        out = resolve_themes_with_context(
+            themes_titles, [], llm, "p",
+            batch_size=10, max_workers=4, use_cache=False,
+        )
+        self.assertEqual(set(out.keys()), set(themes_titles.keys()))
 
 
 if __name__ == "__main__":

--- a/tests/auto/test_theme_resolver.py
+++ b/tests/auto/test_theme_resolver.py
@@ -1,0 +1,188 @@
+#!/usr/bin/env python3
+"""Tests pour lib.theme_resolver — D.1 du chantier C.2.
+
+Couvre :
+  - extract_themes_with_titles : collecte 5 titres par thème, dédup, ordre stable
+  - count_themes : occurrences brutes
+  - themes_with_titles_iter : ordre lexico déterministe
+"""
+
+import json
+import os
+import shutil
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+PROJECT_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+sys.path.insert(0, PROJECT_ROOT)
+
+from dashboard import data  # noqa: E402
+from lib.theme_resolver import (  # noqa: E402
+    TITLES_PER_THEME,
+    count_themes,
+    extract_themes_with_titles,
+    themes_with_titles_iter,
+)
+
+
+class _ResolverBase(unittest.TestCase):
+    def setUp(self):
+        self.tmp = Path(tempfile.mkdtemp(prefix="klodo_resolver_"))
+        (self.tmp / "profiles" / "p" / ".cache").mkdir(parents=True)
+        self._patcher = mock.patch.object(
+            data, "get_project_root", return_value=self.tmp,
+        )
+        self._patcher.start()
+
+    def tearDown(self):
+        self._patcher.stop()
+        shutil.rmtree(self.tmp, ignore_errors=True)
+
+    def _write_vision_cache(self, entries: list[dict]) -> None:
+        path = self.tmp / "profiles" / "p" / ".cache" / "vision_cache.json"
+        cache = {f"hash_{i}": e for i, e in enumerate(entries)}
+        path.write_text(json.dumps(cache, ensure_ascii=False), encoding="utf-8")
+
+
+class TestExtractThemesWithTitles(_ResolverBase):
+    def test_no_cache_returns_empty(self):
+        self.assertEqual(extract_themes_with_titles("p"), {})
+
+    def test_basic_collection(self):
+        self._write_vision_cache([
+            {"result": {"title": "Book A", "themes": [{"theme": "Logic"}]}},
+            {"result": {"title": "Book B", "themes": [{"theme": "Logic"}]}},
+            {"result": {"title": "Book C", "themes": [{"theme": "Statistics"}]}},
+        ])
+        out = extract_themes_with_titles("p")
+        self.assertEqual(set(out.keys()), {"Logic", "Statistics"})
+        self.assertEqual(out["Logic"], ["Book A", "Book B"])
+        self.assertEqual(out["Statistics"], ["Book C"])
+
+    def test_caps_at_titles_per_theme(self):
+        entries = [
+            {"result": {"title": f"Book {i}", "themes": [{"theme": "Foo"}]}}
+            for i in range(10)
+        ]
+        self._write_vision_cache(entries)
+        out = extract_themes_with_titles("p")
+        self.assertEqual(len(out["Foo"]), TITLES_PER_THEME)  # max 5
+        # Premier-arrivé : Book 0..4
+        self.assertEqual(out["Foo"], [f"Book {i}" for i in range(5)])
+
+    def test_deduplicates_titles_per_theme(self):
+        # Même titre apparaît 2x avec le même thème → 1 seule entrée
+        self._write_vision_cache([
+            {"result": {"title": "Repeated", "themes": [{"theme": "X"}]}},
+            {"result": {"title": "Repeated", "themes": [{"theme": "X"}]}},
+            {"result": {"title": "Other", "themes": [{"theme": "X"}]}},
+        ])
+        out = extract_themes_with_titles("p")
+        self.assertEqual(out["X"], ["Repeated", "Other"])
+
+    def test_string_themes_supported(self):
+        # Format legacy : theme en str au lieu de dict
+        self._write_vision_cache([
+            {"result": {"title": "Book", "themes": ["StringTheme", {"theme": "DictTheme"}]}},
+        ])
+        out = extract_themes_with_titles("p")
+        self.assertEqual(set(out.keys()), {"StringTheme", "DictTheme"})
+
+    def test_skips_empty_title(self):
+        # Si pas de titre, on skip (sinon les titres injectés deviennent vides)
+        self._write_vision_cache([
+            {"result": {"title": "", "themes": [{"theme": "X"}]}},
+            {"result": {"title": "Real", "themes": [{"theme": "X"}]}},
+        ])
+        out = extract_themes_with_titles("p")
+        self.assertEqual(out["X"], ["Real"])
+
+    def test_skips_empty_theme(self):
+        self._write_vision_cache([
+            {"result": {"title": "T", "themes": [{"theme": ""}, {"theme": "Real"}]}},
+        ])
+        out = extract_themes_with_titles("p")
+        self.assertEqual(set(out.keys()), {"Real"})
+
+    def test_handles_string_result_legacy(self):
+        # Le vision_cache historique stocke parfois result en str repr Python
+        legacy = "{'title': 'Legacy Book', 'themes': [{'theme': 'X'}]}"
+        self._write_vision_cache([{"result": legacy}])
+        out = extract_themes_with_titles("p")
+        self.assertEqual(out["X"], ["Legacy Book"])
+
+    def test_skips_corrupted_entries(self):
+        self._write_vision_cache([
+            {"result": {"title": "Good", "themes": [{"theme": "X"}]}},
+            {"result": "not json"},
+            {"not_an_entry": True},
+            {"result": {"themes": []}},  # pas de title ni thèmes
+        ])
+        out = extract_themes_with_titles("p")
+        self.assertEqual(out["X"], ["Good"])
+
+    def test_strips_whitespace(self):
+        self._write_vision_cache([
+            {"result": {"title": "  Padded  ", "themes": [{"theme": "  X  "}]}},
+        ])
+        out = extract_themes_with_titles("p")
+        self.assertEqual(out, {"X": ["Padded"]})
+
+    def test_multiple_themes_per_entry(self):
+        # Un livre peut avoir plusieurs thèmes
+        self._write_vision_cache([
+            {"result": {"title": "Multi", "themes": [
+                {"theme": "Theme A"}, {"theme": "Theme B"}, {"theme": "Theme C"},
+            ]}},
+        ])
+        out = extract_themes_with_titles("p")
+        self.assertEqual(out["Theme A"], ["Multi"])
+        self.assertEqual(out["Theme B"], ["Multi"])
+        self.assertEqual(out["Theme C"], ["Multi"])
+
+
+class TestCountThemes(_ResolverBase):
+    def test_basic_count(self):
+        self._write_vision_cache([
+            {"result": {"title": "A", "themes": [{"theme": "X"}, {"theme": "Y"}]}},
+            {"result": {"title": "B", "themes": [{"theme": "X"}]}},
+        ])
+        counts = count_themes("p")
+        self.assertEqual(counts, {"X": 2, "Y": 1})
+
+    def test_no_cache_returns_empty(self):
+        self.assertEqual(count_themes("p"), {})
+
+    def test_skips_empty_themes(self):
+        self._write_vision_cache([
+            {"result": {"title": "T", "themes": [{"theme": ""}, {"theme": "Real"}]}},
+        ])
+        counts = count_themes("p")
+        self.assertEqual(counts, {"Real": 1})
+
+
+class TestThemesWithTitlesIter(unittest.TestCase):
+    def test_lexico_order(self):
+        themes = {
+            "Zebra": ["t1"],
+            "apple": ["t2"],
+            "Banana": ["t3"],
+        }
+        keys = [t for t, _ in themes_with_titles_iter(themes)]
+        # Ordre lexico Python (default uppercase first) : 'B', 'Z', 'a'
+        self.assertEqual(keys, sorted(themes.keys()))
+
+    def test_yields_pairs(self):
+        themes = {"X": ["t1", "t2"]}
+        result = list(themes_with_titles_iter(themes))
+        self.assertEqual(result, [("X", ["t1", "t2"])])
+
+    def test_empty(self):
+        self.assertEqual(list(themes_with_titles_iter({})), [])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Chantier complet pour consolider les variantes orthographiques et synonymes des thèmes LLM (15 376 raw_themes sur le profil `default`). 3 modes proposés, **mode `source` (C.2)** retenu comme défaut.

### Architecture en 3 modes

| Mode | Description | Réduction | Verdict |
|---|---|---|---|
| `syntactic` (Phases 1-3) | Normalisation déterministe + clustering fuzzy + LLM judge | 11% | ortho only |
| `semantic` (C-light) | Vocabulaire bootstrap + LLM aveugle | trop agressif | déconseillé |
| **`source` (C.2)** ← défaut | LLM + contexte titres + skip re-clustering | **5.8 %** | utilisable |

### Composants livrés

**Backend (`lib/`)** :
- `theme_normalizer.py` — normalisation NFKD + déduplication + clustering fuzzy rapidfuzz
- `theme_judge.py` — LLM judge sur clusters ambigus (mode syntactic)
- `theme_canonicalizer.py` — canonisation LLM aveugle (mode semantic)
- `theme_resolver.py` — canonisation LLM avec **contexte 5 titres** (mode source)
- `theme_canon.py` — orchestrateur `build_canon_table(mode=)` + persistance + branchement aggregator

**Backend dashboard (`dashboard/`)** :
- `dedupli.py` — start/get_status/cancel/restore_initial avec threads daemon + zombie reap + boot reset
- `app.py` — 5 endpoints REST (`/api/taxonomy/dedupli/{build,status,clusters,cluster,cancel,restore}`)
- Branchement automatique dans `taxonomy._aggregate_themes_llm` via `load_canon_table` lazy

**UI** :
- Nouvel onglet 🔗 Dédupli dans Taxonomie
- Toggle Mode (Syntactique / Sémantique / Source)
- Progress bar avec phase, bouton 🛑 Annuler en cours, 🔄 Restaurer thèmes initiaux
- Liste clusters + détail éditable (cocher members/splits, renommer canonical, save)
- Modale partagée du dashboard (`#tax-confirm-modal`), toast
- Invalidation automatique du snapshot taxonomy après build/restore — propagation immédiate aux onglets Mappings / Refonte sans clic manuel "🔄 Recharger"

### Bugs résolus en cours de route
- SiliconFlow disconnect serveur-side à ~90s sur function_calling → `streaming=False` côté resolver
- Prompt trop fusionnant → conservateur + anti-composition (X with Y, X for Z, Advanced X)
- Canonical absurde (max len) → max count cumulé
- Re-clustering fuzzy pollu pour mode source → skip
- Run zombie → boot reset + reap 2 min
- Modale natif au lieu de tax-confirm-modal → helper dupliqué

### Métriques
- 1116 tests verts (vs 904 baseline, +212)
- ruff clean
- `theme-canon.json` opt-in : aucun risque de régression sur profils sans canon
- Re-build depuis cache LLM = 0.5s / $0 → itération rapide pour ajuster prompt

## Test plan

- [ ] Build mode `source` sur `default` : ~32 min, ~$2 → 5.8% réduction
- [ ] Vérifier que les onglets Mappings / Refonte voient les counts cumulés après build (hard-reload Cmd+Shift+R)
- [ ] Restaurer via 🔄 → la modale dashboard s'affiche (pas l'alert navigateur), tout revient à l'état initial
- [ ] Lancer + annuler en cours via 🛑 → status passe à `cancelled`, le build n'écrit pas `theme-canon.json`
- [ ] Restart dashboard pendant un run → boot reset met le run à `error` immédiatement

🤖 Generated with [Claude Code](https://claude.com/claude-code)