### PR TITLE
feat: Agent Refonte Phase C + ergonomie Taxonomie (cascade categories, breakdown routage, bulk-delete)

### DIFF
--- a/agents/refonte/agent_backup.py
+++ b/agents/refonte/agent_backup.py
@@ -1,0 +1,250 @@
+"""Backup automatique des YAML de production avant chaque mutation
+de l'agent Refonte Phase C.
+
+Approche : full snapshot de `tree.yaml` + `theme_mapping.yaml` dans
+`profiles/<p>/.cache/taxonomy-backups/agent-<batch_id>-<ts>/`. Pas de
+diff incrémental — la simplicité prime sur la compacité (~quelques KB
+par snapshot, négligeable).
+
+Rotation : ne garde que les MAX_BACKUPS plus récents (défaut 50). Le
+nettoyage cible UNIQUEMENT les snapshots agent-* (les backups manuels
+d'autres systèmes restent intacts).
+
+Pattern réutilisé du backup existant `theme_mapping.yaml` côté taxonomy.
+"""
+
+from __future__ import annotations
+
+import shutil
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+from dashboard import data
+
+# Nombre maximum de snapshots agent gardés. Au-delà, les plus anciens
+# (par ordre de timestamp dans le nom) sont supprimés.
+MAX_BACKUPS_DEFAULT = 50
+
+# Fichiers de production à snapshotter. Si un fichier est absent au moment
+# du backup, on l'omet silencieusement — le restore le créera/n'écrasera
+# que ceux présents dans le snapshot.
+PROD_FILES = ("tree.yaml", "theme_mapping.yaml")
+
+
+class BackupError(Exception):
+    """Erreur côté backup/restore agent."""
+
+
+def _backups_root(profile: str) -> Path:
+    return (
+        data.get_project_root()
+        / "profiles" / profile / ".cache" / "taxonomy-backups"
+    )
+
+
+def _profile_root(profile: str) -> Path:
+    return data.get_project_root() / "profiles" / profile
+
+
+def _ts_for_filename() -> str:
+    """Horodatage compact safe pour un nom de dossier."""
+    return datetime.now(UTC).strftime("%Y%m%d-%H%M%S")
+
+
+def _backup_dir_name(batch_id: str, ts: str | None = None) -> str:
+    """Format canonique du nom de dossier agent : `agent-<batch_id>-<ts>`.
+
+    Le batch_id est un UUID4 (cf. agent_journal.generate_batch_id).
+    """
+    ts = ts or _ts_for_filename()
+    return f"agent-{batch_id}-{ts}"
+
+
+def create_backup(
+    profile: str,
+    batch_id: str,
+    *,
+    max_keep: int = MAX_BACKUPS_DEFAULT,
+) -> str:
+    """Crée un snapshot des YAML de production et applique la rotation.
+
+    Args:
+        profile: Nom du profil.
+        batch_id: UUID4 du batch courant.
+        max_keep: Nombre maximum de backups agent à conserver après l'ajout.
+
+    Returns:
+        Le NOM du dossier créé (relatif à `taxonomy-backups/`) — à
+        stocker dans le journal pour permettre le restore plus tard.
+
+    Raises:
+        BackupError: si aucun YAML de prod n'existe à snapshoter
+                     (rien d'utile à backupper, on refuse).
+    """
+    if not batch_id:
+        raise BackupError("batch_id is required")
+    src_root = _profile_root(profile)
+    dst_root = _backups_root(profile)
+    dst_root.mkdir(parents=True, exist_ok=True)
+
+    dir_name = _backup_dir_name(batch_id)
+    dst_dir = dst_root / dir_name
+    dst_dir.mkdir(parents=True, exist_ok=False)
+
+    copied = 0
+    for fname in PROD_FILES:
+        src = src_root / fname
+        if not src.exists():
+            continue
+        shutil.copy2(src, dst_dir / fname)
+        copied += 1
+
+    if copied == 0:
+        # Rien à snapshotter — nettoie le dossier vide et raise
+        dst_dir.rmdir()
+        raise BackupError(
+            f"no production YAML found in {src_root} — nothing to backup"
+        )
+
+    rotate_backups(profile, max_keep=max_keep)
+    return dir_name
+
+
+def restore_backup(profile: str, backup_dir_name: str) -> dict[str, Any]:
+    """Restaure les YAML de production depuis un snapshot.
+
+    Args:
+        profile: Nom du profil.
+        backup_dir_name: Nom du dossier de backup (cf. create_backup return).
+
+    Returns:
+        {"profile": ..., "backup": dir_name, "restored": [filename...]}
+
+    Raises:
+        BackupError: backup_dir absent ou vide.
+    """
+    src_dir = _backups_root(profile) / backup_dir_name
+    if not src_dir.is_dir():
+        raise BackupError(f"backup directory not found: {backup_dir_name!r}")
+    profile_root = _profile_root(profile)
+    restored: list[str] = []
+    for fname in PROD_FILES:
+        src = src_dir / fname
+        if not src.exists():
+            continue
+        shutil.copy2(src, profile_root / fname)
+        restored.append(fname)
+    if not restored:
+        raise BackupError(
+            f"backup directory {backup_dir_name!r} is empty — nothing to restore"
+        )
+    return {
+        "profile": profile,
+        "backup": backup_dir_name,
+        "restored": restored,
+    }
+
+
+def list_backups(profile: str) -> list[dict[str, Any]]:
+    """Liste les backups agent du profil, triés du plus récent au plus ancien.
+
+    Filtre uniquement les dossiers qui matchent le pattern `agent-<...>`.
+    Les backups manuels d'autres systèmes (theme_mapping-<ts>.yaml en flat
+    files par exemple) sont ignorés.
+
+    Returns:
+        Liste de dicts :
+        ```
+        [{
+            "name": "agent-<batch_id>-<ts>",
+            "batch_id": "...",          # extrait du nom
+            "ts": "YYYYMMDD-HHMMSS",    # extrait du nom
+            "files": ["tree.yaml", "theme_mapping.yaml"],
+            "size_bytes": 12345,        # somme des fichiers du backup
+        }, ...]
+        ```
+    """
+    root = _backups_root(profile)
+    if not root.is_dir():
+        return []
+    out: list[dict[str, Any]] = []
+    for entry in root.iterdir():
+        if not entry.is_dir() or not entry.name.startswith("agent-"):
+            continue
+        parsed = _parse_backup_name(entry.name)
+        if parsed is None:
+            continue
+        batch_id, ts = parsed
+        files = sorted(p.name for p in entry.iterdir() if p.is_file())
+        size = sum(p.stat().st_size for p in entry.iterdir() if p.is_file())
+        out.append({
+            "name": entry.name,
+            "batch_id": batch_id,
+            "ts": ts,
+            "files": files,
+            "size_bytes": size,
+        })
+    out.sort(key=lambda b: b["ts"], reverse=True)
+    return out
+
+
+def _parse_backup_name(name: str) -> tuple[str, str] | None:
+    """Parse `agent-<batch_id>-<ts>` → (batch_id, ts).
+
+    Le batch_id est un UUID4 contenant 4 tirets, donc on splitte par la
+    droite : <ts> est le SUFFIXE après le dernier tiret-précédé-d'un-chiffre.
+    En pratique le format de _ts_for_filename() est "YYYYMMDD-HHMMSS" qui
+    contient lui aussi un tiret — il faut donc splitter sur le motif
+    `-YYYYMMDD-HHMMSS` final.
+    """
+    if not name.startswith("agent-"):
+        return None
+    # Le timestamp est de la forme YYYYMMDD-HHMMSS = 15 chars + 1 tiret
+    # → on isole les 16 derniers chars comme `-YYYYMMDD-HHMMSS`
+    rest = name[len("agent-"):]
+    if len(rest) < 17:  # uuid(36) + tiret(1) + ts(15) — au moins 17
+        return None
+    ts_suffix = rest[-15:]  # "YYYYMMDD-HHMMSS"
+    if rest[-16] != "-":
+        return None
+    batch_id = rest[:-16]
+    return batch_id, ts_suffix
+
+
+def rotate_backups(
+    profile: str,
+    *,
+    max_keep: int = MAX_BACKUPS_DEFAULT,
+) -> int:
+    """Supprime les backups agent les plus anciens au-delà de max_keep.
+
+    Returns:
+        Nombre de dossiers supprimés.
+    """
+    backups = list_backups(profile)
+    if len(backups) <= max_keep:
+        return 0
+    to_drop = backups[max_keep:]
+    root = _backups_root(profile)
+    deleted = 0
+    for b in to_drop:
+        target = root / b["name"]
+        try:
+            shutil.rmtree(target)
+            deleted += 1
+        except OSError:
+            continue
+    return deleted
+
+
+def find_backup_for_batch(profile: str, batch_id: str) -> str | None:
+    """Retrouve le dossier de backup associé à un batch_id.
+
+    Utile au rollback : on a juste le batch_id dans le journal, on doit
+    localiser physiquement le snapshot.
+    """
+    for b in list_backups(profile):
+        if b["batch_id"] == batch_id:
+            return b["name"]
+    return None

--- a/agents/refonte/agent_journal.py
+++ b/agents/refonte/agent_journal.py
@@ -1,0 +1,235 @@
+"""Journal append-only des mutations de l'agent Refonte Phase C.
+
+Pattern : `lib/rename_journal.py` (rename-journal.jsonl) — append-only,
+1 JSON par ligne, jamais d'écriture en place. Sert d'audit + de référence
+pour les rollbacks.
+
+Fichier : `profiles/<p>/.cache/refonte/agent-journal.jsonl`
+
+Chaque entrée :
+    {
+      "ts": "2026-05-30T...",           # ISO UTC du moment de l'action
+      "tool": "add_folder",             # nom de l'outil mutable invoqué
+      "args": {"path": "..."},          # arguments de l'appel
+      "result": "ok" | "error",
+      "error": "...",                   # présent uniquement si result=error
+      "batch_id": "<uuid4>",            # groupe les mutations d'un même tour
+      "human_validated": true,          # confirmation explicite humaine
+      "backup_dir": "agent-<batch_id>-<ts>",  # référence vers le snapshot
+    }
+
+Les entrées de rollback héritent du même format avec `tool="undo"` et
+`args.target_batch_id` pointant vers le batch annulé.
+"""
+
+from __future__ import annotations
+
+import json
+import uuid
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+from dashboard import data
+
+
+def _journal_path(profile: str) -> Path:
+    return (
+        data.get_project_root()
+        / "profiles" / profile / ".cache" / "refonte" / "agent-journal.jsonl"
+    )
+
+
+def generate_batch_id() -> str:
+    """UUID4 pour identifier un batch (= un tour de conversation user)."""
+    return str(uuid.uuid4())
+
+
+def _now_iso() -> str:
+    return datetime.now(UTC).isoformat()
+
+
+def append_entry(
+    profile: str,
+    *,
+    tool: str,
+    args: dict[str, Any],
+    result: str,
+    batch_id: str,
+    human_validated: bool = True,
+    backup_dir: str | None = None,
+    error: str | None = None,
+) -> dict[str, Any]:
+    """Append une entrée au journal et retourne la struct écrite.
+
+    Crée le dossier si absent. Atomique au niveau ligne (1 write).
+
+    Args:
+        profile: Nom du profil.
+        tool: Identifiant de l'outil ("add_folder", "merge_folders", "undo"…).
+        args: Arguments de l'appel — sérialisés JSON tel quel.
+        result: "ok" ou "error".
+        batch_id: UUID4 du batch (cf. generate_batch_id).
+        human_validated: True si confirmation explicite humaine.
+        backup_dir: Nom du dossier de snapshot pré-mutation (ou None pour undo).
+        error: Message d'erreur si result == "error".
+
+    Returns:
+        L'entrée écrite (avec ts ajouté).
+
+    Raises:
+        ValueError: result invalide ou batch_id vide.
+    """
+    if result not in ("ok", "error"):
+        raise ValueError(f"result must be 'ok' or 'error', got {result!r}")
+    if not batch_id:
+        raise ValueError("batch_id is required")
+    entry: dict[str, Any] = {
+        "ts": _now_iso(),
+        "tool": tool,
+        "args": args,
+        "result": result,
+        "batch_id": batch_id,
+        "human_validated": human_validated,
+    }
+    if backup_dir is not None:
+        entry["backup_dir"] = backup_dir
+    if error is not None:
+        entry["error"] = error
+    path = _journal_path(profile)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("a", encoding="utf-8") as f:
+        f.write(json.dumps(entry, ensure_ascii=False) + "\n")
+    return entry
+
+
+def read_journal(profile: str) -> list[dict[str, Any]]:
+    """Lit toutes les entrées du journal (ordre d'écriture).
+
+    Returns:
+        Liste de dicts. Liste vide si pas de journal.
+    """
+    path = _journal_path(profile)
+    if not path.exists():
+        return []
+    entries: list[dict[str, Any]] = []
+    try:
+        for line in path.read_text(encoding="utf-8").splitlines():
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                entries.append(json.loads(line))
+            except json.JSONDecodeError:
+                continue
+    except OSError:
+        return []
+    return entries
+
+
+def list_entries(
+    profile: str,
+    *,
+    batch_id: str | None = None,
+    limit: int = 100,
+) -> list[dict[str, Any]]:
+    """Liste les N entrées les plus récentes, optionnellement filtrées
+    par batch_id (utile pour afficher les mutations d'un batch précis).
+
+    Returns:
+        Entrées du plus récent au plus ancien, plafonnées à limit.
+    """
+    entries = read_journal(profile)
+    if batch_id is not None:
+        entries = [e for e in entries if e.get("batch_id") == batch_id]
+    return list(reversed(entries[-limit:]))
+
+
+def list_batches(profile: str) -> list[dict[str, Any]]:
+    """Regroupe les entrées par batch_id et retourne un résumé par batch.
+
+    Returns:
+        Liste de dicts triée du batch le plus récent au plus ancien :
+        ```
+        [{
+            "batch_id": "...",
+            "ts_first": "...",          # ISO de la 1re entrée du batch
+            "ts_last": "...",           # ISO de la dernière entrée du batch
+            "n_entries": 3,             # total entrées du batch
+            "n_ok": 3,                  # entrées result=ok
+            "n_error": 0,               # entrées result=error
+            "tools": ["add_folder",     # liste ordonnée des tools utilisés
+                      "add_theme_mapping"],
+            "backup_dir": "agent-...",  # 1er backup_dir trouvé dans le batch
+            "rolled_back": false,       # True si un undo a déjà ciblé ce batch
+        }, ...]
+        ```
+    """
+    entries = read_journal(profile)
+    by_batch: dict[str, dict[str, Any]] = {}
+    rolled_back_ids: set[str] = set()
+
+    for e in entries:
+        # Détection des entrées d'undo : tool=="undo" pointant vers un batch
+        if e.get("tool") == "undo":
+            target = (e.get("args") or {}).get("target_batch_id")
+            if target:
+                rolled_back_ids.add(target)
+            continue
+        bid = e.get("batch_id")
+        if not bid:
+            continue
+        slot = by_batch.setdefault(bid, {
+            "batch_id": bid,
+            "ts_first": e.get("ts"),
+            "ts_last": e.get("ts"),
+            "n_entries": 0,
+            "n_ok": 0,
+            "n_error": 0,
+            "tools": [],
+            "backup_dir": e.get("backup_dir"),
+        })
+        slot["ts_last"] = e.get("ts") or slot["ts_last"]
+        slot["n_entries"] += 1
+        if e.get("result") == "ok":
+            slot["n_ok"] += 1
+        elif e.get("result") == "error":
+            slot["n_error"] += 1
+        tool_name = e.get("tool") or "?"
+        slot["tools"].append(tool_name)
+        # Premier backup_dir non-None gagne (les suivants peuvent être None)
+        if slot["backup_dir"] is None and e.get("backup_dir"):
+            slot["backup_dir"] = e.get("backup_dir")
+
+    for bid, slot in by_batch.items():
+        slot["rolled_back"] = bid in rolled_back_ids
+
+    # Tri : batch le plus récent en tête (par ts_last DESC)
+    return sorted(
+        by_batch.values(),
+        key=lambda b: b.get("ts_last") or "",
+        reverse=True,
+    )
+
+
+def record_undo(
+    profile: str,
+    target_batch_id: str,
+    *,
+    result: str = "ok",
+    error: str | None = None,
+) -> dict[str, Any]:
+    """Helper pour journaliser un rollback (réutilise append_entry).
+
+    Le batch_id de l'entrée undo est un NOUVEAU UUID4 — il ne réutilise
+    pas le batch_id ciblé. Le lien se fait via args.target_batch_id.
+    """
+    return append_entry(
+        profile,
+        tool="undo",
+        args={"target_batch_id": target_batch_id},
+        result=result,
+        batch_id=generate_batch_id(),
+        human_validated=True,
+        error=error,
+    )

--- a/agents/refonte/dialog.py
+++ b/agents/refonte/dialog.py
@@ -1,0 +1,408 @@
+"""C.2 — Agent conversationnel Phase C.
+
+Stack validée par user :
+  - LangGraph MemorySaver + persistance JSON manuelle par conv_id
+  - Confirmation explicite tour-par-tour (apply/skip/modify)
+  - Pas de streaming SSE → polling toutes les 1.5s côté UI
+  - Flow minimal : parse_intent → propose → wait_confirm → execute → end
+
+Le graphe a 2 entrées distinctes :
+  1. `run_user_message(state, text)` — texte libre → parse_intent → propose
+  2. `run_user_response(state, action, ...)` — apply/skip/modify
+
+Persistence : `profiles/<p>/.cache/refonte/conversations/<conv_id>/state.json`.
+On stocke le state complet (messages + champs custom) pour permettre
+audit + reprise. Le checkpointer LangGraph n'est PAS utilisé — on persiste
+nous-mêmes à chaque tour pour simplicité.
+"""
+
+from __future__ import annotations
+
+import json
+import uuid
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any, Literal
+
+from langchain_core.language_models import BaseChatModel
+from langchain_core.messages import HumanMessage, SystemMessage
+from pydantic import BaseModel, Field
+
+from agents.refonte import mutations
+from dashboard import data
+
+ConvStatus = Literal[
+    "idle",                # rien en cours, attend nouveau msg user
+    "thinking",            # LLM en train de parser/proposer
+    "awaiting_confirm",    # propose_mutation prêt, attend apply/skip/modify
+    "executing",           # mutation en cours
+    "done",                # mutation appliquée
+    "error",               # erreur quelconque
+]
+
+
+class MutationProposal(BaseModel):
+    """Sortie structurée du LLM parse_intent."""
+
+    tool: str | None = Field(
+        description=(
+            "Nom du tool à invoquer parmi add_folder, add_theme_mapping, "
+            "rename_folder, merge_folders, bulk_move_files. None si "
+            "l'intention n'est pas claire ou hors scope."
+        )
+    )
+    args: dict[str, Any] = Field(
+        default_factory=dict,
+        description="Arguments nommés du tool (cf. signature dans mutations.py)",
+    )
+    preview_text: str = Field(
+        description=(
+            "Explication courte en français de ce qui sera changé, "
+            "destinée à l'utilisateur (1-3 phrases). Utilisé pour "
+            "afficher dans le chat avant validation."
+        )
+    )
+    confidence: Literal["high", "medium", "low"] = Field(
+        description=(
+            "high si tool/args sont sûrs, medium si plausibles mais "
+            "ambigus, low si demande à clarifier"
+        )
+    )
+    notes: str = Field(
+        default="",
+        description="Notes/questions si la confidence n'est pas high",
+    )
+
+
+_SYSTEM_PROMPT = """Tu es l'agent conversationnel Phase C de Klodo Refonte.
+
+Tu reçois un message utilisateur exprimant l'intention de modifier la
+taxonomie (créer/renommer/fusionner un dossier, ajouter un mapping de
+thème, déplacer des fichiers en lot).
+
+Ta tâche : produire une SEULE proposition de mutation parmi ces 5 tools :
+
+1. add_folder(parent, name)
+   Crée un nouveau dossier `name` sous `parent` ("" pour racine).
+   Ex : "Crée le dossier 'Rust' dans 02-INFORMATIQUE/03-Langages" →
+   {tool: "add_folder", args: {parent: "02-INFORMATIQUE/03-Langages", name: "Rust"}}
+
+2. add_theme_mapping(theme, folder)
+   Ajoute un mapping thème → dossier dans theme_mapping.yaml.
+   Ex : "Mappe 'Rust Programming' vers 02-INFORMATIQUE/03-Langages/Rust" →
+   {tool: "add_theme_mapping", args: {theme: "Rust Programming", folder: "02-INFORMATIQUE/03-Langages/Rust"}}
+
+3. rename_folder(old_path, new_name)
+   Renomme un dossier (et remappe les thèmes affectés).
+   Ex : "Renomme le dossier ML en Machine-Learning" →
+   {tool: "rename_folder", args: {old_path: "...ML", new_name: "Machine-Learning"}}
+
+4. merge_folders(src_paths, dest_path)
+   Fusionne des dossiers sources dans un seul (crée dest si absent,
+   déplace tous les fichiers, supprime les sources).
+   Ex : "Fusionne /A/X et /A/Y dans /A/XY" →
+   {tool: "merge_folders", args: {src_paths: ["/A/X", "/A/Y"], dest_path: "/A/XY"}}
+
+5. bulk_move_files(rel_paths, dest_folder)
+   Déplace une liste de fichiers vers un dossier commun.
+   Ex : "Déplace les 3 fichiers Rust vers Rust folder" →
+   {tool: "bulk_move_files", args: {rel_paths: [...], dest_folder: "..."}}
+
+Règles :
+  - Une seule proposition par message user (pas de mutation enchaînée).
+  - Si l'intention est ambiguë ou hors scope, mets tool=None,
+    confidence="low", et explique dans `notes`.
+  - `preview_text` doit être destiné à l'utilisateur : court, clair,
+    en français.
+  - Si on te demande de supprimer un dossier, refuse (hors scope —
+    delete_folder n'est pas encore exposé) et explique pourquoi.
+"""
+
+
+def now_iso() -> str:
+    return datetime.now(UTC).isoformat()
+
+
+def new_conv_id() -> str:
+    return str(uuid.uuid4())
+
+
+def make_state(profile: str, conv_id: str | None = None) -> dict[str, Any]:
+    """État initial d'une conversation."""
+    return {
+        "profile": profile,
+        "conv_id": conv_id or new_conv_id(),
+        "status": "idle",
+        "messages": [],          # liste de {role, content, ts}
+        "proposed_mutation": None,  # {tool, args, preview_text, confidence, notes, batch_id}
+        "mutation_result": None,
+        "error": None,
+        "llm_calls": 0,
+        "created_at": now_iso(),
+        "updated_at": now_iso(),
+    }
+
+
+def _conv_dir(profile: str, conv_id: str) -> Path:
+    return (
+        data.get_project_root()
+        / "profiles" / profile / ".cache" / "refonte"
+        / "conversations" / conv_id
+    )
+
+
+def _state_path(profile: str, conv_id: str) -> Path:
+    return _conv_dir(profile, conv_id) / "state.json"
+
+
+def save_state(state: dict[str, Any]) -> None:
+    """Persiste l'état de la conversation (écriture atomique)."""
+    profile = state["profile"]
+    conv_id = state["conv_id"]
+    state = {**state, "updated_at": now_iso()}
+    path = _state_path(profile, conv_id)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = path.with_suffix(".tmp")
+    tmp.write_text(
+        json.dumps(state, ensure_ascii=False, indent=2),
+        encoding="utf-8",
+    )
+    tmp.replace(path)
+
+
+def load_state(profile: str, conv_id: str) -> dict[str, Any] | None:
+    """Charge l'état d'une conversation. None si introuvable/corrompu."""
+    path = _state_path(profile, conv_id)
+    if not path.exists():
+        return None
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return None
+
+
+def list_conversations(profile: str, *, limit: int = 20) -> list[dict[str, Any]]:
+    """Liste les conversations du profil triées par updated_at DESC."""
+    root = (
+        data.get_project_root()
+        / "profiles" / profile / ".cache" / "refonte" / "conversations"
+    )
+    if not root.is_dir():
+        return []
+    out: list[dict[str, Any]] = []
+    for entry in root.iterdir():
+        if not entry.is_dir():
+            continue
+        state_file = entry / "state.json"
+        if not state_file.exists():
+            continue
+        try:
+            s = json.loads(state_file.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError):
+            continue
+        out.append({
+            "conv_id": s.get("conv_id", entry.name),
+            "status": s.get("status", "?"),
+            "created_at": s.get("created_at"),
+            "updated_at": s.get("updated_at"),
+            "n_messages": len(s.get("messages", [])),
+        })
+    out.sort(key=lambda c: c.get("updated_at") or "", reverse=True)
+    return out[:limit]
+
+
+def _append_message(state: dict, role: str, content: str) -> None:
+    state["messages"].append({
+        "role": role,
+        "content": content,
+        "ts": now_iso(),
+    })
+
+
+def run_user_message(
+    state: dict[str, Any],
+    text: str,
+    llm: BaseChatModel,
+    *,
+    max_llm_calls: int = 5,
+) -> dict[str, Any]:
+    """Traite un nouveau message user → produit une proposition de mutation.
+
+    Pas de re-prompt si la conversation est déjà en awaiting_confirm —
+    le caller doit d'abord appeler run_user_response("skip") ou similaire.
+
+    Args:
+        state: état conv (sera muté).
+        text: message texte de l'utilisateur.
+        llm: ChatOpenAI configuré.
+        max_llm_calls: budget par conversation (cumul).
+
+    Returns:
+        L'état mis à jour (même objet, retour pour fluidité).
+    """
+    if state.get("status") == "awaiting_confirm":
+        # Sécurité : on refuse un nouveau message si une proposition
+        # est encore en attente — sinon on perd la proposition silencieusement.
+        state["status"] = "error"
+        state["error"] = (
+            "une proposition est déjà en attente de confirmation — "
+            "réponds d'abord apply/skip/modify"
+        )
+        save_state(state)
+        return state
+
+    _append_message(state, "user", text)
+    state["status"] = "thinking"
+    state["proposed_mutation"] = None
+    state["mutation_result"] = None
+    state["error"] = None
+    save_state(state)
+
+    if state["llm_calls"] >= max_llm_calls:
+        state["status"] = "error"
+        state["error"] = f"budget llm épuisé ({max_llm_calls} appels max)"
+        save_state(state)
+        return state
+
+    try:
+        structured = llm.with_structured_output(
+            MutationProposal, method="function_calling",
+        )
+        result: MutationProposal = structured.invoke([
+            SystemMessage(content=_SYSTEM_PROMPT),
+            HumanMessage(content=text),
+        ])
+        state["llm_calls"] += 1
+    except Exception as exc:  # noqa: BLE001
+        state["status"] = "error"
+        state["error"] = f"LLM error: {type(exc).__name__}: {exc}"
+        save_state(state)
+        return state
+
+    if not result.tool or result.confidence == "low":
+        # Pas de proposition exécutable — on affiche le message au user
+        # pour clarifier et reste idle.
+        assistant_msg = (
+            f"Je ne suis pas sûr de comprendre. {result.notes}\n\n"
+            "Tu peux reformuler ?"
+        )
+        if result.tool:
+            assistant_msg = (
+                f"{result.preview_text}\n\nMais je ne suis pas sûr : "
+                f"{result.notes}\n\nClarifie ?"
+            )
+        _append_message(state, "assistant", assistant_msg)
+        state["status"] = "idle"
+        save_state(state)
+        return state
+
+    # Proposition prête → wait_confirm
+    from agents.refonte.agent_journal import generate_batch_id
+    proposed = {
+        "tool": result.tool,
+        "args": result.args,
+        "preview_text": result.preview_text,
+        "confidence": result.confidence,
+        "notes": result.notes,
+        "batch_id": generate_batch_id(),
+    }
+    state["proposed_mutation"] = proposed
+    state["status"] = "awaiting_confirm"
+    _append_message(state, "assistant", result.preview_text)
+    save_state(state)
+    return state
+
+
+def run_user_response(
+    state: dict[str, Any],
+    action: Literal["apply", "skip", "modify"],
+    *,
+    modification_text: str | None = None,
+    llm: BaseChatModel | None = None,
+) -> dict[str, Any]:
+    """Traite une réponse à un wait_confirm.
+
+    Args:
+        state: état conv (sera muté).
+        action: "apply" exécute la mutation, "skip" rejette, "modify"
+                relance parse_intent avec le texte fourni.
+        modification_text: requis si action="modify" — nouveau message
+                           user qui modifie la proposition.
+        llm: requis si action="modify".
+
+    Returns:
+        L'état mis à jour.
+    """
+    if state.get("status") != "awaiting_confirm":
+        state["status"] = "error"
+        state["error"] = "aucune proposition en attente de confirmation"
+        save_state(state)
+        return state
+
+    proposed = state.get("proposed_mutation")
+    if not proposed:
+        state["status"] = "error"
+        state["error"] = "état incohérent : awaiting_confirm sans proposed_mutation"
+        save_state(state)
+        return state
+
+    if action == "skip":
+        _append_message(state, "user", "(skip)")
+        _append_message(state, "assistant", "Proposition rejetée.")
+        state["status"] = "idle"
+        state["proposed_mutation"] = None
+        save_state(state)
+        return state
+
+    if action == "modify":
+        if not modification_text or not llm:
+            state["status"] = "error"
+            state["error"] = "modify requires modification_text and llm"
+            save_state(state)
+            return state
+        # Reset awaiting_confirm puis re-run parse_intent
+        state["status"] = "idle"
+        state["proposed_mutation"] = None
+        save_state(state)
+        return run_user_message(state, modification_text, llm)
+
+    # action == "apply"
+    _append_message(state, "user", "(apply)")
+    state["status"] = "executing"
+    save_state(state)
+    try:
+        result = _invoke(state["profile"], proposed)
+    except mutations.MutationError as exc:
+        state["status"] = "error"
+        state["error"] = f"mutation failed: {exc}"
+        _append_message(state, "assistant", f"❌ Échec : {exc}")
+        save_state(state)
+        return state
+
+    state["status"] = "done"
+    state["mutation_result"] = result
+    _append_message(
+        state, "assistant",
+        f"✓ Mutation appliquée (batch {proposed['batch_id'][:8]}). "
+        "Rollback disponible depuis la timeline.",
+    )
+    save_state(state)
+    return state
+
+
+def _invoke(profile: str, proposed: dict[str, Any]) -> dict[str, Any]:
+    """Helper isolé pour facile à mocker dans les tests."""
+    tool = proposed["tool"]
+    args = proposed["args"]
+    batch_id = proposed["batch_id"]
+    dispatch = {
+        "add_folder": mutations.add_folder,
+        "add_theme_mapping": mutations.add_theme_mapping,
+        "rename_folder": mutations.rename_folder,
+        "bulk_move_files": mutations.bulk_move_files,
+        "merge_folders": mutations.merge_folders,
+    }
+    fn = dispatch.get(tool)
+    if fn is None:
+        raise mutations.MutationError(f"unknown tool: {tool}")
+    return fn(profile, batch_id=batch_id, **args)

--- a/agents/refonte/mutations.py
+++ b/agents/refonte/mutations.py
@@ -1,0 +1,347 @@
+"""C.1 — Tools mutables de l'agent Refonte Phase C.
+
+Wrappers fins autour des helpers `dashboard.taxonomy` existants. Chaque
+tool :
+  1. Crée (ou réutilise) un backup pour le batch courant
+  2. Effectue la mutation via le helper taxonomy
+  3. Journalise le résultat (ok ou error)
+  4. Renvoie un résumé sérialisable {batch_id, backup_dir, tool, result_data}
+
+Les batch_ids sont passés par le caller. Si None, on en génère un nouveau
+(utile pour les invocations CLI isolées). L'agent conversationnel (C.2)
+groupera plusieurs mutations sous un même batch_id pour permettre un
+rollback en bloc.
+
+Tools exposés (cf. docs/refonte-agent-spec.md §C.1) :
+  - add_folder
+  - add_theme_mapping
+  - rename_folder
+  - merge_folders            (orchestration : add_folder dest + bulk_move + delete src)
+  - bulk_move_files          (boucle de taxonomy.move_file)
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from agents.refonte import agent_backup, agent_journal
+from dashboard import taxonomy as _tax
+
+
+class MutationError(Exception):
+    """Erreur métier remontée par un tool mutable (validation, conflit…)."""
+
+
+def _ensure_backup_for_batch(profile: str, batch_id: str) -> str:
+    """Garantit qu'un backup existe pour ce batch_id, le crée sinon.
+
+    Permet à plusieurs mutations d'un même batch de partager le snapshot
+    initial — le rollback restaurera l'état AVANT la première mutation
+    du batch, peu importe combien il en a eu.
+    """
+    existing = agent_backup.find_backup_for_batch(profile, batch_id)
+    if existing:
+        return existing
+    return agent_backup.create_backup(profile, batch_id)
+
+
+def _journal_and_raise(
+    profile: str,
+    *,
+    tool: str,
+    args: dict[str, Any],
+    batch_id: str,
+    backup_dir: str | None,
+    exc: Exception,
+) -> None:
+    """Helper : journal une erreur puis re-raise comme MutationError."""
+    agent_journal.append_entry(
+        profile, tool=tool, args=args, result="error",
+        batch_id=batch_id, backup_dir=backup_dir, error=str(exc),
+    )
+    raise MutationError(str(exc)) from exc
+
+
+def _journal_ok(
+    profile: str,
+    *,
+    tool: str,
+    args: dict[str, Any],
+    batch_id: str,
+    backup_dir: str,
+) -> None:
+    agent_journal.append_entry(
+        profile, tool=tool, args=args, result="ok",
+        batch_id=batch_id, backup_dir=backup_dir,
+    )
+
+
+# ─── add_folder ─────────────────────────────────────────────────────────────
+
+
+def add_folder(
+    profile: str,
+    parent: str,
+    name: str,
+    *,
+    batch_id: str | None = None,
+) -> dict[str, Any]:
+    """Ajoute un nouveau dossier sous `parent` avec le nom `name`.
+
+    Args:
+        profile: Profil cible.
+        parent: Path parent ("" pour racine).
+        name: Nom simple du nouveau dossier.
+        batch_id: UUID du batch (généré si None).
+
+    Returns:
+        {batch_id, backup_dir, tool, result_data}
+
+    Raises:
+        MutationError: si validation taxonomy échoue (dossier existant,
+                       nom invalide, etc.) ou si backup échoue.
+    """
+    bid = batch_id or agent_journal.generate_batch_id()
+    args = {"parent": parent, "name": name}
+    try:
+        backup_dir = _ensure_backup_for_batch(profile, bid)
+    except agent_backup.BackupError as exc:
+        _journal_and_raise(profile, tool="add_folder", args=args,
+                           batch_id=bid, backup_dir=None, exc=exc)
+    try:
+        result = _tax.create_folder(profile, parent, name)
+    except Exception as exc:  # noqa: BLE001 — on journalise + re-raise
+        _journal_and_raise(profile, tool="add_folder", args=args,
+                           batch_id=bid, backup_dir=backup_dir, exc=exc)
+    _journal_ok(profile, tool="add_folder", args=args,
+                batch_id=bid, backup_dir=backup_dir)
+    return {
+        "batch_id": bid,
+        "backup_dir": backup_dir,
+        "tool": "add_folder",
+        "result_data": result,
+    }
+
+
+# ─── add_theme_mapping ──────────────────────────────────────────────────────
+
+
+def add_theme_mapping(
+    profile: str,
+    theme: str,
+    folder: str,
+    *,
+    batch_id: str | None = None,
+) -> dict[str, Any]:
+    """Ajoute un mapping thème → dossier dans theme_mapping.yaml."""
+    bid = batch_id or agent_journal.generate_batch_id()
+    args = {"theme": theme, "folder": folder}
+    try:
+        backup_dir = _ensure_backup_for_batch(profile, bid)
+    except agent_backup.BackupError as exc:
+        _journal_and_raise(profile, tool="add_theme_mapping", args=args,
+                           batch_id=bid, backup_dir=None, exc=exc)
+    try:
+        result = _tax.add_mapping(profile, theme, folder)
+    except Exception as exc:  # noqa: BLE001
+        _journal_and_raise(profile, tool="add_theme_mapping", args=args,
+                           batch_id=bid, backup_dir=backup_dir, exc=exc)
+    _journal_ok(profile, tool="add_theme_mapping", args=args,
+                batch_id=bid, backup_dir=backup_dir)
+    return {
+        "batch_id": bid,
+        "backup_dir": backup_dir,
+        "tool": "add_theme_mapping",
+        "result_data": result,
+    }
+
+
+# ─── rename_folder ──────────────────────────────────────────────────────────
+
+
+def rename_folder(
+    profile: str,
+    old_path: str,
+    new_name: str,
+    *,
+    batch_id: str | None = None,
+) -> dict[str, Any]:
+    """Renomme un dossier (taxonomy.rename_folder remappe aussi les
+    mappings de thèmes qui pointaient dessus)."""
+    bid = batch_id or agent_journal.generate_batch_id()
+    args = {"old_path": old_path, "new_name": new_name}
+    try:
+        backup_dir = _ensure_backup_for_batch(profile, bid)
+    except agent_backup.BackupError as exc:
+        _journal_and_raise(profile, tool="rename_folder", args=args,
+                           batch_id=bid, backup_dir=None, exc=exc)
+    try:
+        result = _tax.rename_folder(profile, old_path, new_name)
+    except Exception as exc:  # noqa: BLE001
+        _journal_and_raise(profile, tool="rename_folder", args=args,
+                           batch_id=bid, backup_dir=backup_dir, exc=exc)
+    _journal_ok(profile, tool="rename_folder", args=args,
+                batch_id=bid, backup_dir=backup_dir)
+    return {
+        "batch_id": bid,
+        "backup_dir": backup_dir,
+        "tool": "rename_folder",
+        "result_data": result,
+    }
+
+
+# ─── bulk_move_files ────────────────────────────────────────────────────────
+
+
+def bulk_move_files(
+    profile: str,
+    rel_paths: list[str],
+    dest_folder: str,
+    *,
+    batch_id: str | None = None,
+) -> dict[str, Any]:
+    """Déplace une liste de fichiers vers le même dossier de destination.
+
+    Les fichiers sont traités séquentiellement. Si l'un échoue, on
+    continue avec les suivants (best-effort) et on agrège les erreurs.
+    Le journal liste chaque résultat individuel pour traçabilité.
+
+    Args:
+        profile: Profil.
+        rel_paths: Liste des chemins fichiers relatifs au target du profil.
+        dest_folder: Dossier de destination commun.
+        batch_id: UUID partagé (optionnel).
+
+    Returns:
+        {batch_id, backup_dir, tool, result_data:
+            {moved: [rel_path...], errors: [{path, error}...]}}
+    """
+    bid = batch_id or agent_journal.generate_batch_id()
+    args = {"rel_paths": list(rel_paths), "dest_folder": dest_folder}
+    try:
+        backup_dir = _ensure_backup_for_batch(profile, bid)
+    except agent_backup.BackupError as exc:
+        _journal_and_raise(profile, tool="bulk_move_files", args=args,
+                           batch_id=bid, backup_dir=None, exc=exc)
+    moved: list[str] = []
+    errors: list[dict[str, str]] = []
+    for rel_path in rel_paths:
+        try:
+            _tax.move_file(profile, rel_path, dest_folder)
+            moved.append(rel_path)
+        except Exception as exc:  # noqa: BLE001
+            errors.append({"path": rel_path, "error": str(exc)})
+    # Journal global pour ce bulk (les erreurs individuelles sont dans
+    # result_data — pas la peine de spammer le journal avec N entries).
+    result_summary = {"moved": moved, "errors": errors}
+    result = "ok" if not errors else "error"
+    error_msg = (
+        f"{len(errors)} of {len(rel_paths)} files failed"
+        if errors else None
+    )
+    agent_journal.append_entry(
+        profile, tool="bulk_move_files",
+        args={**args, "summary": {"n_moved": len(moved), "n_errors": len(errors)}},
+        result=result, batch_id=bid, backup_dir=backup_dir, error=error_msg,
+    )
+    return {
+        "batch_id": bid,
+        "backup_dir": backup_dir,
+        "tool": "bulk_move_files",
+        "result_data": result_summary,
+    }
+
+
+# ─── merge_folders ──────────────────────────────────────────────────────────
+
+
+def merge_folders(
+    profile: str,
+    src_paths: list[str],
+    dest_path: str,
+    *,
+    batch_id: str | None = None,
+) -> dict[str, Any]:
+    """Fusionne plusieurs dossiers sources dans un seul dossier destination.
+
+    Workflow :
+      1. Crée le dossier `dest_path` s'il n'existe pas (via create_folder)
+      2. Pour chaque src_path : déplace TOUS les fichiers vers dest_path
+         puis supprime le dossier source (delete_folder force=True)
+      3. Les mappings de thèmes pointant vers les src sont remappés vers
+         dest (logique déléguée à taxonomy.delete_folder dans son flux)
+
+    Args:
+        profile: Profil cible.
+        src_paths: Liste de dossiers sources à fusionner.
+        dest_path: Dossier destination (sera créé si absent).
+        batch_id: UUID partagé.
+
+    Returns:
+        {batch_id, backup_dir, tool, result_data:
+            {created_dest: bool, sources_merged: [path...],
+             sources_failed: [{path, error}...]}}
+    """
+    bid = batch_id or agent_journal.generate_batch_id()
+    args = {"src_paths": list(src_paths), "dest_path": dest_path}
+    try:
+        backup_dir = _ensure_backup_for_batch(profile, bid)
+    except agent_backup.BackupError as exc:
+        _journal_and_raise(profile, tool="merge_folders", args=args,
+                           batch_id=bid, backup_dir=None, exc=exc)
+    # 1. Crée dest si absent
+    created_dest = False
+    snapshot = _tax.get_snapshot(profile, force_reload=True)
+    existing_folders = {f["path"] for f in snapshot.get("folders", [])}
+    if dest_path not in existing_folders:
+        # Décompose dest_path en parent/name pour create_folder
+        if "/" in dest_path:
+            parent, name = dest_path.rsplit("/", 1)
+        else:
+            parent, name = "", dest_path
+        try:
+            _tax.create_folder(profile, parent, name)
+            created_dest = True
+        except Exception as exc:  # noqa: BLE001
+            _journal_and_raise(profile, tool="merge_folders", args=args,
+                               batch_id=bid, backup_dir=backup_dir, exc=exc)
+    # 2. Pour chaque source, move all files + delete folder
+    sources_merged: list[str] = []
+    sources_failed: list[dict[str, str]] = []
+    for src in src_paths:
+        try:
+            # Délègue au flux taxonomy : delete_folder déclenche le
+            # mécanisme de migration des thèmes mappés vers dest_path.
+            # Note : delete_folder ne déplace PAS les fichiers — on doit
+            # le faire à la main avant.
+            # limit=10000 = tous les fichiers en pratique (les bibliothèques
+            # avec un dossier de 10k fichiers sortent de notre scope d'usage)
+            listing = _tax.list_files_in_folder(profile, src, limit=10000)
+            for f in listing.get("files", []):
+                _tax.move_file(profile, f["rel_path"], dest_path)
+            _tax.delete_folder(profile, src, force=True)
+            sources_merged.append(src)
+        except Exception as exc:  # noqa: BLE001
+            sources_failed.append({"path": src, "error": str(exc)})
+    result_summary = {
+        "created_dest": created_dest,
+        "sources_merged": sources_merged,
+        "sources_failed": sources_failed,
+    }
+    result = "ok" if not sources_failed else "error"
+    error_msg = (
+        f"{len(sources_failed)} of {len(src_paths)} sources failed"
+        if sources_failed else None
+    )
+    agent_journal.append_entry(
+        profile, tool="merge_folders",
+        args={**args, "summary": {"n_merged": len(sources_merged),
+                                  "n_failed": len(sources_failed)}},
+        result=result, batch_id=bid, backup_dir=backup_dir, error=error_msg,
+    )
+    return {
+        "batch_id": bid,
+        "backup_dir": backup_dir,
+        "tool": "merge_folders",
+        "result_data": result_summary,
+    }

--- a/dashboard/agent_refonte_phase_c.py
+++ b/dashboard/agent_refonte_phase_c.py
@@ -1,0 +1,114 @@
+"""Backend dashboard pour Phase C de l'agent Refonte — couche fine
+au-dessus de agents.refonte.agent_journal + agent_backup, exposée par
+les endpoints FastAPI.
+
+Cette couche garde dashboard/app.py mince et permet de tester la logique
+sans monter une instance FastAPI complète.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from agents.refonte import agent_backup, agent_journal
+from dashboard import data
+
+
+class RollbackError(Exception):
+    """Tentative de rollback impossible (batch inexistant, déjà rollback, etc.)."""
+
+
+def list_batches(profile: str) -> list[dict[str, Any]]:
+    """Wrap agent_journal.list_batches — pour symétrie avec les autres
+    helpers du wrapper."""
+    return agent_journal.list_batches(profile)
+
+
+def list_entries(
+    profile: str,
+    *,
+    batch_id: str | None = None,
+    limit: int = 100,
+) -> list[dict[str, Any]]:
+    """Wrap agent_journal.list_entries."""
+    return agent_journal.list_entries(profile, batch_id=batch_id, limit=limit)
+
+
+def rollback_batch(profile: str, batch_id: str) -> dict[str, Any]:
+    """Restaure les YAML de production depuis le backup d'un batch.
+
+    Policy : on rollback UNIQUEMENT le batch ciblé (pas en cascade). Si
+    des batches plus récents existent, on warn dans la réponse mais on
+    procède quand même — c'est le user qui valide.
+
+    Workflow :
+      1. Validation : profile + batch_id non vides
+      2. Vérifie qu'on a bien un batch correspondant dans le journal
+      3. Refuse si le batch a déjà été rolled back
+      4. Trouve le backup_dir associé via find_backup_for_batch
+      5. Restaure les YAML
+      6. Journalise l'undo avec result selon succès/échec
+      7. Renvoie un résumé avec liste des fichiers restaurés + flag warn
+         si des batches plus récents existent
+
+    Raises:
+        ValueError: inputs invalides.
+        RollbackError: batch introuvable, déjà rollback, ou backup absent.
+    """
+    if not profile:
+        raise ValueError("profile is required")
+    if not batch_id:
+        raise ValueError("batch_id is required")
+
+    # Validation du profil
+    profile_dir = data.get_project_root() / "profiles" / profile
+    if not profile_dir.is_dir():
+        raise FileNotFoundError(f"profile not found: {profile!r}")
+
+    batches = agent_journal.list_batches(profile)
+    matching = next((b for b in batches if b["batch_id"] == batch_id), None)
+    if matching is None:
+        raise RollbackError(f"batch {batch_id!r} not found in journal")
+    if matching.get("rolled_back"):
+        raise RollbackError(
+            f"batch {batch_id!r} has already been rolled back"
+        )
+
+    backup_dir = agent_backup.find_backup_for_batch(profile, batch_id)
+    if backup_dir is None:
+        # Cas pathologique : journal a une entrée mais le backup physique
+        # a disparu (rotation trop agressive, suppression manuelle…).
+        raise RollbackError(
+            f"no backup directory found for batch {batch_id!r} "
+            "(rotated out or manually deleted)"
+        )
+
+    try:
+        result = agent_backup.restore_backup(profile, backup_dir)
+    except agent_backup.BackupError as exc:
+        # Journalise l'échec pour traçabilité, puis raise
+        agent_journal.record_undo(profile, batch_id, result="error",
+                                  error=str(exc))
+        raise RollbackError(str(exc)) from exc
+
+    # Journalise le succès
+    agent_journal.record_undo(profile, batch_id, result="ok")
+
+    # Détecte si des batches plus récents existent (warning, pas erreur)
+    # `batches` est trié recent→ancien. Le batch ciblé est dans la liste,
+    # ceux avant lui dans la liste sont plus récents.
+    newer_count = 0
+    for b in batches:
+        if b["batch_id"] == batch_id:
+            break
+        if b.get("rolled_back"):
+            continue
+        newer_count += 1
+
+    return {
+        "profile": profile,
+        "batch_id": batch_id,
+        "backup_dir": backup_dir,
+        "restored_files": result["restored"],
+        "warning_newer_batches": newer_count,
+    }

--- a/dashboard/agent_refonte_phase_c.py
+++ b/dashboard/agent_refonte_phase_c.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 
 from typing import Any
 
-from agents.refonte import agent_backup, agent_journal
+from agents.refonte import agent_backup, agent_journal, mutations
 from dashboard import data
 
 
@@ -112,3 +112,57 @@ def rollback_batch(profile: str, batch_id: str) -> dict[str, Any]:
         "restored_files": result["restored"],
         "warning_newer_batches": newer_count,
     }
+
+
+# ─── Tools mutables (C.1) ───────────────────────────────────────────────────
+
+
+# Dispatcher tool_name → fonction. Permet d'avoir un seul endpoint
+# /api/agent/refonte/c/mutate qui prend `tool` en body et route vers le
+# bon helper, plutôt que N endpoints presque identiques. Plus simple à
+# wirer côté agent conversationnel (C.2) qui appelle un seul endpoint.
+_TOOL_DISPATCH: dict[str, Any] = {
+    "add_folder": mutations.add_folder,
+    "add_theme_mapping": mutations.add_theme_mapping,
+    "rename_folder": mutations.rename_folder,
+    "bulk_move_files": mutations.bulk_move_files,
+    "merge_folders": mutations.merge_folders,
+}
+
+
+def list_available_tools() -> list[str]:
+    """Liste des noms d'outils mutables disponibles."""
+    return sorted(_TOOL_DISPATCH.keys())
+
+
+def invoke_mutation(
+    profile: str,
+    tool: str,
+    args: dict[str, Any],
+    *,
+    batch_id: str | None = None,
+) -> dict[str, Any]:
+    """Dispatche un appel mutation vers le bon helper.
+
+    Args:
+        profile: Profil cible.
+        tool: Nom du tool (cf. list_available_tools).
+        args: Arguments nommés à passer au tool (validés par le tool).
+        batch_id: UUID partagé (généré si None).
+
+    Raises:
+        ValueError: profile vide ou tool inconnu.
+        FileNotFoundError: profil inexistant.
+        mutations.MutationError: validation taxonomy ou backup échoué.
+    """
+    if not profile:
+        raise ValueError("profile is required")
+    if tool not in _TOOL_DISPATCH:
+        raise ValueError(
+            f"unknown tool {tool!r}, available: {list_available_tools()}"
+        )
+    profile_dir = data.get_project_root() / "profiles" / profile
+    if not profile_dir.is_dir():
+        raise FileNotFoundError(f"profile not found: {profile!r}")
+    fn = _TOOL_DISPATCH[tool]
+    return fn(profile, batch_id=batch_id, **args)

--- a/dashboard/agent_refonte_phase_c.py
+++ b/dashboard/agent_refonte_phase_c.py
@@ -166,3 +166,90 @@ def invoke_mutation(
         raise FileNotFoundError(f"profile not found: {profile!r}")
     fn = _TOOL_DISPATCH[tool]
     return fn(profile, batch_id=batch_id, **args)
+
+
+# ─── Conversations (C.2) ────────────────────────────────────────────────────
+
+
+def start_conversation(profile: str) -> dict[str, Any]:
+    """Crée et persiste une nouvelle conversation pour le profil.
+
+    Raises:
+        ValueError: profile vide.
+        FileNotFoundError: profil inexistant.
+    """
+    from agents.refonte import dialog
+    if not profile:
+        raise ValueError("profile is required")
+    profile_dir = data.get_project_root() / "profiles" / profile
+    if not profile_dir.is_dir():
+        raise FileNotFoundError(f"profile not found: {profile!r}")
+    state = dialog.make_state(profile)
+    dialog.save_state(state)
+    return state
+
+
+def send_user_message(
+    profile: str,
+    conv_id: str,
+    text: str,
+) -> dict[str, Any]:
+    """Envoie un message texte libre dans une conversation existante.
+
+    Raises:
+        ValueError: profile/conv_id/text vide.
+        FileNotFoundError: conversation introuvable.
+    """
+    from agents.llm import get_agent_llm
+    from agents.refonte import dialog
+    if not profile or not conv_id or not text:
+        raise ValueError("profile, conv_id and text are required")
+    state = dialog.load_state(profile, conv_id)
+    if state is None:
+        raise FileNotFoundError(f"conversation not found: {conv_id!r}")
+    llm = get_agent_llm()
+    return dialog.run_user_message(state, text, llm)
+
+
+def send_user_response(
+    profile: str,
+    conv_id: str,
+    action: str,
+    *,
+    modification_text: str | None = None,
+) -> dict[str, Any]:
+    """Répond apply/skip/modify à une proposition en attente.
+
+    Raises:
+        ValueError: action invalide.
+        FileNotFoundError: conversation introuvable.
+    """
+    from agents.llm import get_agent_llm
+    from agents.refonte import dialog
+    if action not in ("apply", "skip", "modify"):
+        raise ValueError("action must be 'apply', 'skip' or 'modify'")
+    state = dialog.load_state(profile, conv_id)
+    if state is None:
+        raise FileNotFoundError(f"conversation not found: {conv_id!r}")
+    llm = get_agent_llm() if action == "modify" else None
+    return dialog.run_user_response(
+        state, action,  # type: ignore[arg-type]
+        modification_text=modification_text,
+        llm=llm,
+    )
+
+
+def get_conversation(profile: str, conv_id: str) -> dict[str, Any] | None:
+    """Lit l'état d'une conversation (None si introuvable)."""
+    from agents.refonte import dialog
+    return dialog.load_state(profile, conv_id)
+
+
+def list_conversations(
+    profile: str,
+    *,
+    limit: int = 20,
+) -> list[dict[str, Any]]:
+    """Liste les conversations du profil triées par updated_at DESC."""
+    from agents.refonte import dialog
+    return dialog.list_conversations(profile, limit=limit)

--- a/dashboard/app.py
+++ b/dashboard/app.py
@@ -2559,6 +2559,92 @@ async def api_agent_refonte_c_tools():
     return JSONResponse({"tools": _c.list_available_tools()})
 
 
+@app.post("/api/agent/refonte/c/conv")
+async def api_agent_refonte_c_conv_start(request: Request):
+    """Crée une nouvelle conversation pour le profil. Body: {profile}."""
+    from fastapi.responses import JSONResponse
+
+    from dashboard import agent_refonte_phase_c as _c
+    body = await request.json()
+    profile = (body.get("profile") or "").strip()
+    try:
+        return JSONResponse(_c.start_conversation(profile))
+    except ValueError as exc:
+        return JSONResponse({"error": str(exc)}, status_code=400)
+    except FileNotFoundError as exc:
+        return JSONResponse({"error": str(exc)}, status_code=404)
+
+
+@app.get("/api/agent/refonte/c/conv")
+async def api_agent_refonte_c_conv_list(profile: str, limit: int = 20):
+    """Liste les conversations du profil."""
+    from fastapi.responses import JSONResponse
+
+    from dashboard import agent_refonte_phase_c as _c
+    if not profile:
+        return JSONResponse({"error": "profile query param is required"}, status_code=400)
+    limit = max(1, min(int(limit), 100))
+    return JSONResponse({
+        "profile": profile,
+        "conversations": _c.list_conversations(profile, limit=limit),
+    })
+
+
+@app.get("/api/agent/refonte/c/conv/{conv_id}")
+async def api_agent_refonte_c_conv_get(conv_id: str, profile: str):
+    """Lit l'état d'une conversation (polling UI)."""
+    from fastapi.responses import JSONResponse
+
+    from dashboard import agent_refonte_phase_c as _c
+    if not profile:
+        return JSONResponse({"error": "profile query param is required"}, status_code=400)
+    state = _c.get_conversation(profile, conv_id)
+    if state is None:
+        return JSONResponse({"error": f"conversation not found: {conv_id}"}, status_code=404)
+    return JSONResponse(state)
+
+
+@app.post("/api/agent/refonte/c/conv/{conv_id}/message")
+async def api_agent_refonte_c_conv_message(conv_id: str, request: Request):
+    """Envoie un message texte libre dans la conversation. Body: {profile, text}."""
+    from fastapi.responses import JSONResponse
+
+    from dashboard import agent_refonte_phase_c as _c
+    body = await request.json()
+    profile = (body.get("profile") or "").strip()
+    text = (body.get("text") or "").strip()
+    try:
+        return JSONResponse(_c.send_user_message(profile, conv_id, text))
+    except ValueError as exc:
+        return JSONResponse({"error": str(exc)}, status_code=400)
+    except FileNotFoundError as exc:
+        return JSONResponse({"error": str(exc)}, status_code=404)
+
+
+@app.post("/api/agent/refonte/c/conv/{conv_id}/respond")
+async def api_agent_refonte_c_conv_respond(conv_id: str, request: Request):
+    """Répond apply/skip/modify à une proposition.
+
+    Body: {profile, action, modification_text?}.
+    """
+    from fastapi.responses import JSONResponse
+
+    from dashboard import agent_refonte_phase_c as _c
+    body = await request.json()
+    profile = (body.get("profile") or "").strip()
+    action = (body.get("action") or "").strip()
+    modification_text = body.get("modification_text")
+    try:
+        return JSONResponse(_c.send_user_response(
+            profile, conv_id, action,
+            modification_text=modification_text,
+        ))
+    except ValueError as exc:
+        return JSONResponse({"error": str(exc)}, status_code=400)
+    except FileNotFoundError as exc:
+        return JSONResponse({"error": str(exc)}, status_code=404)
+
+
 @app.post("/api/agent/refonte/c/mutate")
 async def api_agent_refonte_c_mutate(request: Request):
     """Invoque une mutation agent (add_folder, rename, merge, etc.).

--- a/dashboard/app.py
+++ b/dashboard/app.py
@@ -1922,6 +1922,22 @@ async def taxonomy_files_api(
     return JSONResponse(taxonomy.list_files_in_folder(profile, path, offset, limit))
 
 
+@app.get("/api/taxonomy/folder/theme-breakdown")
+async def taxonomy_folder_theme_breakdown_api(profile: str, path: str = ""):
+    """3-way breakdown des thèmes d'un dossier — stable / incoming / outgoing.
+
+    Permet à l'utilisateur de visualiser, dans le panneau "Routage", ce qui
+    va RESTER, ce qui va ARRIVER et ce qui va PARTIR au prochain reclassify,
+    sans avoir besoin d'un dry-run complet.
+    """
+    from fastapi.responses import JSONResponse
+    try:
+        data = taxonomy.compute_folder_theme_breakdown(profile, path)
+    except Exception as e:  # noqa: BLE001
+        return JSONResponse({"error": str(e)}, status_code=500)
+    return JSONResponse(data)
+
+
 @app.get("/api/taxonomy/theme/files")
 async def taxonomy_theme_files_api(
     profile: str,

--- a/dashboard/app.py
+++ b/dashboard/app.py
@@ -2489,6 +2489,67 @@ async def api_agent_refonte_tree_diff(run_id: str, profile: str):
     return JSONResponse(diff)
 
 
+# ──────────── Phase C : Dialog (mutations + rollback) ────────────
+
+
+@app.get("/api/agent/refonte/c/batches")
+async def api_agent_refonte_c_batches(profile: str):
+    """Liste les batches de mutations agent (Phase C) pour le profil."""
+    from fastapi.responses import JSONResponse
+
+    from dashboard import agent_refonte_phase_c as _c
+    if not profile:
+        return JSONResponse({"error": "profile query param is required"}, status_code=400)
+    return JSONResponse({
+        "profile": profile,
+        "batches": _c.list_batches(profile),
+    })
+
+
+@app.get("/api/agent/refonte/c/entries")
+async def api_agent_refonte_c_entries(
+    profile: str, batch_id: str | None = None, limit: int = 100,
+):
+    """Liste les entrées du journal (toutes ou filtrées par batch_id)."""
+    from fastapi.responses import JSONResponse
+
+    from dashboard import agent_refonte_phase_c as _c
+    if not profile:
+        return JSONResponse({"error": "profile query param is required"}, status_code=400)
+    limit = max(1, min(int(limit), 500))
+    return JSONResponse({
+        "profile": profile,
+        "entries": _c.list_entries(profile, batch_id=batch_id, limit=limit),
+    })
+
+
+@app.post("/api/agent/refonte/c/rollback")
+async def api_agent_refonte_c_rollback(request: Request):
+    """Restaure les YAML depuis le backup d'un batch ciblé.
+
+    Body: {profile, batch_id}.
+    """
+    from fastapi.responses import JSONResponse
+
+    from dashboard import agent_refonte_phase_c as _c
+    body = await request.json()
+    profile = (body.get("profile") or "").strip()
+    batch_id = (body.get("batch_id") or "").strip()
+    try:
+        result = _c.rollback_batch(profile, batch_id)
+        return JSONResponse(result)
+    except ValueError as exc:
+        return JSONResponse({"error": str(exc)}, status_code=400)
+    except FileNotFoundError as exc:
+        return JSONResponse({"error": str(exc)}, status_code=404)
+    except _c.RollbackError as exc:
+        msg = str(exc)
+        # "already been rolled back" → 409, "not found" / "no backup" → 404
+        if "already" in msg:
+            return JSONResponse({"error": msg}, status_code=409)
+        return JSONResponse({"error": msg}, status_code=404)
+
+
 @app.get("/api/agent/refonte/proposition/{run_id}/simulation")
 async def api_agent_refonte_simulation(run_id: str, profile: str, sample_limit: int = 50):
     """Lit le simulation-summary.json + N premières lignes de la projection CSV."""

--- a/dashboard/app.py
+++ b/dashboard/app.py
@@ -1857,6 +1857,22 @@ async def categories_dormant_api(profile: str):
     return JSONResponse(categories.dormant_audit(profile))
 
 
+@app.get("/api/categories/suggest-path")
+async def categories_suggest_path_api(profile: str, chemin: str):
+    """Propose un chemin du tree.yaml comme cible pour un orphan.
+
+    Pour aider l'utilisateur à corriger les entries dont la cible n'existe
+    plus (typiquement après un rename de folder qui n'a pas pu cascader).
+    Le frontend appelle cet endpoint au clic sur le bouton « 💡 Suggérer »
+    du panneau Détail entry, pré-remplit le popover Renommer chemin avec
+    la suggestion + affiche la raison + les alternatives.
+    """
+    from fastapi.responses import JSONResponse
+
+    from dashboard import categories
+    return JSONResponse(categories.suggest_target_path(profile, chemin))
+
+
 @app.post("/api/categories/keywords/bulk-delete")
 async def categories_keywords_bulk_delete_api(request: Request):
     """Delete multiple keywords in one transaction (one backup)."""

--- a/dashboard/app.py
+++ b/dashboard/app.py
@@ -2550,6 +2550,49 @@ async def api_agent_refonte_c_rollback(request: Request):
         return JSONResponse({"error": msg}, status_code=404)
 
 
+@app.get("/api/agent/refonte/c/tools")
+async def api_agent_refonte_c_tools():
+    """Liste des outils mutables disponibles."""
+    from fastapi.responses import JSONResponse
+
+    from dashboard import agent_refonte_phase_c as _c
+    return JSONResponse({"tools": _c.list_available_tools()})
+
+
+@app.post("/api/agent/refonte/c/mutate")
+async def api_agent_refonte_c_mutate(request: Request):
+    """Invoque une mutation agent (add_folder, rename, merge, etc.).
+
+    Body: {profile, tool, args, batch_id?}.
+    `batch_id` est optionnel — généré si absent. Passer le même batch_id
+    sur plusieurs appels groupe les mutations sous un seul snapshot
+    (rollback restaure l'état AVANT la 1re mutation du batch).
+    """
+    from fastapi.responses import JSONResponse
+
+    from agents.refonte import mutations as _mut
+    from dashboard import agent_refonte_phase_c as _c
+    body = await request.json()
+    profile = (body.get("profile") or "").strip()
+    tool = (body.get("tool") or "").strip()
+    args = body.get("args") or {}
+    batch_id = body.get("batch_id")
+    if not isinstance(args, dict):
+        return JSONResponse({"error": "args must be a JSON object"}, status_code=400)
+    try:
+        result = _c.invoke_mutation(profile, tool, args, batch_id=batch_id)
+        return JSONResponse(result)
+    except ValueError as exc:
+        return JSONResponse({"error": str(exc)}, status_code=400)
+    except FileNotFoundError as exc:
+        return JSONResponse({"error": str(exc)}, status_code=404)
+    except _mut.MutationError as exc:
+        return JSONResponse({"error": str(exc)}, status_code=409)
+    except TypeError as exc:
+        # Arguments manquants ou en trop pour le tool
+        return JSONResponse({"error": f"invalid args: {exc}"}, status_code=400)
+
+
 @app.get("/api/agent/refonte/proposition/{run_id}/simulation")
 async def api_agent_refonte_simulation(run_id: str, profile: str, sample_limit: int = 50):
     """Lit le simulation-summary.json + N premières lignes de la projection CSV."""

--- a/dashboard/categories.py
+++ b/dashboard/categories.py
@@ -635,6 +635,149 @@ def cascade_rename_target(
     }
 
 
+_PREFIX_NUM_RE = re.compile(r"^\s*\d{1,2}\s*-?\s*")
+
+
+def _normalize_segment(s: str) -> str:
+    """Drop leading numeric prefix ("01 - ", "02-", "1 ") + lowercase.
+    Permet de matcher 'CHIMIE' avec '03 - CHIMIE' ou 'JEUX-VIDEO' avec
+    '06 - JEUX-VIDEO' — pattern systématique d'ordonnancement des folders
+    qu'on observe dans la bibliothèque."""
+    return _PREFIX_NUM_RE.sub("", (s or "").strip()).strip().lower()
+
+
+def _normalize_path(p: str) -> str:
+    return "/".join(_normalize_segment(seg) for seg in (p or "").split("/") if seg)
+
+
+def suggest_target_path(profile: str, orphan_chemin: str) -> dict:
+    """Propose un chemin du tree.yaml comme cible pour un orphan.
+
+    Cas typiques d'orphans (cf. cause racine de la cascade) :
+      - Folder renommé en ajoutant un préfixe d'ordonnancement (``01 - ``,
+        ``02 - ``…) à un segment du milieu : ``X/CHIMIE/Y`` → ``X/03 -
+        CHIMIE/Y``. Le matching après normalisation (drop prefixes) fait
+        ressortir un candidat unique.
+      - Folder déplacé ailleurs : matching exact échoue, on tente par
+        suffixe descendant (nom le plus long → nom de base).
+      - Folder supprimé : aucun match → l'utilisateur doit décider (supprimer
+        l'entry, ou re-créer le folder).
+
+    Renvoie::
+
+        {
+          "suggestion": str | None,
+          "confidence": "high" | "medium" | "low" | "none",
+          "alternatives": [str, ...],     # autres candidats <= 5
+          "reason": str                   # humain-lisible, pour l'UI
+        }
+
+    Confidence :
+      - high   : chemin normalisé == path normalisé d'UN folder du tree
+                 (collision typique d'ajout de préfixe numérique).
+      - medium : match unique sur le suffixe long (>= 2 segments).
+      - low    : match unique sur le segment final uniquement, OU plusieurs
+                 candidats matched (alternatives renseignées).
+      - none   : aucun match.
+    """
+    from dashboard import taxonomy as _tax
+    chemin = (orphan_chemin or "").strip().strip("/")
+    if not chemin:
+        return {"suggestion": None, "confidence": "none",
+                "alternatives": [], "reason": "chemin vide"}
+
+    try:
+        tree = _tax._load_tree(profile)
+    except Exception:  # noqa: BLE001
+        tree = []
+    if not tree:
+        return {"suggestion": None, "confidence": "none",
+                "alternatives": [],
+                "reason": "tree.yaml introuvable ou vide pour ce profil"}
+
+    # Si le chemin existe déjà dans le tree, pas d'orphan (mais on l'a quand
+    # même appelé) — renvoie tel quel.
+    if chemin in tree:
+        return {"suggestion": chemin, "confidence": "high",
+                "alternatives": [],
+                "reason": "ce chemin existe déjà dans tree.yaml"}
+
+    chemin_n = _normalize_path(chemin)
+    # Index tree paths par leur version normalisée
+    tree_by_norm: dict[str, list[str]] = {}
+    for t in tree:
+        tn = _normalize_path(t)
+        tree_by_norm.setdefault(tn, []).append(t)
+
+    # Stratégie 1 — match exact après normalisation. Couvre le cas "préfixe
+    # numérique ajouté à un segment du milieu".
+    if chemin_n in tree_by_norm:
+        cands = tree_by_norm[chemin_n]
+        if len(cands) == 1:
+            return {
+                "suggestion": cands[0],
+                "confidence": "high",
+                "alternatives": [],
+                "reason": "match normalisé unique (préfixe numérique ajouté)",
+            }
+        return {
+            "suggestion": cands[0],
+            "confidence": "low",
+            "alternatives": cands[1:5],
+            "reason": f"{len(cands)} folders ont le même chemin normalisé",
+        }
+
+    # Stratégie 2 — suffixe long (>= 2 segments) sur le chemin normalisé.
+    parts_n = chemin_n.split("/")
+    for n in range(min(3, len(parts_n)), 1, -1):  # 3, 2 segments
+        suffix = "/".join(parts_n[-n:])
+        cands = [
+            t for t, tn in (
+                (orig, _normalize_path(orig)) for orig in tree
+            ) if tn.endswith("/" + suffix) or tn == suffix
+        ]
+        if not cands:
+            continue
+        if len(cands) == 1:
+            return {
+                "suggestion": cands[0],
+                "confidence": "medium",
+                "alternatives": [],
+                "reason": f"match unique par suffixe ({n} segments)",
+            }
+        return {
+            "suggestion": cands[0],
+            "confidence": "low",
+            "alternatives": cands[1:5],
+            "reason": f"{len(cands)} candidats sur suffixe {n}-segments",
+        }
+
+    # Stratégie 3 — segment final uniquement.
+    last_n = parts_n[-1]
+    cands = []
+    for orig in tree:
+        tn_parts = _normalize_path(orig).split("/")
+        if tn_parts and tn_parts[-1] == last_n:
+            cands.append(orig)
+    if cands:
+        if len(cands) == 1:
+            return {
+                "suggestion": cands[0],
+                "confidence": "low",
+                "alternatives": [],
+                "reason": "match unique sur le nom de base (parent différent)",
+            }
+        return {
+            "suggestion": cands[0],
+            "confidence": "low",
+            "alternatives": cands[1:5],
+            "reason": f"{len(cands)} candidats sur le nom de base",
+        }
+
+    return {"suggestion": None, "confidence": "none", "alternatives": [],
+            "reason": "aucun candidat trouvé — folder probablement supprimé"}
+
+
 def add_keyword(profile: str, group: str, chemin: str, keyword: str) -> dict:
     """Append a keyword to an entry's `mots_cles` list. Dedups (case-insensitive
     on lowercased form) — silent no-op when already present."""

--- a/dashboard/categories.py
+++ b/dashboard/categories.py
@@ -143,8 +143,15 @@ def _load_raw(profile: str) -> dict:
     return loaded if isinstance(loaded, dict) else {}
 
 
-def _normalize_entry(raw: dict) -> dict | None:
-    """Validate + clean a single entry. Returns None on bad shape."""
+def _normalize_entry(raw: dict, tree_folders: set[str] | None = None) -> dict | None:
+    """Validate + clean a single entry. Returns None on bad shape.
+
+    Quand ``tree_folders`` est fourni (set des chemins de ``tree.yaml``),
+    chaque entry est annotée ``is_orphan: bool`` — True si la ``chemin``
+    cible n'existe plus dans l'arborescence (typiquement après un rename
+    de folder fait AVANT que la cascade Phase X n'existe). L'UI peut alors
+    afficher un badge ⚠ pour permettre à l'utilisateur de corriger.
+    """
     if not isinstance(raw, dict):
         return None
     chemin = str(raw.get("chemin") or "").strip()
@@ -158,12 +165,15 @@ def _normalize_entry(raw: dict) -> dict | None:
     if not isinstance(mots_cles_raw, list):
         mots_cles_raw = []
     mots_cles = [str(m).strip() for m in mots_cles_raw if str(m).strip()]
-    return {
+    entry = {
         "chemin": chemin,
         "priorite": priorite,
         "mots_cles": mots_cles,
         "n_keywords": len(mots_cles),
     }
+    if tree_folders is not None:
+        entry["is_orphan"] = chemin not in tree_folders
+    return entry
 
 
 def build_snapshot(profile: str, force_reload: bool = False) -> dict:
@@ -210,18 +220,34 @@ def build_snapshot(profile: str, force_reload: bool = False) -> dict:
         return out
 
     raw = _load_raw(profile)
+    # Charge tree.yaml du profil pour annoter chaque entry avec is_orphan
+    # (chemin qui n'existe plus dans l'arbo après un rename antérieur au
+    # cascade fix). Échec silencieux ou fichier absent : on n'annote pas,
+    # l'UI ne montrera juste pas de badge (vs annoter à tort comme orphan
+    # quand on n'a pas l'info — ce qui rendrait toutes les entries rouges).
+    tree_folders: set[str] | None = None
+    try:
+        from dashboard import taxonomy as _tax
+        if _tax._tree_path(profile).exists():
+            tree_folders = set(_tax._load_tree(profile))
+    except Exception:  # noqa: BLE001
+        tree_folders = None
+
     total_entries = 0
     total_keywords = 0
+    n_orphans = 0
     groups = []
     for group_name, group_entries in raw.items():
         if not isinstance(group_entries, list):
             continue
         cleaned: list[dict] = []
         for raw_entry in group_entries:
-            normalized = _normalize_entry(raw_entry)
+            normalized = _normalize_entry(raw_entry, tree_folders)
             if normalized is None:
                 continue
             cleaned.append(normalized)
+            if normalized.get("is_orphan"):
+                n_orphans += 1
         # Sort: lowest priority first (1 = highest), then path alpha
         cleaned.sort(key=lambda r: (r["priorite"], r["chemin"].lower()))
         for e in cleaned:
@@ -230,6 +256,7 @@ def build_snapshot(profile: str, force_reload: bool = False) -> dict:
         groups.append({
             "group": str(group_name),
             "n_entries": len(cleaned),
+            "n_orphans": sum(1 for e in cleaned if e.get("is_orphan")),
             "entries": cleaned,
         })
     groups.sort(key=lambda g: g["group"].lower())
@@ -239,6 +266,7 @@ def build_snapshot(profile: str, force_reload: bool = False) -> dict:
         "n_groups": len(groups),
         "n_entries": total_entries,
         "n_keywords": total_keywords,
+        "n_orphans": n_orphans,
         "avg_keywords": (round(total_keywords / total_entries, 1)
                          if total_entries else 0.0),
     }
@@ -486,6 +514,124 @@ def delete_entry(profile: str, group: str, chemin: str) -> dict:
         "chemin": chemin,
         "n_keywords_removed": len(removed.get("mots_cles") or []),
         "backup": str(backup.relative_to(data.get_project_root())) if backup else None,
+    }
+
+
+def cascade_rename_target(
+    profile: str, old_path: str, new_path: str,
+) -> dict:
+    """Rewrite every `chemin: <old_path>` (or `<old_path>/*`) in
+    ``categories.yaml`` to point at ``new_path`` (or ``new_path/*``).
+
+    Appelée depuis ``taxonomy._change_folder_path`` après un rename/move de
+    folder dans l'arbo : sans ce relayage, les entries des Catégories
+    pointaient vers un dossier qui n'existait plus côté tree.yaml /
+    filesystem, donc la classification fallback (étape 2 du pipeline) ne
+    rangeait plus rien depuis ce groupe.
+
+    Collision possible : si une entry ``new_path`` existe DÉJÀ dans le même
+    groupe (le user l'avait créée à la main avant le rename), on fusionne
+    les ``mots_cles`` (dedup case-insensitive) et on garde la ``priorite``
+    minimale des deux. Aucune perte de travail manuel.
+
+    No-op (retour ``n_entries_updated=0``) si :
+      - ``categories.yaml`` absent du profil
+      - aucun chemin ne matche ``old_path`` (ni en exact ni en préfixe)
+
+    Backup créé UNIQUEMENT si quelque chose change — pas de pollution
+    inutile du dossier ``.cache/categories-backups/``.
+    """
+    old_path = (old_path or "").strip().strip("/")
+    new_path = (new_path or "").strip().strip("/")
+    if not old_path or not new_path or old_path == new_path:
+        return {"ok": True, "n_entries_updated": 0, "n_merged": 0,
+                "backup": None}
+
+    if not _categories_path(profile).exists():
+        return {"ok": True, "n_entries_updated": 0, "n_merged": 0,
+                "backup": None, "skipped": "no_categories_yaml"}
+
+    prefix = old_path + "/"
+
+    def _remap(chemin_val: str) -> str | None:
+        s = (chemin_val or "").strip()
+        if not s:
+            return None
+        if s == old_path:
+            return new_path
+        if s.startswith(prefix):
+            return new_path + "/" + s[len(prefix):]
+        return None
+
+    with _locks[profile]:
+        payload = _load_mutable(profile)
+        if not payload:
+            return {"ok": True, "n_entries_updated": 0, "n_merged": 0,
+                    "backup": None}
+
+        n_updated = 0
+        n_merged = 0
+        for group_name, entries in list(payload.items()):
+            if not isinstance(entries, list) or not entries:
+                continue
+            # Index des chemins existants APRÈS rename hypothétique → permet
+            # de détecter et fusionner les collisions à l'intérieur du group.
+            by_path: dict[str, dict] = {}
+            new_entries: list[dict] = []
+            for raw in entries:
+                if not isinstance(raw, dict):
+                    new_entries.append(raw)
+                    continue
+                remapped = _remap(str(raw.get("chemin") or ""))
+                if remapped is not None:
+                    raw = dict(raw)  # avoid mutating input
+                    raw["chemin"] = remapped
+                    n_updated += 1
+                key = str(raw.get("chemin") or "")
+                if key in by_path:
+                    # Fusion : dedup mots_cles case-insensitive + min(priorite)
+                    existing = by_path[key]
+                    ex_mots = existing.get("mots_cles") or []
+                    new_mots = raw.get("mots_cles") or []
+                    seen = {str(m).strip().lower(): str(m).strip()
+                            for m in ex_mots if str(m).strip()}
+                    for m in new_mots:
+                        ml = str(m).strip().lower()
+                        if ml and ml not in seen:
+                            seen[ml] = str(m).strip()
+                    existing["mots_cles"] = list(seen.values())
+                    try:
+                        p_ex = int(existing.get("priorite") or 0)
+                        p_new = int(raw.get("priorite") or 0)
+                        # priorite 0 = absente, on prend la valeur réelle si l'autre est 0
+                        if p_ex == 0:
+                            existing["priorite"] = p_new
+                        elif p_new == 0:
+                            pass
+                        else:
+                            existing["priorite"] = min(p_ex, p_new)
+                    except (TypeError, ValueError):
+                        pass
+                    n_merged += 1
+                else:
+                    by_path[key] = raw
+                    new_entries.append(raw)
+            payload[group_name] = new_entries
+
+        if n_updated == 0:
+            return {"ok": True, "n_entries_updated": 0, "n_merged": 0,
+                    "backup": None}
+
+        backup = _backup_file(profile)
+        _save_mutable(profile, payload)
+        reset_cache(profile)
+
+    return {
+        "ok": True,
+        "n_entries_updated": n_updated,
+        "n_merged": n_merged,
+        "backup": (str(backup.relative_to(data.get_project_root()))
+                   if backup else None),
     }
 
 

--- a/dashboard/static/js/taxonomy.js
+++ b/dashboard/static/js/taxonomy.js
@@ -2194,7 +2194,28 @@
     }
     const mappings = state.snapshot.mapping_by_folder[path] || [];
     const suffix = frozenBySpotlight ? ' (focus thème)' : '';
-    sub.textContent = `${path || 'racine'} · ${mappings.length} clé(s)${suffix}`;
+    // Compteur "X fichiers actuels · Y prévus au reclassify"
+    // - actuels  = file_count direct du folder dans tree.yaml (FS scan)
+    // - prévus   = somme des counts des thèmes LLM qui mappent vers ce folder
+    //   (= ce que classify_by_theme acheminerait au prochain reclassify)
+    const node = state.snapshot.tree
+        ? findNode(state.snapshot.tree, path) : null;
+    const nCurrent = node ? (node.file_count || 0) : 0;
+    const mappedLower = new Set(mappings.map(t => t.toLowerCase()));
+    const themesLLM = state.snapshot.themes_llm || [];
+    let nReclassify = 0;
+    for (const t of themesLLM) {
+      if (mappedLower.has((t.theme || '').toLowerCase())) {
+        nReclassify += (t.count || 0);
+      }
+    }
+    sub.textContent = `${path || 'racine'} · ${mappings.length} règle(s) · `
+                    + `${nCurrent} fichier(s) actuel(s) · `
+                    + `~${nReclassify} prévu(s) au reclassify${suffix}`;
+    sub.title = 'Compte des fichiers physiquement dans le dossier (snapshot FS) '
+              + 'vs estimation des fichiers qui y arriveraient au prochain '
+              + 'reclassify (somme des occurrences des thèmes mappés ici dans '
+              + 'le vision_cache).';
     if (mappings.length === 0) {
       list.appendChild(el('li', { class: 'muted small' },
         ['Aucun thème mappé. Glisse un thème LLM ici ou utilise « + Mapper ».']));
@@ -2227,11 +2248,18 @@
       });
       cb.checked = bulkSet.has(keyL);
       const editBtn = el('button', {
-        class: 'tax-mapped-action', title: 'Rediriger ce mapping vers un autre dossier',
+        class: 'tax-mapped-action',
+        title: 'Rediriger : changer la destination de cette règle de routage. '
+             + 'Les fichiers déjà rangés ne bougent pas — seulement où ils '
+             + 'iraient au prochain reclassify.',
         onclick: e => { e.stopPropagation(); openMapPopover({ theme: t, count: '?', is_edit: true }, e.currentTarget); },
       }, ['↗']);
       const delBtn = el('button', {
-        class: 'tax-mapped-action tax-mapped-del', title: 'Supprimer ce mapping',
+        class: 'tax-mapped-action tax-mapped-del',
+        title: 'Supprimer cette règle de routage. Les fichiers déjà rangés '
+             + 'ne bougent pas. Au prochain reclassify, les fichiers portant '
+             + 'ce thème deviendront orphelins (à reclasser via Keyword '
+             + 'Classifier ou LLM Mapper).',
         onclick: e => { e.stopPropagation(); confirmDeleteMapping(t); },
       }, ['×']);
       const isTouched = touched.has(t);

--- a/dashboard/static/js/taxonomy.js
+++ b/dashboard/static/js/taxonomy.js
@@ -80,6 +80,12 @@
     // bulkSelectionForPath). Permet de cocher plusieurs thèmes et de
     // les supprimer en un seul appel (POST /mappings/bulk-delete).
     bulkMappedSelection: { folderPath: null, keysLower: new Set() },
+
+    // Cache du breakdown 3-way (stable / incoming / outgoing) par path.
+    // Permet à l'UI d'afficher ce qui va RESTER, ARRIVER, PARTIR au prochain
+    // reclassify sans devoir lancer un dryrun. Lazily fetché à l'ouverture
+    // du panel Routage. Invalidé par renderAll() après une mutation.
+    folderBreakdown: new Map(),
   };
 
   // Touched folders / themes — derived from snapshot.stats (which diffs
@@ -168,6 +174,9 @@
     if (state.mappedFilesByTheme && state.mappedFilesByTheme.size > 0) {
       state.mappedFilesByTheme.clear();
     }
+    if (state.folderBreakdown && state.folderBreakdown.size > 0) {
+      state.folderBreakdown.clear();
+    }
     return r.json();
   }
   async function fetchFiles(path, offset, limit) {
@@ -175,6 +184,13 @@
                 `&path=${encodeURIComponent(path)}&offset=${offset}&limit=${limit}`;
     const r = await fetch(url);
     if (!r.ok) throw new Error('files HTTP ' + r.status);
+    return r.json();
+  }
+  async function fetchFolderBreakdown(path) {
+    const url = `/api/taxonomy/folder/theme-breakdown?profile=${encodeURIComponent(state.profile)}` +
+                `&path=${encodeURIComponent(path)}`;
+    const r = await fetch(url);
+    if (!r.ok) throw new Error('breakdown HTTP ' + r.status);
     return r.json();
   }
   async function fetchFileMetadata(path) {
@@ -2216,6 +2232,13 @@
               + 'vs estimation des fichiers qui y arriveraient au prochain '
               + 'reclassify (somme des occurrences des thèmes mappés ici dans '
               + 'le vision_cache).';
+
+    // ── Breakdown 3-way (Stables / Entrants / Sortants) ──
+    // Affiché AVANT la liste des règles, donne l'aperçu du churn au prochain
+    // reclassify. Lazily fetché : premier passage = "Chargement…", refetch
+    // automatique au prochain renderAll() après mutation.
+    list.appendChild(renderBreakdownSections(path));
+
     if (mappings.length === 0) {
       list.appendChild(el('li', { class: 'muted small' },
         ['Aucun thème mappé. Glisse un thème LLM ici ou utilise « + Mapper ».']));
@@ -2279,6 +2302,142 @@
       list.appendChild(item);
       if (isSelected) list.appendChild(renderMappedFilesExpand(t));
     }
+  }
+
+  // ── Breakdown 3-way : Stables / Entrants / Sortants ────────────────────
+  //
+  // Donne à l'utilisateur un aperçu IMMÉDIAT de ce qui se passera au prochain
+  // reclassify sur ce dossier, SANS lancer de dry-run :
+  //   ✓ Stables : déjà ici + mapping pointe ici → restent
+  //   → Entrants : mapping pointe ici mais fichier ailleurs → arriveront
+  //   ← Sortants : ici mais mapping ailleurs (ou orphelin) → partiront
+  //
+  // Fetch lazy (premier appel) + cache par path. Invalidation : renderAll()
+  // après mutation purge le cache via fetchSnapshot().
+
+  function renderBreakdownSections(path) {
+    const wrap = el('li', { class: 'tax-breakdown-wrap' });
+    const cached = state.folderBreakdown.get(path);
+
+    if (cached === undefined) {
+      // Premier passage : déclenche le fetch et affiche un placeholder.
+      // Note: le fetch reschedule un re-render asynchrone.
+      wrap.appendChild(el('div', { class: 'tax-breakdown-loading muted small' },
+        ['Chargement de la décomposition…']));
+      state.folderBreakdown.set(path, null);  // marqueur "fetch en cours"
+      (async () => {
+        try {
+          const data = await fetchFolderBreakdown(path);
+          state.folderBreakdown.set(path, data);
+        } catch (e) {
+          state.folderBreakdown.set(path, { error: e.message });
+        }
+        renderMappedPanel();
+      })();
+      return wrap;
+    }
+    if (cached === null) {
+      wrap.appendChild(el('div', { class: 'tax-breakdown-loading muted small' },
+        ['Chargement de la décomposition…']));
+      return wrap;
+    }
+    if (cached.error) {
+      wrap.appendChild(el('div', { class: 'tax-breakdown-error error small' },
+        ['✗ ' + cached.error]));
+      return wrap;
+    }
+
+    const stable = cached.stable || [];
+    const incoming = cached.incoming || [];
+    const outgoing = cached.outgoing || [];
+    const totalThemes = stable.length + incoming.length + outgoing.length;
+    if (totalThemes === 0) {
+      wrap.appendChild(el('div', { class: 'muted small tax-breakdown-empty' },
+        ['Aucun thème détecté ici, ni mappé vers ici.']));
+      return wrap;
+    }
+
+    wrap.appendChild(renderBreakdownSection({
+      icon: '✓',
+      label: 'Stables',
+      items: stable,
+      cssMod: 'stable',
+      countKey: 'count_in_folder',
+      hint: 'Thèmes présents dans les fichiers actuels ET mappés vers ce dossier. '
+          + 'Au prochain reclassify, ces fichiers RESTENT ici.',
+      emptyText: '— aucun thème stable —',
+    }));
+    wrap.appendChild(renderBreakdownSection({
+      icon: '→',
+      label: 'Entrants',
+      items: incoming,
+      cssMod: 'incoming',
+      countKey: 'count_expected',
+      hint: 'Thèmes mappés vers ce dossier mais ABSENTS des fichiers actuels. '
+          + 'Au prochain reclassify, ces fichiers ARRIVENT depuis ailleurs.',
+      emptyText: '— rien à recevoir —',
+    }));
+    wrap.appendChild(renderBreakdownSection({
+      icon: '←',
+      label: 'Sortants',
+      items: outgoing,
+      cssMod: 'outgoing',
+      countKey: 'count_in_folder',
+      hint: 'Thèmes des fichiers actuels mais mappés vers un autre dossier '
+          + '(ou orphelins). Au prochain reclassify, ces fichiers PARTENT.',
+      emptyText: '— rien ne sort —',
+      renderExtra: x => x.target
+        ? el('span', { class: 'tax-breakdown-target', title: `Destination : ${x.target}` },
+              [` → ${shortPath(x.target)}`])
+        : el('span', { class: 'tax-breakdown-orphan', title: 'Aucun mapping pour ce thème' },
+              [' · orphelin']),
+    }));
+    return wrap;
+  }
+
+  function shortPath(p) {
+    // Affichage compact : "01-SCIENCES/PHYSIQUE/QUANTIQUE" → ".../QUANTIQUE"
+    if (!p) return '';
+    const parts = p.split('/').filter(Boolean);
+    if (parts.length <= 1) return p;
+    if (parts.length === 2) return p;
+    return '…/' + parts[parts.length - 1];
+  }
+
+  function renderBreakdownSection(cfg) {
+    const { icon, label, items, cssMod, countKey, hint, emptyText, renderExtra } = cfg;
+    const n = items.length;
+    const totalFiles = items.reduce((acc, x) => acc + (x[countKey] || 0), 0);
+    const header = el('div', { class: 'tax-breakdown-header', title: hint }, [
+      el('span', { class: 'tax-breakdown-icon' }, [icon]),
+      el('span', { class: 'tax-breakdown-label' }, [label]),
+      el('span', { class: 'tax-breakdown-count' },
+        [n ? ` · ${n} thème(s) · ${totalFiles} fichier(s)` : ' · 0']),
+    ]);
+    const body = el('ul', { class: 'tax-breakdown-list' });
+    if (n === 0) {
+      body.appendChild(el('li', { class: 'muted small tax-breakdown-empty-row' },
+        [emptyText]));
+    } else {
+      // Limite l'affichage à 8 pour ne pas noyer le panneau. Le détail
+      // complet reste accessible via la liste des règles (entrants) ou le
+      // dryrun reclassify (sortants).
+      const display = items.slice(0, 8);
+      for (const x of display) {
+        const row = el('li', { class: 'tax-breakdown-item' }, [
+          el('span', { class: 'tax-breakdown-theme', title: x.theme }, [x.theme]),
+          el('span', { class: 'tax-breakdown-num' }, [` ${x[countKey]}`]),
+          renderExtra ? renderExtra(x) : null,
+        ]);
+        body.appendChild(row);
+      }
+      if (items.length > display.length) {
+        body.appendChild(el('li', { class: 'muted small tax-breakdown-more' },
+          [`+ ${items.length - display.length} autre(s)`]));
+      }
+    }
+    return el('div', { class: 'tax-breakdown-section tax-breakdown-' + cssMod },
+      [header, body]);
   }
 
   // ── Bulk delete des mappings d'un folder ───────────────────────────────

--- a/dashboard/static/js/taxonomy.js
+++ b/dashboard/static/js/taxonomy.js
@@ -74,6 +74,12 @@
     selectedMappedTheme: null,
     mappedFilesByTheme: new Map(),
     mappedFilesTab: 'future',  // 'future' | 'current'
+
+    // Mapped panel — multi-sélection pour bulk delete. Scopée au folder
+    // courant : changement de folder = clear automatique (cf. helper
+    // bulkSelectionForPath). Permet de cocher plusieurs thèmes et de
+    // les supprimer en un seul appel (POST /mappings/bulk-delete).
+    bulkMappedSelection: { folderPath: null, keysLower: new Set() },
   };
 
   // Touched folders / themes — derived from snapshot.stats (which diffs
@@ -2199,7 +2205,27 @@
     // that doesn't contain the spotlit theme. The user exits via the
     // 🔦× button in the tree subtitle.
     const touched = touchedThemesSet();
+    const bulkSet = bulkSelectionForPath(path);
+
+    // Mini-toolbar de sélection bulk (apparaît dès qu'au moins 1 cochée
+    // OU si le user a fait Tout cocher sur ce folder).
+    if (bulkSet.size > 0) {
+      list.appendChild(renderBulkMappedToolbar(path, mappings, bulkSet));
+    }
+
     for (const t of mappings) {
+      const keyL = t.toLowerCase();
+      const cb = el('input', {
+        type: 'checkbox',
+        class: 'tax-mapped-cb',
+        title: 'Sélectionner pour suppression en lot',
+        onclick: e => {
+          e.stopPropagation();
+          toggleBulkMapping(t, path);
+          renderMappedPanel();
+        },
+      });
+      cb.checked = bulkSet.has(keyL);
       const editBtn = el('button', {
         class: 'tax-mapped-action', title: 'Rediriger ce mapping vers un autre dossier',
         onclick: e => { e.stopPropagation(); openMapPopover({ theme: t, count: '?', is_edit: true }, e.currentTarget); },
@@ -2209,20 +2235,117 @@
         onclick: e => { e.stopPropagation(); confirmDeleteMapping(t); },
       }, ['×']);
       const isTouched = touched.has(t);
-      const isSelected = state.selectedMappedTheme === t.toLowerCase();
+      const isSelected = state.selectedMappedTheme === keyL;
+      const isInBulk = bulkSet.has(keyL);
       const dot = isTouched
         ? el('span', { class: 'tax-touched-dot', title: 'Modifié — annulable via le bouton Annuler' })
         : null;
       const item = el('li', {
         class: 'tax-mapped-item'
                + (isTouched ? ' touched' : '')
-               + (isSelected ? ' selected' : ''),
+               + (isSelected ? ' selected' : '')
+               + (isInBulk ? ' bulk-selected' : ''),
         title: t + ' — clic pour voir les fichiers concernés',
         onclick: () => toggleMappedThemeSelection(t),
-      }, [el('span', { class: 'tax-mapped-key' }, [t]), dot, editBtn, delBtn]);
+      }, [cb, el('span', { class: 'tax-mapped-key' }, [t]), dot, editBtn, delBtn]);
       list.appendChild(item);
       if (isSelected) list.appendChild(renderMappedFilesExpand(t));
     }
+  }
+
+  // ── Bulk delete des mappings d'un folder ───────────────────────────────
+
+  function bulkSelectionForPath(path) {
+    // Si le path change, on réinitialise la sélection : éviter de
+    // supprimer accidentellement des thèmes d'un folder qu'on ne voit plus.
+    if (state.bulkMappedSelection.folderPath !== path) {
+      state.bulkMappedSelection = { folderPath: path, keysLower: new Set() };
+    }
+    return state.bulkMappedSelection.keysLower;
+  }
+
+  function toggleBulkMapping(theme, path) {
+    const set = bulkSelectionForPath(path);
+    const k = theme.toLowerCase();
+    if (set.has(k)) set.delete(k); else set.add(k);
+  }
+
+  function selectAllMappingsForPath(path, mappings) {
+    const set = bulkSelectionForPath(path);
+    for (const t of mappings) set.add(t.toLowerCase());
+  }
+
+  function clearBulkMappingSelection() {
+    state.bulkMappedSelection.keysLower.clear();
+  }
+
+  function renderBulkMappedToolbar(path, mappings, bulkSet) {
+    const n = bulkSet.size;
+    const total = mappings.length;
+    const allSelected = n >= total;
+    const toolbar = el('li', { class: 'tax-mapped-bulk-toolbar' }, [
+      el('span', { class: 'tax-mapped-bulk-count' },
+         [`${n} sélectionné${n > 1 ? 's' : ''}`]),
+      el('button', {
+        class: 'tax-mapped-bulk-btn', title: 'Cocher tous les thèmes du dossier',
+        disabled: allSelected,
+        onclick: e => {
+          e.stopPropagation();
+          selectAllMappingsForPath(path, mappings);
+          renderMappedPanel();
+        },
+      }, [allSelected ? '☑ Tout coché' : `☑ Tout (${total})`]),
+      el('button', {
+        class: 'tax-mapped-bulk-btn', title: 'Tout désélectionner',
+        onclick: e => {
+          e.stopPropagation();
+          clearBulkMappingSelection();
+          renderMappedPanel();
+        },
+      }, ['Annuler sélection']),
+      el('button', {
+        class: 'tax-mapped-bulk-btn tax-mapped-bulk-danger',
+        title: 'Supprimer les mappings cochés',
+        onclick: e => {
+          e.stopPropagation();
+          confirmBulkDeleteMappings(path, mappings);
+        },
+      }, [`🗑 Supprimer (${n})`]),
+    ]);
+    return toolbar;
+  }
+
+  async function confirmBulkDeleteMappings(path, mappings) {
+    const bulkSet = bulkSelectionForPath(path);
+    if (bulkSet.size === 0) return;
+    // Récupère les clés EXACTES (casse préservée) depuis mappings
+    const keys = mappings.filter(t => bulkSet.has(t.toLowerCase()));
+    const preview = keys.slice(0, 5).map(k => `  • ${k}`).join('\n');
+    const more = keys.length > 5 ? `\n  + ${keys.length - 5} autre(s)` : '';
+    const ok = await showConfirm({
+      title: `Supprimer ${keys.length} mapping(s) ?`,
+      body: `Folder : ${path || 'racine'}\n\n${preview}${more}\n\n`
+          + 'Les thèmes bruts restent dans le vision_cache — seuls les '
+          + 'mappings (theme_mapping.yaml) sont retirés. Backup auto + '
+          + 'Annulable via le bouton Annuler du header.',
+      confirmLabel: `Supprimer ${keys.length} clé(s)`,
+      variant: 'danger',
+    });
+    if (!ok) return;
+    await withBusy(`Suppression de ${keys.length} mapping(s)…`, async () => {
+      try {
+        const r = await postBulkDeleteMappings(keys);
+        showToast(`✓ ${r.n_deleted} mapping(s) supprimé(s)`, 'success');
+        if (r.not_found && r.not_found.length) {
+          showToast(`⚠ ${r.not_found.length} introuvable(s) ignoré(s)`, 'info');
+        }
+        clearBulkMappingSelection();
+        state.snapshot = await fetchSnapshot();
+        renderAll();
+      } catch (e) {
+        showToast('✗ ' + e.message, 'error');
+      }
+    });
   }
 
   function toggleMappedThemeSelection(theme) {

--- a/dashboard/static/js/taxonomy.js
+++ b/dashboard/static/js/taxonomy.js
@@ -350,6 +350,18 @@
     showToast._tid = setTimeout(() => { t.style.display = 'none'; }, 4500);
   }
 
+  // Suffixe à concaténer aux toasts rename/move quand des entries de
+  // categories.yaml ont été cascadées en plus du mapping (mention "merged"
+  // si une collision a fusionné des mots-clés).
+  function _catSuffix(r) {
+    const n = r && r.n_categories_updated;
+    if (!n) return '';
+    const m = r.n_categories_merged || 0;
+    return m > 0
+      ? `, ${n} catégorie(s) cascadée(s) [${m} fusionnée(s)]`
+      : `, ${n} catégorie(s) cascadée(s)`;
+  }
+
   // ── Busy overlay ─────────────────────────────────────────────────────
   // Locks the UI during async write actions (snapshot refetch takes 2-3s
   // and the user shouldn't be able to fire concurrent writes).
@@ -2829,7 +2841,7 @@
           return;
         }
         showToast(
-          `✓ Déplacé : ${r.new_path}  ·  ${r.n_tree_entries_renamed} entrée(s) tree, ${r.n_mappings_updated} mapping(s)`,
+          `✓ Déplacé : ${r.new_path}  ·  ${r.n_tree_entries_renamed} entrée(s) tree, ${r.n_mappings_updated} mapping(s)${_catSuffix(r)}`,
           'success',
         );
         // Rewrite expanded set + selection prefixes (same logic as the
@@ -3257,7 +3269,7 @@
           return;
         }
         showToast(
-          `✓ Déplacé : ${r.new_path}  ·  ${r.n_tree_entries_renamed} entrée(s) tree, ${r.n_mappings_updated} mapping(s) cascadé(s)`,
+          `✓ Déplacé : ${r.new_path}  ·  ${r.n_tree_entries_renamed} entrée(s) tree, ${r.n_mappings_updated} mapping(s) cascadé(s)${_catSuffix(r)}`,
           'success',
         );
         // Rewrite expanded set + selection prefixes
@@ -3292,7 +3304,7 @@
           return;
         }
         showToast(
-          `✓ Renommé : ${r.new_path}  ·  ${r.n_tree_entries_renamed} entrée(s) tree, ${r.n_mappings_updated} mapping(s) cascadé(s)`,
+          `✓ Renommé : ${r.new_path}  ·  ${r.n_tree_entries_renamed} entrée(s) tree, ${r.n_mappings_updated} mapping(s) cascadé(s)${_catSuffix(r)}`,
           'success',
         );
         // Update expanded set: replace old prefix with new

--- a/dashboard/static/js/taxonomy_categories.js
+++ b/dashboard/static/js/taxonomy_categories.js
@@ -195,9 +195,18 @@
       return;
     }
     const s = state.snapshot.stats;
-    sub.textContent = `${s.n_groups} groupes · ${s.n_entries} entries`;
+    const nOrphans = s.n_orphans || 0;
+    sub.textContent = `${s.n_groups} groupes · ${s.n_entries} entries`
+                    + (nOrphans ? ` · ⚠ ${nOrphans} orphelin(s)` : '');
+    sub.title = nOrphans
+      ? `${nOrphans} entry(s) pointent vers un chemin qui n'existe plus dans `
+      + 'tree.yaml — souvent un folder renommé/supprimé avant que la cascade '
+      + 'automatique n\'existe. Modifie la cible (action Renommer chemin) '
+      + 'ou supprime l\'entry.'
+      : '';
     for (const g of state.snapshot.groups) {
       const collapsed = state.collapsedGroups.has(g.group);
+      const nGroupOrphans = g.n_orphans || 0;
       const header = el('div', {
         class: 'tax-cat-group' + (collapsed ? ' collapsed' : ''),
       }, [
@@ -212,6 +221,12 @@
           el('span', { class: 'tax-cat-group-chevron' }, [collapsed ? '▶' : '▼']),
           ' ', g.group, ' ',
           el('span', { class: 'muted small' }, [`(${g.n_entries})`]),
+          nGroupOrphans
+            ? el('span', {
+                class: 'tax-cat-group-orphan-count',
+                title: `${nGroupOrphans} entry(s) avec chemin obsolète`,
+              }, [` · ⚠ ${nGroupOrphans}`])
+            : null,
         ]),
         el('button', {
           class: 'tax-cat-group-add',
@@ -226,17 +241,29 @@
                    && state.selectedEntry.group === g.group
                    && state.selectedEntry.chemin === e.chemin;
         const isDormant = e.n_keywords === 0;
+        const isOrphan = !!e.is_orphan;
+        const children = [
+          el('span', { class: 'tax-cat-entry-path' }, [shortenPath(e.chemin)]),
+        ];
+        if (isOrphan) {
+          children.push(el('span', {
+            class: 'tax-cat-entry-orphan',
+            title: `Chemin obsolète : "${e.chemin}" n'existe plus dans `
+                 + 'tree.yaml. Probablement un folder renommé/supprimé '
+                 + 'avant la cascade automatique. Clique pour modifier la '
+                 + 'cible.',
+          }, ['⚠']));
+        }
+        children.push(el('span', { class: 'tax-cat-entry-prio', title: 'Priorité' },
+                                  ['P' + e.priorite]));
         wrap.appendChild(el('div', {
           class: 'tax-cat-entry'
                  + (isSel ? ' selected' : '')
-                 + (isDormant ? ' dormant' : ''),
-          title: e.chemin,
+                 + (isDormant ? ' dormant' : '')
+                 + (isOrphan ? ' orphan' : ''),
+          title: e.chemin + (isOrphan ? ' — chemin obsolète' : ''),
           onclick: () => selectEntry(g.group, e.chemin),
-        }, [
-          el('span', { class: 'tax-cat-entry-path' }, [shortenPath(e.chemin)]),
-          el('span', { class: 'tax-cat-entry-prio', title: 'Priorité' },
-                     ['P' + e.priorite]),
-        ]));
+        }, children));
       }
     }
     // "New group" footer action

--- a/dashboard/static/js/taxonomy_categories.js
+++ b/dashboard/static/js/taxonomy_categories.js
@@ -364,24 +364,43 @@
       ]),
     ]));
     // Actions
-    wrap.appendChild(el('div', { class: 'tax-cat-field', style: 'border-bottom:none;' }, [
+    const actionChildren = [
       el('label', null, ['Actions']),
-      el('button', {
-        class: 'btn-secondary tax-cat-action',
-        onclick: () => openRenamePopover(state.selectedEntry.group, e.chemin),
-      }, ['Renommer chemin']),
-      ' ',
-      el('button', {
-        class: 'btn-secondary tax-cat-action',
-        onclick: () => openPriorityPopover(state.selectedEntry.group,
-                                            e.chemin, e.priorite),
-      }, ['Modifier priorité']),
-      ' ',
-      el('button', {
-        class: 'btn-danger tax-cat-action',
-        onclick: () => deleteSelectedEntry(),
-      }, ['Supprimer entry']),
-    ]));
+    ];
+    if (e.is_orphan) {
+      // Banneau d'avertissement orphan + bouton Suggérer en premier
+      actionChildren.push(el('div', {
+        class: 'tax-cat-orphan-banner',
+        title: 'Le chemin actuel n\'existe plus dans tree.yaml. Clique '
+             + '« 💡 Suggérer » pour proposer une cible existante.',
+      }, [
+        '⚠ Chemin obsolète — n\'existe plus dans tree.yaml',
+      ]));
+      actionChildren.push(el('button', {
+        class: 'btn-secondary tax-cat-action tax-cat-action-suggest',
+        title: 'Trouver le folder le plus proche dans tree.yaml et pré-remplir '
+             + 'le popover de renommage',
+        onclick: () => openSuggestPopover(state.selectedEntry.group, e.chemin),
+      }, ['💡 Suggérer cible']));
+      actionChildren.push(' ');
+    }
+    actionChildren.push(el('button', {
+      class: 'btn-secondary tax-cat-action',
+      onclick: () => openRenamePopover(state.selectedEntry.group, e.chemin),
+    }, ['Renommer chemin']));
+    actionChildren.push(' ');
+    actionChildren.push(el('button', {
+      class: 'btn-secondary tax-cat-action',
+      onclick: () => openPriorityPopover(state.selectedEntry.group,
+                                          e.chemin, e.priorite),
+    }, ['Modifier priorité']));
+    actionChildren.push(' ');
+    actionChildren.push(el('button', {
+      class: 'btn-danger tax-cat-action',
+      onclick: () => deleteSelectedEntry(),
+    }, ['Supprimer entry']));
+    wrap.appendChild(el('div', { class: 'tax-cat-field', style: 'border-bottom:none;' },
+                       actionChildren));
   }
 
   // ── Column 3 — keywords (chips) ─────────────────────────────────────
@@ -640,6 +659,55 @@
       title: 'Renommer le chemin de cette entry',
       label: `Nouveau chemin (group « ${group} »)`,
       initial: chemin,
+      confirmLabel: 'Renommer',
+      validator: v => v ? null : 'chemin vide',
+    });
+    if (!value || value === chemin) return;
+    await withBusy('Renommage…', async () => {
+      try {
+        await patchJSON('/api/categories/entry',
+                        { group, chemin, new_chemin: value });
+        showToast(`✓ Renommé : ${value}`, 'success');
+        state.selectedEntry = { group, chemin: value };
+        await reloadAfterWrite();
+      } catch (e) {
+        showToast('✗ ' + e.message, 'error');
+      }
+    });
+  }
+
+  async function openSuggestPopover(group, chemin) {
+    // Fetch la suggestion serveur (recherche heuristique dans tree.yaml par
+    // normalisation des préfixes numériques + match suffixe / nom de base).
+    let payload;
+    try {
+      const url = `/api/categories/suggest-path?profile=${encodeURIComponent(state.profile)}`
+                + `&chemin=${encodeURIComponent(chemin)}`;
+      const r = await fetch(url);
+      if (!r.ok) throw new Error('suggest HTTP ' + r.status);
+      payload = await r.json();
+    } catch (err) {
+      showToast('✗ ' + err.message, 'error');
+      return;
+    }
+    if (!payload.suggestion) {
+      showToast(`Aucune suggestion : ${payload.reason || 'folder probablement supprimé'}`,
+                'info');
+      return;
+    }
+    // Affiche le bandeau + ouvre le prompt rename avec la suggestion en initial.
+    const confidence = payload.confidence;
+    const conLabel = { high: 'haute', medium: 'moyenne',
+                       low: 'faible', none: '—' }[confidence] || confidence;
+    const altInfo = (payload.alternatives && payload.alternatives.length)
+      ? `\n\nAlternatives :\n  • ${payload.alternatives.join('\n  • ')}`
+      : '';
+    const value = await showPrompt({
+      title: '💡 Suggestion de cible',
+      label: `Confiance ${conLabel} — ${payload.reason || ''}.\n`
+           + `Le bouton « Renommer » accepte la suggestion telle quelle, `
+           + `ou modifie-la avant de valider.${altInfo}`,
+      initial: payload.suggestion,
       confirmLabel: 'Renommer',
       validator: v => v ? null : 'chemin vide',
     });

--- a/dashboard/static/style.css
+++ b/dashboard/static/style.css
@@ -5642,6 +5642,124 @@ th {
     color: #fff;
 }
 
+/* ───────────────────────────────────────────────────────────────────────
+   Breakdown 3-way : Stables / Entrants / Sortants
+   Affiché en haut du panneau Routage, avant la liste des règles.
+   Donne l'aperçu visuel de ce qui RESTE / ARRIVE / PART au prochain reclassify.
+   ─────────────────────────────────────────────────────────────────────── */
+.tax-breakdown-wrap {
+    list-style: none;
+    margin: 0 0 10px 0;
+    padding: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+}
+.tax-breakdown-loading,
+.tax-breakdown-empty,
+.tax-breakdown-error {
+    padding: 6px 8px;
+    font-style: italic;
+}
+.tax-breakdown-section {
+    border: 1px solid var(--border, #30363d);
+    border-left-width: 3px;
+    border-radius: 4px;
+    padding: 4px 6px 6px 6px;
+    background: rgba(255, 255, 255, 0.015);
+}
+.tax-breakdown-stable {
+    border-left-color: #3fb950;
+}
+.tax-breakdown-incoming {
+    border-left-color: #58a6ff;
+}
+.tax-breakdown-outgoing {
+    border-left-color: #d29922;
+}
+.tax-breakdown-header {
+    display: flex;
+    align-items: baseline;
+    gap: 4px;
+    font-size: 12px;
+    font-weight: 600;
+    color: var(--text, #c9d1d9);
+    margin-bottom: 3px;
+    cursor: help;
+}
+.tax-breakdown-icon {
+    font-size: 13px;
+    width: 14px;
+    display: inline-block;
+    text-align: center;
+}
+.tax-breakdown-stable .tax-breakdown-icon { color: #3fb950; }
+.tax-breakdown-incoming .tax-breakdown-icon { color: #58a6ff; }
+.tax-breakdown-outgoing .tax-breakdown-icon { color: #d29922; }
+.tax-breakdown-label {
+    text-transform: uppercase;
+    letter-spacing: 0.4px;
+    font-size: 11px;
+}
+.tax-breakdown-count {
+    font-weight: normal;
+    font-size: 11px;
+    color: var(--text-muted, #8b949e);
+}
+.tax-breakdown-list {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 1px;
+}
+.tax-breakdown-item {
+    display: flex;
+    align-items: baseline;
+    gap: 3px;
+    padding: 1px 4px;
+    font-size: 12px;
+    color: var(--text, #c9d1d9);
+    border-radius: 2px;
+}
+.tax-breakdown-item:hover {
+    background: rgba(255,255,255,0.04);
+}
+.tax-breakdown-theme {
+    flex: 1;
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+.tax-breakdown-num {
+    font-variant-numeric: tabular-nums;
+    color: var(--text-muted, #8b949e);
+    font-size: 11px;
+    margin-left: 4px;
+}
+.tax-breakdown-target {
+    color: var(--text-muted, #8b949e);
+    font-size: 11px;
+    margin-left: 4px;
+    font-style: italic;
+}
+.tax-breakdown-orphan {
+    color: #d29922;
+    font-size: 11px;
+    margin-left: 4px;
+    font-style: italic;
+}
+.tax-breakdown-more {
+    padding: 2px 4px;
+    font-size: 11px;
+}
+.tax-breakdown-empty-row {
+    padding: 2px 4px;
+    font-size: 11px;
+}
+
 /* Inline expand under a selected mapped theme — tabs + file list */
 .tax-mapped-expand {
     list-style: none;

--- a/dashboard/static/style.css
+++ b/dashboard/static/style.css
@@ -3881,6 +3881,22 @@ th {
 .tax-cat-entry.dormant {
     opacity: 0.55;
 }
+.tax-cat-entry.orphan {
+    background: rgba(248, 81, 73, 0.06);
+    border-left: 2px solid rgba(248, 81, 73, 0.45);
+    padding-left: 8px;
+}
+.tax-cat-entry.orphan.selected {
+    background: rgba(248, 81, 73, 0.14);
+    border-left-color: var(--red, #f85149);
+}
+.tax-cat-entry-orphan {
+    color: #f85149;
+    font-size: 11px;
+    margin-right: 4px;
+    cursor: help;
+    flex-shrink: 0;
+}
 .tax-cat-entry-path {
     flex: 1;
     white-space: nowrap;
@@ -3888,6 +3904,11 @@ th {
     text-overflow: ellipsis;
     font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
     font-size: 11px;
+}
+.tax-cat-entry.orphan .tax-cat-entry-path {
+    text-decoration: line-through;
+    text-decoration-color: rgba(248, 81, 73, 0.6);
+    color: var(--text-muted, #8b949e);
 }
 .tax-cat-entry-prio {
     font-size: 9px;
@@ -3897,6 +3918,12 @@ th {
     border-radius: 8px;
     font-variant-numeric: tabular-nums;
     flex-shrink: 0;
+}
+.tax-cat-group-orphan-count {
+    color: #f85149;
+    font-size: 10.5px;
+    font-weight: 600;
+    cursor: help;
 }
 
 /* Col 2 — detail */

--- a/dashboard/static/style.css
+++ b/dashboard/static/style.css
@@ -5556,6 +5556,71 @@ th {
 }
 .tax-mapped-item.selected .tax-mapped-action { opacity: 1; }
 
+/* Bulk-delete des mappings : checkbox + toolbar (apparaît dès 1 cochée) */
+.tax-mapped-cb {
+    flex-shrink: 0;
+    width: 14px;
+    height: 14px;
+    margin: 0 4px 0 0;
+    cursor: pointer;
+    accent-color: var(--blue, #58a6ff);
+}
+.tax-mapped-item.bulk-selected {
+    background: rgba(248, 81, 73, 0.08);
+}
+.tax-mapped-item.bulk-selected.selected {
+    /* Si à la fois spotlight ET bulk-cochée : fond mixte */
+    background: rgba(88, 166, 255, 0.10);
+    border-left-color: var(--red, #f85149);
+}
+.tax-mapped-bulk-toolbar {
+    list-style: none;
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    flex-wrap: wrap;
+    padding: 6px 8px;
+    margin: 0 0 6px 0;
+    background: rgba(248, 81, 73, 0.08);
+    border: 1px solid rgba(248, 81, 73, 0.25);
+    border-radius: 5px;
+    font-size: 12px;
+}
+.tax-mapped-bulk-count {
+    color: var(--text, #c9d1d9);
+    font-weight: 600;
+    margin-right: auto;
+}
+.tax-mapped-bulk-btn {
+    padding: 3px 8px;
+    font-size: 11.5px;
+    border: 1px solid var(--border, #30363d);
+    background: var(--bg-secondary, transparent);
+    color: var(--text, #c9d1d9);
+    border-radius: 3px;
+    cursor: pointer;
+    transition: background 0.12s, border-color 0.12s;
+}
+.tax-mapped-bulk-btn:hover:not(:disabled) {
+    background: rgba(255,255,255,0.06);
+    border-color: var(--border-light, #3a3a3a);
+}
+.tax-mapped-bulk-btn:disabled {
+    opacity: 0.5;
+    cursor: default;
+}
+.tax-mapped-bulk-btn.tax-mapped-bulk-danger {
+    background: rgba(248, 81, 73, 0.18);
+    border-color: rgba(248, 81, 73, 0.45);
+    color: #ff8a82;
+    font-weight: 600;
+}
+.tax-mapped-bulk-btn.tax-mapped-bulk-danger:hover:not(:disabled) {
+    background: rgba(248, 81, 73, 0.3);
+    border-color: var(--red, #f85149);
+    color: #ffb3ad;
+}
+
 /* Inline expand under a selected mapped theme — tabs + file list */
 .tax-mapped-expand {
     list-style: none;

--- a/dashboard/static/style.css
+++ b/dashboard/static/style.css
@@ -3925,6 +3925,27 @@ th {
     font-weight: 600;
     cursor: help;
 }
+.tax-cat-orphan-banner {
+    padding: 6px 10px;
+    margin: 4px 0 8px 0;
+    background: rgba(248, 81, 73, 0.12);
+    border: 1px solid rgba(248, 81, 73, 0.35);
+    border-radius: 4px;
+    color: #ffb3ad;
+    font-size: 11.5px;
+    font-weight: 500;
+    cursor: help;
+}
+.tax-cat-action-suggest {
+    background: rgba(56, 139, 253, 0.18) !important;
+    border-color: rgba(56, 139, 253, 0.45) !important;
+    color: #79c0ff !important;
+    font-weight: 600;
+}
+.tax-cat-action-suggest:hover {
+    background: rgba(56, 139, 253, 0.28) !important;
+    border-color: var(--blue, #58a6ff) !important;
+}
 
 /* Col 2 — detail */
 .tax-cat-field {

--- a/dashboard/static/style.css
+++ b/dashboard/static/style.css
@@ -5621,6 +5621,27 @@ th {
     color: #ffb3ad;
 }
 
+/* Badge d'aide ⓘ à côté du titre "Routage" */
+.tax-routing-help {
+    display: inline-block;
+    margin-left: 4px;
+    width: 14px; height: 14px;
+    line-height: 14px;
+    text-align: center;
+    font-size: 11px;
+    font-weight: normal;
+    border-radius: 50%;
+    background: var(--bg-tertiary, #1a1a1a);
+    color: var(--text-muted, #8b949e);
+    cursor: help;
+    user-select: none;
+    vertical-align: middle;
+}
+.tax-routing-help:hover {
+    background: var(--blue, #58a6ff);
+    color: #fff;
+}
+
 /* Inline expand under a selected mapped theme — tabs + file list */
 .tax-mapped-expand {
     list-style: none;

--- a/dashboard/taxonomy.py
+++ b/dashboard/taxonomy.py
@@ -2414,6 +2414,19 @@ def _change_folder_path(profile: str, old_path: str, new_path: str) -> dict:
                     pass
             raise
 
+        # Cascade categories.yaml — relaie le rename de chemin sur les
+        # entries de l'étape 2 du pipeline (KeywordClassifier). Lazy import
+        # pour éviter une dépendance circulaire à l'import et un échec sur
+        # les profils sans categories.yaml (cascade_rename_target no-op).
+        # Best-effort : si la cascade categories crash, on n'annule PAS le
+        # rename — l'utilisateur verra les badges ⚠ orphelin et corrigera.
+        cat_result: dict = {"n_entries_updated": 0, "n_merged": 0, "backup": None}
+        try:
+            from dashboard import categories as _cat
+            cat_result = _cat.cascade_rename_target(profile, old_path, new_path)
+        except Exception:  # noqa: BLE001
+            pass
+
         reset_cache(profile)
         return {
             "ok": True,
@@ -2421,6 +2434,8 @@ def _change_folder_path(profile: str, old_path: str, new_path: str) -> dict:
             "new_path": new_path,
             "n_tree_entries_renamed": n_renamed,
             "n_mappings_updated": n_mappings_updated,
+            "n_categories_updated": cat_result.get("n_entries_updated", 0),
+            "n_categories_merged": cat_result.get("n_merged", 0),
             "fs_renamed": fs_renamed,
             "tree_backup": (
                 str(tree_backup.relative_to(data.get_project_root()))
@@ -2430,6 +2445,7 @@ def _change_folder_path(profile: str, old_path: str, new_path: str) -> dict:
                 str(mapping_backup.relative_to(data.get_project_root()))
                 if mapping_backup else None
             ),
+            "categories_backup": cat_result.get("backup"),
         }
 
 

--- a/dashboard/taxonomy.py
+++ b/dashboard/taxonomy.py
@@ -262,6 +262,153 @@ def _aggregate_themes_llm(profile: str, mapping: dict) -> tuple[list[dict], dict
     return themes_out, stats
 
 
+# ─── Folder theme breakdown (stable / incoming / outgoing) ───────────────
+
+
+def _aggregate_themes_in_folder_files(
+    profile: str, path: str,
+) -> dict[str, dict]:
+    """Pour chaque fichier physiquement présent dans `path`, agrège les
+    thèmes détectés (via vision_cache). Retourne `{theme_lower: {count, label}}`
+    où `label` est la forme canonique du thème (Title Case d'origine).
+
+    Le matching fichier ↔ vision_cache se fait via `compute_content_key`
+    (MD5 des head bytes) — survit aux renames. Filtre par
+    `_MIN_CONFIDENCE` pour cohérence avec _aggregate_themes_llm.
+    """
+    from lib.thumbnail import compute_content_key
+    target = _profile_target_path(profile)
+    if target is None or not target.exists():
+        return {}
+    folder_path = (target / path) if path else target
+    if not folder_path.is_dir():
+        return {}
+
+    cache_path = _vision_cache_path(profile)
+    if not cache_path.exists():
+        return {}
+    try:
+        cache = json.loads(cache_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return {}
+
+    # Optionnel : canonisation Phase dédupli si theme-canon.json présent
+    try:
+        from lib.theme_canon import canonicalize, load_canon_table
+        canon_table = load_canon_table(profile)
+    except Exception:  # noqa: BLE001
+        canon_table = None
+
+        def canonicalize(t, _ct):  # type: ignore[no-redef]
+            return t
+
+    counts: dict[str, dict] = {}
+    # Pas de récursion : seulement fichiers DIRECTEMENT dans le folder
+    # (cohérent avec _scan_folder_counts qui sert au file_count du tree).
+    for f in folder_path.iterdir():
+        if not f.is_file():
+            continue
+        if f.suffix.lower() not in (".pdf", ".epub"):
+            continue
+        key = compute_content_key(f)
+        if not key:
+            continue
+        entry = cache.get(key)
+        if not entry:
+            continue
+        for theme_str, conf in _iter_themes({"x": entry}):
+            if conf < _MIN_CONFIDENCE:
+                continue
+            canonical = canonicalize(theme_str, canon_table)
+            kl = canonical.lower()
+            slot = counts.setdefault(
+                kl, {"label": canonical, "count": 0},
+            )
+            slot["count"] += 1
+    return counts
+
+
+def compute_folder_theme_breakdown(
+    profile: str, path: str,
+) -> dict[str, list[dict]]:
+    """Décomposition des thèmes d'un dossier pour visualiser l'impact d'un
+    futur reclassify.
+
+    Renvoie `{stable, incoming, outgoing, summary}` où :
+
+      - **stable** : thèmes mappés vers `path` ET détectés sur les fichiers
+        actuels du dossier. Au reclassify, leurs fichiers RESTENT.
+      - **incoming** : thèmes mappés vers `path` mais PAS détectés sur les
+        fichiers actuels. Au reclassify, des fichiers ARRIVENT depuis ailleurs.
+      - **outgoing** : thèmes détectés sur les fichiers actuels mais mappés
+        ailleurs (ou orphelins). Au reclassify, ces fichiers PARTENT.
+
+    Le résultat est utile pour répondre "que se passera-t-il au prochain
+    reclassify sur ce dossier ?" — sans avoir à lancer un dry-run complet.
+    """
+    mapping = _load_mapping(profile)
+    mapping_lower = {k.lower(): v for k, v in mapping.items()}
+
+    # 1. Thèmes mappés VERS ce path (avec casse originale + count global)
+    mapped_to_here_keys = [k for k, v in mapping.items() if v == path]
+    mapped_to_here_lower = {k.lower() for k in mapped_to_here_keys}
+
+    # 2. Thèmes effectivement présents dans les fichiers du dossier
+    in_folder = _aggregate_themes_in_folder_files(profile, path)
+
+    # 3. Univers global pour les counts d'incoming
+    themes_llm, _stats = _aggregate_themes_llm(profile, mapping)
+    counts_global = {t["theme"].lower(): t["count"] for t in themes_llm}
+
+    stable: list[dict] = []
+    outgoing: list[dict] = []
+    for theme_l, slot in in_folder.items():
+        target_folder = mapping_lower.get(theme_l)
+        entry = {
+            "theme": slot["label"],
+            "count_in_folder": slot["count"],
+        }
+        if target_folder == path:
+            stable.append(entry)
+        elif target_folder is None:
+            outgoing.append({**entry, "target": None, "reason": "orphan"})
+        else:
+            outgoing.append({
+                **entry, "target": target_folder, "reason": "mapped_elsewhere",
+            })
+
+    incoming: list[dict] = []
+    for theme in mapped_to_here_keys:
+        if theme.lower() in in_folder:
+            continue
+        total = counts_global.get(theme.lower(), 0)
+        incoming.append({
+            "theme": theme,
+            "count_expected": total,  # pas dans le folder = arrivera entièrement
+        })
+
+    stable.sort(key=lambda x: -x["count_in_folder"])
+    incoming.sort(key=lambda x: -x["count_expected"])
+    outgoing.sort(key=lambda x: -x["count_in_folder"])
+
+    summary = {
+        "path": path,
+        "n_stable": len(stable),
+        "n_incoming": len(incoming),
+        "n_outgoing": len(outgoing),
+        "files_stable": sum(s["count_in_folder"] for s in stable),
+        "files_incoming": sum(s["count_expected"] for s in incoming),
+        "files_outgoing": sum(s["count_in_folder"] for s in outgoing),
+        "n_mapped_rules": len(mapped_to_here_lower),
+    }
+    return {
+        "stable": stable,
+        "incoming": incoming,
+        "outgoing": outgoing,
+        "summary": summary,
+    }
+
+
 # ─── Live file counts per folder ──────────────────────────────────────────
 
 

--- a/dashboard/templates/partials/agent_refonte_panel.html
+++ b/dashboard/templates/partials/agent_refonte_panel.html
@@ -38,7 +38,7 @@
         </div>
     </div>
 
-    <div style="display: grid; grid-template-columns: 320px 1fr; gap: 16px; margin-top: 16px;">
+    <div class="tax-refonte-c-grid">
         <!-- COL 1 : runs récents + conversations -->
         <div>
             <h3 style="margin-top: 0;">Runs récents</h3>
@@ -75,8 +75,10 @@
                     <div id="tax-refonte-report" class="tax-refonte-md"></div>
                 </div>
             </div>
+            <!-- Wrapper centré pour le chat (limite max-width sur ultra-wide) -->
+            <div id="tax-refonte-chat-wrapper" class="tax-refonte-chat-wrapper" style="display: none;">
             <!-- Mode CHAT (Phase C) -->
-            <div id="tax-refonte-chat-view" style="display: none;">
+            <div id="tax-refonte-chat-view">
                 <div class="tax-refonte-report-header">
                     <h3 style="margin: 0;">
                         🗨 Conversation
@@ -101,6 +103,19 @@
                                 type="button" title="Envoyer (Entrée)">Envoyer</button>
                     </div>
                 </div>
+            </div>
+            </div><!-- /chat-wrapper -->
+        </div>
+        <!-- COL 3 : timeline mutations (visible ≥ 1280px) -->
+        <div id="tax-refonte-timeline-col" class="tax-refonte-timeline-col">
+            <h3 style="margin-top: 0; display:flex; align-items:center; gap:6px;">
+                <span>📋 Timeline</span>
+                <button id="tax-refonte-timeline-refresh" class="btn-secondary"
+                        type="button" style="padding:2px 8px;font-size:11px;margin-left:auto;"
+                        title="Recharger">↻</button>
+            </h3>
+            <div id="tax-refonte-timeline">
+                <p class="muted small">Aucune mutation.</p>
             </div>
         </div>
     </div>
@@ -540,7 +555,49 @@
                        border-radius: 3px; font-size: 0.9em; }
 .tax-refonte-md strong { color: var(--text-primary, inherit); }
 
-/* ─── Phase C : Chat + Conversations sidebar ──────────────────────────── */
+/* ─── Phase C : Grid responsive + Chat + Conversations sidebar ───────── */
+
+/* Grid 2-col (défaut) avec wrapper centré pour le chat */
+.tax-refonte-c-grid {
+    display: grid;
+    grid-template-columns: 320px minmax(0, 1fr);
+    gap: 16px;
+    margin-top: 16px;
+}
+.tax-refonte-timeline-col { display: none; }
+.tax-refonte-chat-wrapper {
+    max-width: 960px;       /* limite la largeur du chat même sans col 3 */
+    margin: 0 auto;
+    width: 100%;
+}
+
+/* ≥ 1280 px : 3 colonnes — la timeline mutations apparaît à droite */
+@media (min-width: 1280px) {
+    .tax-refonte-c-grid {
+        grid-template-columns: 320px minmax(0, 1fr) 320px;
+    }
+    .tax-refonte-timeline-col { display: block; }
+    .tax-refonte-chat-wrapper { max-width: 920px; }
+}
+
+/* ≥ 1920 px (écrans wide/ultra-wide) : col 3 plus large pour respirer */
+@media (min-width: 1920px) {
+    .tax-refonte-c-grid {
+        grid-template-columns: 340px minmax(0, 1100px) 380px;
+        justify-content: center;  /* centre toute la grille horizontalement */
+    }
+    .tax-refonte-chat-wrapper { max-width: 1100px; }
+}
+
+/* < 900 px (mobile/tablette) : tout empilé sur 1 colonne */
+@media (max-width: 900px) {
+    .tax-refonte-c-grid {
+        grid-template-columns: 1fr;
+    }
+    .tax-refonte-chat-wrapper { max-width: 100%; }
+}
+
+
 
 /* Item conversation (sidebar col 1) */
 .tax-refonte-conv-item {
@@ -622,7 +679,7 @@
     gap: 12px;
 }
 .tax-refonte-chat-msg {
-    max-width: 85%;
+    max-width: min(85%, 680px);  /* lisibilité sur ultra-wide */
     padding: 10px 14px;
     border-radius: 8px;
     font-size: 13.5px;
@@ -683,6 +740,43 @@
     align-self: flex-end;
     padding: 8px 16px;
 }
+
+/* Timeline mutations (col 3) */
+.tax-refonte-timeline-item {
+    padding: 8px 10px;
+    margin-bottom: 6px;
+    border: 1px solid var(--border);
+    border-left: 3px solid var(--border);
+    border-radius: 5px;
+    background: var(--bg-secondary);
+    font-size: 12px;
+}
+.tax-refonte-timeline-item.ok      { border-left-color: #22c55e; }
+.tax-refonte-timeline-item.error   { border-left-color: #ef4444; }
+.tax-refonte-timeline-item.rolled  { border-left-color: #6b7280; opacity: 0.65; }
+.tax-refonte-timeline-head {
+    display: flex; justify-content: space-between; align-items: center;
+    gap: 6px; margin-bottom: 4px;
+}
+.tax-refonte-timeline-bid {
+    font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+    font-size: 11px;
+    color: var(--text-muted);
+}
+.tax-refonte-timeline-ts { font-size: 11px; color: var(--text-muted); }
+.tax-refonte-timeline-tools {
+    font-size: 12px;
+    color: var(--text-primary, #e6e6e6);
+    margin-bottom: 4px;
+    word-break: break-word;
+}
+.tax-refonte-timeline-actions {
+    display: flex; gap: 4px; margin-top: 6px;
+}
+.tax-refonte-timeline-actions button {
+    padding: 3px 8px; font-size: 11px;
+}
+
 </style>
 
 <script>
@@ -1734,7 +1828,121 @@
         }
     });
 
-    // Chargement initial des convs
+    // ─── Timeline mutations (col 3, visible ≥ 1280px) ───────────────────
+    const timelineEl = document.getElementById('tax-refonte-timeline');
+    const timelineRefreshBtn = document.getElementById('tax-refonte-timeline-refresh');
+
+    async function loadTimeline() {
+        const profile = currentProfile();
+        try {
+            const r = await fetch('/api/agent/refonte/c/batches?profile='
+                                + encodeURIComponent(profile));
+            if (!r.ok) throw new Error('HTTP ' + r.status);
+            const data = await r.json();
+            renderTimeline(data.batches || []);
+        } catch (e) {
+            timelineEl.innerHTML = '<p class="muted small">Erreur : ' + e.message + '</p>';
+        }
+    }
+
+    function renderTimeline(batches) {
+        if (!batches.length) {
+            timelineEl.innerHTML = '<p class="muted small">Aucune mutation.</p>';
+            return;
+        }
+        timelineEl.innerHTML = '';
+        for (const b of batches) {
+            const item = document.createElement('div');
+            const klass = b.rolled_back ? 'rolled'
+                        : (b.n_error > 0 ? 'error' : 'ok');
+            item.className = 'tax-refonte-timeline-item ' + klass;
+            const bid = (b.batch_id || '').slice(0, 8);
+            const ts = b.ts_last ? new Date(b.ts_last).toLocaleString('fr-FR', {
+                day: '2-digit', month: '2-digit',
+                hour: '2-digit', minute: '2-digit',
+            }) : '';
+            const toolsList = (b.tools || []).join(', ') || '?';
+            const status = b.rolled_back ? '⏪ rolled back'
+                         : (b.n_error > 0 ? '❌ ' + b.n_error + ' err' : '✓ ' + b.n_ok);
+            item.innerHTML =
+                '<div class="tax-refonte-timeline-head">'
+              + '  <code class="tax-refonte-timeline-bid">' + bid + '</code>'
+              + '  <span class="tax-refonte-timeline-ts">' + ts + '</span>'
+              + '</div>'
+              + '<div class="tax-refonte-timeline-tools">' + escapeHtml(toolsList) + '</div>'
+              + '<div class="muted small">' + status + '</div>'
+              + (b.rolled_back ? ''
+                 : '<div class="tax-refonte-timeline-actions">'
+                 + '  <button class="btn-secondary" data-action="rollback" '
+                 + '          data-bid="' + b.batch_id + '">⏪ Rollback</button>'
+                 + '</div>');
+            const rb = item.querySelector('[data-action="rollback"]');
+            if (rb) rb.addEventListener('click', () => rollbackBatch(b.batch_id));
+            timelineEl.appendChild(item);
+        }
+    }
+
+    async function rollbackBatch(batchId) {
+        const ok = await showConfirm({
+            title: 'Rollback de la mutation ?',
+            body: 'Va restaurer tree.yaml et theme_mapping.yaml depuis le '
+                + 'snapshot. Les fichiers physiques déplacés ne reviennent PAS. '
+                + 'Le rollback est lui-même journalisé.',
+            confirmLabel: 'Rollback',
+            cancelLabel: 'Annuler',
+            variant: 'danger',
+        });
+        if (!ok) return;
+        const profile = currentProfile();
+        try {
+            const r = await fetch('/api/agent/refonte/c/rollback', {
+                method: 'POST',
+                headers: {'Content-Type': 'application/json'},
+                body: JSON.stringify({profile, batch_id: batchId}),
+            });
+            if (!r.ok) {
+                const err = await r.json().catch(() => ({}));
+                showToast('Erreur : ' + (err.error || r.status), 'error');
+                return;
+            }
+            const data = await r.json();
+            const warn = data.warning_newer_batches > 0
+                ? ' (⚠ ' + data.warning_newer_batches + ' batch(es) plus récents)'
+                : '';
+            showToast('✓ Rollback effectué' + warn, 'success');
+            loadTimeline();
+        } catch (e) {
+            showToast('Erreur réseau : ' + e.message, 'error');
+        }
+    }
+
+    function escapeHtml(s) {
+        return String(s)
+            .replace(/&/g, '&amp;').replace(/</g, '&lt;')
+            .replace(/>/g, '&gt;').replace(/"/g, '&quot;')
+            .replace(/'/g, '&#39;');
+    }
+
+    timelineRefreshBtn.addEventListener('click', loadTimeline);
+
+    // Refresh timeline + convs après chaque mutation (apply via chat)
+    const _originalRefreshConvState = refreshConvState;
+    refreshConvState = async function() {
+        const prev = currentConvId
+            ? (await fetch('/api/agent/refonte/c/conv/' + encodeURIComponent(currentConvId)
+                          + '?profile=' + encodeURIComponent(currentProfile()))
+                .then(r => r.ok ? r.json() : null).catch(() => null))
+            : null;
+        await _originalRefreshConvState();
+        // Si le status vient de passer de executing/thinking à done → reload timeline
+        if (prev && prev.status === 'executing') {
+            loadTimeline();
+            loadConvs();
+        }
+    };
+
+    // Chargement initial des convs + timeline
     loadConvs();
+    loadTimeline();
 })();
 </script>

--- a/dashboard/templates/partials/agent_refonte_panel.html
+++ b/dashboard/templates/partials/agent_refonte_panel.html
@@ -1332,10 +1332,12 @@
                 item.classList.add('active');
                 // Bascule en mode rapport (au cas où on était sur le chat
                 // d'une conv Phase C avant de cliquer sur ce run A/B).
-                const chatView = document.getElementById('tax-refonte-chat-view');
-                const reportView = document.getElementById('tax-refonte-report-view');
-                if (chatView) chatView.style.display = 'none';
-                if (reportView) reportView.style.display = '';
+                const _chatView = document.getElementById('tax-refonte-chat-view');
+                const _chatWrapper = document.getElementById('tax-refonte-chat-wrapper');
+                const _reportView = document.getElementById('tax-refonte-report-view');
+                if (_chatWrapper) _chatWrapper.style.display = 'none';
+                if (_chatView) _chatView.style.display = 'none';
+                if (_reportView) _reportView.style.display = '';
                 // Désélectionne la conv active
                 const convs = document.getElementById('tax-refonte-convs');
                 if (convs) convs.querySelectorAll('.tax-refonte-conv-item.active')
@@ -1557,6 +1559,7 @@
     const convsEl = document.getElementById('tax-refonte-convs');
     const reportView = document.getElementById('tax-refonte-report-view');
     const chatView = document.getElementById('tax-refonte-chat-view');
+    const chatWrapper = document.getElementById('tax-refonte-chat-wrapper');
     const chatConvIdEl = document.getElementById('tax-refonte-chat-conv-id');
     const chatStatusEl = document.getElementById('tax-refonte-chat-status');
     const chatMessagesEl = document.getElementById('tax-refonte-chat-messages');
@@ -1569,10 +1572,14 @@
 
     function showChatView() {
         reportView.style.display = 'none';
-        chatView.style.display = '';
+        // Bascule le WRAPPER pas l'inner view (wrapper est display:none par
+        // défaut côté HTML pour le responsive centré).
+        if (chatWrapper) chatWrapper.style.display = '';
+        if (chatView) chatView.style.display = '';
     }
     function showReportView() {
-        chatView.style.display = 'none';
+        if (chatWrapper) chatWrapper.style.display = 'none';
+        if (chatView) chatView.style.display = 'none';
         reportView.style.display = '';
     }
 

--- a/dashboard/templates/partials/agent_refonte_panel.html
+++ b/dashboard/templates/partials/agent_refonte_panel.html
@@ -20,6 +20,11 @@
                 <span class="tax-refonte-start-icon">🔧</span>
                 <span>Proposer une refonte</span>
             </button>
+            <button id="tax-refonte-new-conv" class="tax-refonte-propose-btn"
+                    title="Démarrer une conversation avec l'agent (Phase C) — créer/renommer/fusionner des dossiers, ajouter des mappings">
+                <span class="tax-refonte-start-icon">🗨</span>
+                <span>Nouvelle conversation</span>
+            </button>
             <div class="tax-refonte-budget-field">
                 <label for="tax-refonte-budget" class="filter-label">Budget LLM</label>
                 <input type="number" id="tax-refonte-budget" value="5" min="1" max="20">
@@ -34,32 +39,68 @@
     </div>
 
     <div style="display: grid; grid-template-columns: 320px 1fr; gap: 16px; margin-top: 16px;">
-        <!-- COL 1 : runs récents -->
+        <!-- COL 1 : runs récents + conversations -->
         <div>
             <h3 style="margin-top: 0;">Runs récents</h3>
             <div id="tax-refonte-runs">
                 <p class="muted small">Chargement…</p>
             </div>
+            <h3 style="margin-top: 20px; display: flex; align-items: center; gap: 6px;">
+                <span>🗨 Conversations</span>
+            </h3>
+            <div id="tax-refonte-convs">
+                <p class="muted small">Aucune conversation.</p>
+            </div>
         </div>
-        <!-- COL 2 : rapport courant -->
+        <!-- COL 2 : rapport courant OU chat (selon sélection) -->
         <div>
-            <div class="tax-refonte-report-header">
-                <h3 style="margin: 0;">Rapport</h3>
-                <div class="tax-refonte-report-actions">
-                    <button id="tax-refonte-copy" class="btn-secondary" type="button"
-                            title="Copier le rapport markdown" disabled>📋 Copier</button>
-                    <button id="tax-refonte-download" class="btn-secondary" type="button"
-                            title="Télécharger en .md" disabled>⬇ Télécharger</button>
+            <!-- Mode RAPPORT (Phase A/B) -->
+            <div id="tax-refonte-report-view">
+                <div class="tax-refonte-report-header">
+                    <h3 style="margin: 0;">Rapport</h3>
+                    <div class="tax-refonte-report-actions">
+                        <button id="tax-refonte-copy" class="btn-secondary" type="button"
+                                title="Copier le rapport markdown" disabled>📋 Copier</button>
+                        <button id="tax-refonte-download" class="btn-secondary" type="button"
+                                title="Télécharger en .md" disabled>⬇ Télécharger</button>
+                    </div>
+                </div>
+                <div id="tax-refonte-report-container"
+                     style="padding: 16px; border: 1px solid var(--border);
+                            border-radius: 8px; min-height: 400px;
+                            background: var(--bg-secondary);">
+                    <div id="tax-refonte-status" class="muted" style="margin-bottom: 12px;">
+                        Sélectionne un run à gauche ou lance un nouveau diagnostic.
+                    </div>
+                    <div id="tax-refonte-report" class="tax-refonte-md"></div>
                 </div>
             </div>
-            <div id="tax-refonte-report-container"
-                 style="padding: 16px; border: 1px solid var(--border);
-                        border-radius: 8px; min-height: 400px;
-                        background: var(--bg-secondary);">
-                <div id="tax-refonte-status" class="muted" style="margin-bottom: 12px;">
-                    Sélectionne un run à gauche ou lance un nouveau diagnostic.
+            <!-- Mode CHAT (Phase C) -->
+            <div id="tax-refonte-chat-view" style="display: none;">
+                <div class="tax-refonte-report-header">
+                    <h3 style="margin: 0;">
+                        🗨 Conversation
+                        <span id="tax-refonte-chat-conv-id" class="muted small"
+                              style="margin-left: 8px; font-weight: normal;"></span>
+                    </h3>
+                    <div class="tax-refonte-report-actions">
+                        <span id="tax-refonte-chat-status" class="muted small"></span>
+                    </div>
                 </div>
-                <div id="tax-refonte-report" class="tax-refonte-md"></div>
+                <div class="tax-refonte-chat-container">
+                    <div id="tax-refonte-chat-messages" class="tax-refonte-chat-messages">
+                        <p class="muted small" style="text-align: center; padding: 24px;">
+                            Décris ce que tu veux changer dans la taxonomie.
+                        </p>
+                    </div>
+                    <div class="tax-refonte-chat-input-row">
+                        <textarea id="tax-refonte-chat-input"
+                                  placeholder="Crée le dossier 'Rust' dans 02-INFORMATIQUE/03-Langages..."
+                                  rows="2"></textarea>
+                        <button id="tax-refonte-chat-send" class="btn-primary"
+                                type="button" title="Envoyer (Entrée)">Envoyer</button>
+                    </div>
+                </div>
             </div>
         </div>
     </div>
@@ -498,6 +539,150 @@
 .tax-refonte-md code { background: var(--bg-tertiary, #1a1a1a); padding: 1px 5px;
                        border-radius: 3px; font-size: 0.9em; }
 .tax-refonte-md strong { color: var(--text-primary, inherit); }
+
+/* ─── Phase C : Chat + Conversations sidebar ──────────────────────────── */
+
+/* Item conversation (sidebar col 1) */
+.tax-refonte-conv-item {
+    padding: 10px 12px;
+    margin-bottom: 6px;
+    border: 1px solid var(--border);
+    border-radius: 6px;
+    cursor: pointer;
+    background: var(--bg-secondary);
+    transition: background 0.15s, border-color 0.15s;
+    display: flex;
+    align-items: center;
+    gap: 8px;
+}
+.tax-refonte-conv-item:hover {
+    background: var(--bg-tertiary, rgba(255, 255, 255, 0.04));
+    border-color: var(--border-light, #3a3a3a);
+}
+.tax-refonte-conv-item.active {
+    border-color: rgba(168, 85, 247, 0.6);
+    background: rgba(168, 85, 247, 0.08);
+    box-shadow: 0 0 0 1px rgba(168, 85, 247, 0.18);
+}
+.tax-refonte-conv-icon {
+    width: 28px; height: 28px;
+    border-radius: 50%;
+    background: linear-gradient(135deg, #a855f7, #c084fc);
+    color: #fff;
+    display: flex; align-items: center; justify-content: center;
+    font-size: 14px;
+    flex-shrink: 0;
+}
+.tax-refonte-conv-meta { flex: 1; min-width: 0; }
+.tax-refonte-conv-id {
+    font-size: 11.5px;
+    color: var(--text-muted);
+    font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+}
+.tax-refonte-conv-status {
+    font-size: 11.5px;
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+}
+.tax-refonte-conv-status::before {
+    content: '';
+    width: 6px; height: 6px;
+    border-radius: 50%;
+    background: var(--text-muted);
+}
+.tax-refonte-conv-status[data-status="idle"]::before { background: #6b7280; }
+.tax-refonte-conv-status[data-status="thinking"]::before,
+.tax-refonte-conv-status[data-status="executing"]::before {
+    background: #4f6ef2; animation: taxRefontePulse 1.4s ease-in-out infinite;
+}
+.tax-refonte-conv-status[data-status="awaiting_confirm"]::before { background: #f59e0b; }
+.tax-refonte-conv-status[data-status="done"]::before { background: #22c55e; }
+.tax-refonte-conv-status[data-status="error"]::before { background: #ef4444; }
+@keyframes taxRefontePulse {
+    0%, 100% { transform: scale(1); opacity: 1; }
+    50%      { transform: scale(1.2); opacity: 0.6; }
+}
+
+/* Chat panel (col 2 quand mode chat) */
+.tax-refonte-chat-container {
+    border: 1px solid var(--border);
+    border-radius: 8px;
+    background: var(--bg-secondary);
+    height: 540px;
+    display: flex;
+    flex-direction: column;
+}
+.tax-refonte-chat-messages {
+    flex: 1;
+    overflow-y: auto;
+    padding: 16px;
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+}
+.tax-refonte-chat-msg {
+    max-width: 85%;
+    padding: 10px 14px;
+    border-radius: 8px;
+    font-size: 13.5px;
+    line-height: 1.5;
+    word-wrap: break-word;
+}
+.tax-refonte-chat-msg.user {
+    align-self: flex-end;
+    background: rgba(79, 110, 242, 0.15);
+    border: 1px solid rgba(79, 110, 242, 0.3);
+}
+.tax-refonte-chat-msg.assistant {
+    align-self: flex-start;
+    background: var(--bg-primary);
+    border: 1px solid var(--border);
+}
+.tax-refonte-chat-msg.assistant.preview {
+    border-color: rgba(245, 158, 11, 0.5);
+    background: rgba(245, 158, 11, 0.06);
+}
+.tax-refonte-chat-msg-ts {
+    font-size: 11px;
+    color: var(--text-muted);
+    margin-top: 4px;
+}
+.tax-refonte-chat-confirm-actions {
+    display: flex;
+    gap: 6px;
+    margin-top: 10px;
+    padding-top: 10px;
+    border-top: 1px dashed var(--border);
+}
+.tax-refonte-chat-confirm-actions button {
+    padding: 5px 12px;
+    font-size: 12.5px;
+}
+.tax-refonte-chat-input-row {
+    display: flex;
+    gap: 8px;
+    padding: 12px;
+    border-top: 1px solid var(--border);
+    background: var(--bg-primary);
+    border-radius: 0 0 8px 8px;
+}
+.tax-refonte-chat-input-row textarea {
+    flex: 1;
+    padding: 8px 12px;
+    background: var(--bg-tertiary, #1a1a1a);
+    border: 1px solid var(--border);
+    border-radius: 6px;
+    color: var(--text-primary, #e6e6e6);
+    font-size: 13px;
+    resize: vertical;
+    min-height: 38px;
+    max-height: 120px;
+}
+.tax-refonte-chat-input-row button {
+    align-self: flex-end;
+    padding: 8px 16px;
+}
 </style>
 
 <script>
@@ -1051,6 +1236,16 @@
                 runsEl.querySelectorAll('.tax-refonte-run-item.active')
                       .forEach(el => el.classList.remove('active'));
                 item.classList.add('active');
+                // Bascule en mode rapport (au cas où on était sur le chat
+                // d'une conv Phase C avant de cliquer sur ce run A/B).
+                const chatView = document.getElementById('tax-refonte-chat-view');
+                const reportView = document.getElementById('tax-refonte-report-view');
+                if (chatView) chatView.style.display = 'none';
+                if (reportView) reportView.style.display = '';
+                // Désélectionne la conv active
+                const convs = document.getElementById('tax-refonte-convs');
+                if (convs) convs.querySelectorAll('.tax-refonte-conv-item.active')
+                                .forEach(el => el.classList.remove('active'));
                 // Si on change de run : clear le report area pour éviter
                 // d'afficher le contenu du run précédent ("Commence maintenant."
                 // fantôme observé en prod 2026-05-25). Sera re-rempli si le
@@ -1259,5 +1454,287 @@
     // sous-onglet Taxonomie ça permet de reprendre un run lancé avant
     // un reload de page.
     loadRuns();
+
+    // ════════════════════════════════════════════════════════════════════
+    //  Phase C — Agent conversationnel (C.3 UI)
+    // ════════════════════════════════════════════════════════════════════
+
+    const newConvBtn = document.getElementById('tax-refonte-new-conv');
+    const convsEl = document.getElementById('tax-refonte-convs');
+    const reportView = document.getElementById('tax-refonte-report-view');
+    const chatView = document.getElementById('tax-refonte-chat-view');
+    const chatConvIdEl = document.getElementById('tax-refonte-chat-conv-id');
+    const chatStatusEl = document.getElementById('tax-refonte-chat-status');
+    const chatMessagesEl = document.getElementById('tax-refonte-chat-messages');
+    const chatInputEl = document.getElementById('tax-refonte-chat-input');
+    const chatSendBtn = document.getElementById('tax-refonte-chat-send');
+
+    let currentConvId = null;
+    let chatPollTimer = null;
+    const CHAT_POLL_MS = 1500;
+
+    function showChatView() {
+        reportView.style.display = 'none';
+        chatView.style.display = '';
+    }
+    function showReportView() {
+        chatView.style.display = 'none';
+        reportView.style.display = '';
+    }
+
+    async function loadConvs() {
+        const profile = currentProfile();
+        try {
+            const r = await fetch('/api/agent/refonte/c/conv?profile='
+                                + encodeURIComponent(profile));
+            if (!r.ok) throw new Error('HTTP ' + r.status);
+            const data = await r.json();
+            renderConvs(data.conversations || []);
+        } catch (err) {
+            convsEl.innerHTML = '<p class="muted small">Erreur : ' + err.message + '</p>';
+        }
+    }
+
+    function renderConvs(convs) {
+        if (!convs.length) {
+            convsEl.innerHTML = '<p class="muted small">Aucune conversation. Clique "Nouvelle conversation" ↑</p>';
+            return;
+        }
+        convsEl.innerHTML = '';
+        for (const c of convs) {
+            const item = document.createElement('div');
+            item.className = 'tax-refonte-conv-item';
+            if (currentConvId === c.conv_id) item.classList.add('active');
+            item.dataset.convId = c.conv_id;
+            const shortId = c.conv_id.slice(0, 8);
+            const status = c.status || 'idle';
+            item.innerHTML =
+                '<div class="tax-refonte-conv-icon">🗨</div>'
+              + '<div class="tax-refonte-conv-meta">'
+              + '  <div><code class="tax-refonte-conv-id">' + shortId + '</code></div>'
+              + '  <div><span class="tax-refonte-conv-status" data-status="' + status + '">' + status + '</span> · '
+              + (c.n_messages || 0) + ' msg</div>'
+              + '</div>';
+            item.addEventListener('click', () => openConv(c.conv_id));
+            convsEl.appendChild(item);
+        }
+    }
+
+    async function openConv(convId) {
+        currentConvId = convId;
+        // Highlight item
+        convsEl.querySelectorAll('.tax-refonte-conv-item.active')
+              .forEach(el => el.classList.remove('active'));
+        const target = convsEl.querySelector('[data-conv-id="' + convId + '"]');
+        if (target) target.classList.add('active');
+        // Deselect run (l'icône chat prend priorité)
+        runsEl.querySelectorAll('.tax-refonte-run-item.active')
+              .forEach(el => el.classList.remove('active'));
+        showChatView();
+        chatConvIdEl.textContent = convId.slice(0, 8) + '…';
+        await refreshConvState();
+        startChatPolling();
+    }
+
+    async function refreshConvState() {
+        if (!currentConvId) return;
+        const profile = currentProfile();
+        try {
+            const r = await fetch('/api/agent/refonte/c/conv/'
+                                + encodeURIComponent(currentConvId)
+                                + '?profile=' + encodeURIComponent(profile));
+            if (!r.ok) throw new Error('HTTP ' + r.status);
+            const state = await r.json();
+            renderChatState(state);
+            // Pause polling si état stable
+            if (['idle', 'awaiting_confirm', 'done', 'error'].includes(state.status)) {
+                stopChatPolling();
+            } else if (!chatPollTimer) {
+                startChatPolling();
+            }
+        } catch (e) {
+            chatStatusEl.textContent = 'Erreur : ' + e.message;
+        }
+    }
+
+    function startChatPolling() {
+        if (chatPollTimer) return;
+        chatPollTimer = setInterval(refreshConvState, CHAT_POLL_MS);
+    }
+    function stopChatPolling() {
+        if (chatPollTimer) { clearInterval(chatPollTimer); chatPollTimer = null; }
+    }
+
+    function renderChatState(state) {
+        chatStatusEl.textContent = stateLabel(state.status);
+        chatMessagesEl.innerHTML = '';
+        const messages = state.messages || [];
+        if (!messages.length) {
+            chatMessagesEl.innerHTML =
+                '<p class="muted small" style="text-align:center;padding:24px;">'
+              + 'Décris ce que tu veux changer dans la taxonomie.</p>';
+        } else {
+            for (let i = 0; i < messages.length; i++) {
+                const isLast = i === messages.length - 1;
+                appendChatMessage(messages[i],
+                    isLast && state.status === 'awaiting_confirm');
+            }
+        }
+        // Si awaiting_confirm, render des boutons Apply/Skip/Modify dans
+        // le dernier message assistant (preview) — sinon disabled send btn
+        chatSendBtn.disabled = (state.status === 'thinking' ||
+                                state.status === 'executing');
+        chatInputEl.disabled = (state.status === 'thinking' ||
+                                state.status === 'executing');
+        // Scroll bas
+        chatMessagesEl.scrollTop = chatMessagesEl.scrollHeight;
+    }
+
+    function stateLabel(status) {
+        const labels = {
+            'idle': 'En attente de ton message',
+            'thinking': '⌛ Réflexion en cours…',
+            'awaiting_confirm': '⚠ En attente de ta validation',
+            'executing': '⌛ Application en cours…',
+            'done': '✓ Mutation appliquée',
+            'error': '❌ Erreur',
+        };
+        return labels[status] || status;
+    }
+
+    function appendChatMessage(msg, attachConfirmActions) {
+        const div = document.createElement('div');
+        div.className = 'tax-refonte-chat-msg ' + (msg.role || 'assistant');
+        if (attachConfirmActions) div.classList.add('preview');
+        const content = document.createElement('div');
+        content.textContent = msg.content || '';
+        div.appendChild(content);
+        const ts = document.createElement('div');
+        ts.className = 'tax-refonte-chat-msg-ts';
+        ts.textContent = formatTs(msg.ts);
+        div.appendChild(ts);
+        if (attachConfirmActions) {
+            const actions = document.createElement('div');
+            actions.className = 'tax-refonte-chat-confirm-actions';
+            actions.innerHTML =
+                '<button class="btn-primary" data-action="apply">✓ Apply</button>'
+              + '<button class="btn-secondary" data-action="skip">✕ Skip</button>'
+              + '<button class="btn-secondary" data-action="modify">✎ Modify</button>';
+            actions.querySelector('[data-action="apply"]')
+                   .addEventListener('click', () => respond('apply'));
+            actions.querySelector('[data-action="skip"]')
+                   .addEventListener('click', () => respond('skip'));
+            actions.querySelector('[data-action="modify"]')
+                   .addEventListener('click', () => {
+                       chatInputEl.placeholder = 'Modifier la proposition…';
+                       chatInputEl.focus();
+                       // Le user re-tape un message → send() détectera awaiting_confirm
+                       // et basculera en modify via une réponse spéciale.
+                       chatInputEl.dataset.modifyMode = '1';
+                   });
+            div.appendChild(actions);
+        }
+        chatMessagesEl.appendChild(div);
+    }
+
+    function formatTs(iso) {
+        if (!iso) return '';
+        try {
+            return new Date(iso).toLocaleTimeString('fr-FR', {
+                hour: '2-digit', minute: '2-digit',
+            });
+        } catch (e) { return ''; }
+    }
+
+    async function startNewConv() {
+        const profile = currentProfile();
+        try {
+            const r = await fetch('/api/agent/refonte/c/conv', {
+                method: 'POST',
+                headers: {'Content-Type': 'application/json'},
+                body: JSON.stringify({profile}),
+            });
+            if (!r.ok) {
+                const err = await r.json().catch(() => ({}));
+                alert('Erreur : ' + (err.error || r.status));
+                return;
+            }
+            const state = await r.json();
+            await loadConvs();
+            await openConv(state.conv_id);
+        } catch (e) {
+            alert('Erreur réseau : ' + e.message);
+        }
+    }
+
+    async function sendChatMessage() {
+        const text = chatInputEl.value.trim();
+        if (!text || !currentConvId) return;
+        const profile = currentProfile();
+        const modifyMode = chatInputEl.dataset.modifyMode === '1';
+        chatInputEl.value = '';
+        chatInputEl.placeholder = 'Crée le dossier...';
+        delete chatInputEl.dataset.modifyMode;
+        try {
+            const url = modifyMode
+                ? '/api/agent/refonte/c/conv/' + encodeURIComponent(currentConvId) + '/respond'
+                : '/api/agent/refonte/c/conv/' + encodeURIComponent(currentConvId) + '/message';
+            const body = modifyMode
+                ? {profile, action: 'modify', modification_text: text}
+                : {profile, text};
+            const r = await fetch(url, {
+                method: 'POST',
+                headers: {'Content-Type': 'application/json'},
+                body: JSON.stringify(body),
+            });
+            if (!r.ok) {
+                const err = await r.json().catch(() => ({}));
+                alert('Erreur : ' + (err.error || r.status));
+                return;
+            }
+            const state = await r.json();
+            renderChatState(state);
+            startChatPolling();
+        } catch (e) {
+            alert('Erreur réseau : ' + e.message);
+        }
+    }
+
+    async function respond(action) {
+        if (!currentConvId) return;
+        if (action === 'modify') return;  // géré via le bouton lui-même
+        const profile = currentProfile();
+        try {
+            const r = await fetch(
+                '/api/agent/refonte/c/conv/' + encodeURIComponent(currentConvId) + '/respond',
+                {
+                    method: 'POST',
+                    headers: {'Content-Type': 'application/json'},
+                    body: JSON.stringify({profile, action}),
+                });
+            if (!r.ok) {
+                const err = await r.json().catch(() => ({}));
+                alert('Erreur : ' + (err.error || r.status));
+                return;
+            }
+            const state = await r.json();
+            renderChatState(state);
+            loadConvs();  // refresh sidebar status
+        } catch (e) {
+            alert('Erreur réseau : ' + e.message);
+        }
+    }
+
+    newConvBtn.addEventListener('click', startNewConv);
+    chatSendBtn.addEventListener('click', sendChatMessage);
+    chatInputEl.addEventListener('keydown', (e) => {
+        if (e.key === 'Enter' && !e.shiftKey) {
+            e.preventDefault();
+            sendChatMessage();
+        }
+    });
+
+    // Chargement initial des convs
+    loadConvs();
 })();
 </script>

--- a/dashboard/templates/taxonomy.html
+++ b/dashboard/templates/taxonomy.html
@@ -154,7 +154,10 @@
     <section class="tax-col tax-col-themes">
         <div class="tax-themes-mapped">
             <header class="tax-col-header">
-                <h2 class="tax-col-title">Thèmes mappés</h2>
+                <h2 class="tax-col-title" title="Liste des règles de routage : ces thèmes IRAIENT vers le dossier sélectionné au prochain reclassify. Pas les fichiers actuellement dedans.">
+                    Routage : thèmes → ce dossier
+                    <span class="tax-routing-help" title="Ces thèmes sont une RÈGLE DE ROUTAGE (theme_mapping.yaml), pas la liste des fichiers actuels du dossier. Au prochain reclassify, les fichiers dont le LLM Vision a détecté un de ces thèmes y seraient déplacés. Supprimer une règle n'affecte pas les fichiers déjà rangés — seulement où ils iraient au prochain reclassify.">ⓘ</span>
+                </h2>
                 <span class="tax-col-sub" id="tax-mapped-sub">Sélectionne un dossier</span>
             </header>
             <ul id="tax-mapped-list" class="tax-mapped-list"></ul>

--- a/tests/auto/test_agent_dialog.py
+++ b/tests/auto/test_agent_dialog.py
@@ -1,0 +1,272 @@
+#!/usr/bin/env python3
+"""Tests pour agents.refonte.dialog — C.2 Phase C.
+
+Stratégie : on mock le LLM (`structured_llm.invoke`) pour scripter les
+MutationProposal retournées. On mock aussi `_invoke` pour intercepter
+les mutations sans toucher au FS.
+"""
+
+import json
+import os
+import shutil
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+PROJECT_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+sys.path.insert(0, PROJECT_ROOT)
+
+from agents.refonte import dialog, mutations  # noqa: E402
+from dashboard import data  # noqa: E402
+
+
+class _DialogBase(unittest.TestCase):
+    def setUp(self):
+        self.tmp = Path(tempfile.mkdtemp(prefix="klodo_dialog_"))
+        (self.tmp / "profiles" / "p").mkdir(parents=True)
+        self._patcher = mock.patch.object(
+            data, "get_project_root", return_value=self.tmp,
+        )
+        self._patcher.start()
+
+    def tearDown(self):
+        self._patcher.stop()
+        shutil.rmtree(self.tmp, ignore_errors=True)
+
+    def _mock_llm(self, proposal: dialog.MutationProposal):
+        mock_llm = mock.MagicMock()
+        mock_structured = mock.MagicMock()
+        mock_llm.with_structured_output.return_value = mock_structured
+        mock_structured.invoke.return_value = proposal
+        return mock_llm
+
+
+# ─── Setup et persistence ──────────────────────────────────────────────────
+
+
+class TestStateAndPersistence(_DialogBase):
+    def test_make_state_defaults(self):
+        s = dialog.make_state("p")
+        self.assertEqual(s["profile"], "p")
+        self.assertEqual(s["status"], "idle")
+        self.assertEqual(s["messages"], [])
+        self.assertEqual(s["llm_calls"], 0)
+        # conv_id auto
+        self.assertIsNotNone(s["conv_id"])
+        self.assertEqual(len(s["conv_id"]), 36)
+
+    def test_save_then_load_roundtrip(self):
+        s = dialog.make_state("p", conv_id="abc")
+        s["messages"].append({"role": "user", "content": "hi", "ts": "X"})
+        dialog.save_state(s)
+        loaded = dialog.load_state("p", "abc")
+        self.assertIsNotNone(loaded)
+        self.assertEqual(loaded["messages"], s["messages"])
+
+    def test_load_missing_returns_none(self):
+        self.assertIsNone(dialog.load_state("p", "ghost"))
+
+    def test_list_conversations_sorted(self):
+        # 3 conv avec updated_at différents
+        for i, cid in enumerate(["a", "b", "c"]):
+            s = dialog.make_state("p", conv_id=cid)
+            # Force updated_at distinct via fake ts
+            s["updated_at"] = f"2026-05-3{i}T00:00:00+00:00"
+            path = dialog._state_path("p", cid)
+            path.parent.mkdir(parents=True, exist_ok=True)
+            path.write_text(json.dumps(s), encoding="utf-8")
+        listed = dialog.list_conversations("p")
+        # Plus récent en tête (c)
+        self.assertEqual([c["conv_id"] for c in listed], ["c", "b", "a"])
+
+    def test_list_conversations_empty(self):
+        self.assertEqual(dialog.list_conversations("p"), [])
+
+
+# ─── run_user_message — happy path ─────────────────────────────────────────
+
+
+class TestRunUserMessageHappy(_DialogBase):
+    def test_proposes_and_awaits_confirm(self):
+        llm = self._mock_llm(dialog.MutationProposal(
+            tool="add_folder",
+            args={"parent": "", "name": "Rust"},
+            preview_text="Je vais créer le dossier Rust à la racine.",
+            confidence="high",
+        ))
+        s = dialog.make_state("p")
+        result = dialog.run_user_message(s, "Crée Rust à la racine", llm)
+        self.assertEqual(result["status"], "awaiting_confirm")
+        prop = result["proposed_mutation"]
+        self.assertEqual(prop["tool"], "add_folder")
+        self.assertEqual(prop["args"], {"parent": "", "name": "Rust"})
+        # batch_id généré et stable au moment du wait_confirm
+        self.assertIsNotNone(prop["batch_id"])
+        # 2 messages (user + assistant preview)
+        self.assertEqual(len(result["messages"]), 2)
+        self.assertEqual(result["messages"][0]["role"], "user")
+        self.assertEqual(result["messages"][1]["role"], "assistant")
+        self.assertEqual(result["llm_calls"], 1)
+
+
+# ─── run_user_message — cas d'erreur / clarification ──────────────────────
+
+
+class TestRunUserMessageEdgeCases(_DialogBase):
+    def test_low_confidence_stays_idle(self):
+        llm = self._mock_llm(dialog.MutationProposal(
+            tool=None,
+            args={},
+            preview_text="",
+            confidence="low",
+            notes="quel dossier précisément ?",
+        ))
+        s = dialog.make_state("p")
+        result = dialog.run_user_message(s, "fais quelque chose", llm)
+        self.assertEqual(result["status"], "idle")
+        self.assertIsNone(result["proposed_mutation"])
+        # 2 messages : user + clarification
+        self.assertIn("quel dossier", result["messages"][1]["content"].lower())
+
+    def test_refuses_new_message_when_awaiting_confirm(self):
+        s = dialog.make_state("p")
+        s["status"] = "awaiting_confirm"
+        s["proposed_mutation"] = {"tool": "add_folder"}
+        llm = mock.MagicMock()
+        result = dialog.run_user_message(s, "autre intention", llm)
+        self.assertEqual(result["status"], "error")
+        self.assertIn("déjà en attente", result["error"])
+        # LLM jamais appelé
+        llm.with_structured_output.assert_not_called()
+
+    def test_budget_exhausted(self):
+        llm = mock.MagicMock()
+        s = dialog.make_state("p")
+        s["llm_calls"] = 5
+        result = dialog.run_user_message(s, "test", llm, max_llm_calls=5)
+        self.assertEqual(result["status"], "error")
+        self.assertIn("budget", result["error"])
+
+    def test_llm_exception_propagated_as_error(self):
+        mock_llm = mock.MagicMock()
+        mock_structured = mock.MagicMock()
+        mock_llm.with_structured_output.return_value = mock_structured
+        mock_structured.invoke.side_effect = RuntimeError("LLM down")
+        s = dialog.make_state("p")
+        result = dialog.run_user_message(s, "test", mock_llm)
+        self.assertEqual(result["status"], "error")
+        self.assertIn("LLM down", result["error"])
+
+
+# ─── run_user_response : apply / skip / modify ─────────────────────────────
+
+
+class TestRunUserResponseApply(_DialogBase):
+    def _seed_proposal(self):
+        s = dialog.make_state("p")
+        s["status"] = "awaiting_confirm"
+        s["proposed_mutation"] = {
+            "tool": "add_folder",
+            "args": {"parent": "", "name": "X"},
+            "preview_text": "...",
+            "confidence": "high",
+            "notes": "",
+            "batch_id": "batch-uuid",
+        }
+        s["messages"].append({"role": "user", "content": "create X", "ts": "_"})
+        s["messages"].append({"role": "assistant", "content": "...", "ts": "_"})
+        return s
+
+    @mock.patch.object(dialog, "_invoke")
+    def test_apply_calls_invoke_and_marks_done(self, mock_invoke):
+        mock_invoke.return_value = {"tool": "add_folder", "batch_id": "..."}
+        s = self._seed_proposal()
+        result = dialog.run_user_response(s, "apply")
+        self.assertEqual(result["status"], "done")
+        self.assertIsNotNone(result["mutation_result"])
+        # invoke a bien été appelé avec le proposed
+        mock_invoke.assert_called_once()
+        args = mock_invoke.call_args[0]
+        self.assertEqual(args[0], "p")
+        self.assertEqual(args[1]["tool"], "add_folder")
+
+    @mock.patch.object(dialog, "_invoke")
+    def test_apply_handles_mutation_error(self, mock_invoke):
+        mock_invoke.side_effect = mutations.MutationError("folder exists")
+        s = self._seed_proposal()
+        result = dialog.run_user_response(s, "apply")
+        self.assertEqual(result["status"], "error")
+        self.assertIn("folder exists", result["error"])
+        # Message assistant explique l'erreur
+        last_msg = result["messages"][-1]
+        self.assertEqual(last_msg["role"], "assistant")
+        self.assertIn("Échec", last_msg["content"])
+
+
+class TestRunUserResponseSkip(_DialogBase):
+    def test_skip_clears_proposal(self):
+        s = dialog.make_state("p")
+        s["status"] = "awaiting_confirm"
+        s["proposed_mutation"] = {"tool": "add_folder", "args": {}}
+        result = dialog.run_user_response(s, "skip")
+        self.assertEqual(result["status"], "idle")
+        self.assertIsNone(result["proposed_mutation"])
+
+
+class TestRunUserResponseModify(_DialogBase):
+    def test_modify_reruns_parse_with_new_text(self):
+        llm = self._mock_llm(dialog.MutationProposal(
+            tool="add_folder", args={"parent": "/A", "name": "X"},
+            preview_text="...", confidence="high",
+        ))
+        s = dialog.make_state("p")
+        s["status"] = "awaiting_confirm"
+        s["proposed_mutation"] = {"tool": "add_folder", "args": {}}
+        result = dialog.run_user_response(
+            s, "modify",
+            modification_text="plutôt dans /A",
+            llm=llm,
+        )
+        # Nouvelle proposition acceptée
+        self.assertEqual(result["status"], "awaiting_confirm")
+        self.assertEqual(result["proposed_mutation"]["args"]["parent"], "/A")
+
+    def test_modify_requires_text_and_llm(self):
+        s = dialog.make_state("p")
+        s["status"] = "awaiting_confirm"
+        s["proposed_mutation"] = {"tool": "add_folder", "args": {}}
+        result = dialog.run_user_response(s, "modify")
+        self.assertEqual(result["status"], "error")
+        self.assertIn("modification_text", result["error"])
+
+
+class TestRunUserResponseRejections(_DialogBase):
+    def test_rejects_when_not_awaiting_confirm(self):
+        s = dialog.make_state("p")  # idle
+        result = dialog.run_user_response(s, "apply")
+        self.assertEqual(result["status"], "error")
+        self.assertIn("aucune proposition", result["error"])
+
+
+# ─── Persistence après chaque tour ─────────────────────────────────────────
+
+
+class TestPersistenceAfterEachStep(_DialogBase):
+    def test_run_user_message_persists(self):
+        llm = self._mock_llm(dialog.MutationProposal(
+            tool="add_folder", args={"parent": "", "name": "X"},
+            preview_text="...", confidence="high",
+        ))
+        s = dialog.make_state("p", conv_id="conv-1")
+        dialog.run_user_message(s, "create X", llm)
+        # State.json existe et contient bien la proposition
+        loaded = dialog.load_state("p", "conv-1")
+        self.assertIsNotNone(loaded)
+        self.assertEqual(loaded["status"], "awaiting_confirm")
+        self.assertEqual(loaded["proposed_mutation"]["tool"], "add_folder")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/auto/test_agent_journal_backup.py
+++ b/tests/auto/test_agent_journal_backup.py
@@ -1,0 +1,341 @@
+#!/usr/bin/env python3
+"""Tests pour agents.refonte.agent_journal + agent_backup — C.0 Phase C.
+
+Couvre :
+  - Journal append-only + read + filter by batch_id + list_batches
+  - Backup create/restore/list/rotate
+  - Lien journal ↔ backup via find_backup_for_batch
+  - Rollback : record_undo + flag rolled_back dans list_batches
+"""
+
+import json
+import os
+import shutil
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+PROJECT_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+sys.path.insert(0, PROJECT_ROOT)
+
+from agents.refonte import agent_backup, agent_journal  # noqa: E402
+from dashboard import data  # noqa: E402
+
+
+class _AgentC0Base(unittest.TestCase):
+    def setUp(self):
+        self.tmp = Path(tempfile.mkdtemp(prefix="klodo_agent_c0_"))
+        (self.tmp / "profiles" / "p").mkdir(parents=True)
+        self._patcher = mock.patch.object(
+            data, "get_project_root", return_value=self.tmp,
+        )
+        self._patcher.start()
+
+    def tearDown(self):
+        self._patcher.stop()
+        shutil.rmtree(self.tmp, ignore_errors=True)
+
+    def _profile_root(self) -> Path:
+        return self.tmp / "profiles" / "p"
+
+    def _seed_prod_yamls(self, *, tree="folders:\n  - A\n",
+                        mapping="x: A\n"):
+        (self._profile_root() / "tree.yaml").write_text(tree, encoding="utf-8")
+        (self._profile_root() / "theme_mapping.yaml").write_text(
+            mapping, encoding="utf-8",
+        )
+
+
+# ─── Journal ───────────────────────────────────────────────────────────────
+
+
+class TestAgentJournalAppend(_AgentC0Base):
+    def test_generate_batch_id_unique(self):
+        b1 = agent_journal.generate_batch_id()
+        b2 = agent_journal.generate_batch_id()
+        self.assertNotEqual(b1, b2)
+        # Format UUID4
+        self.assertEqual(len(b1), 36)
+
+    def test_append_creates_file_and_writes_one_line(self):
+        bid = agent_journal.generate_batch_id()
+        entry = agent_journal.append_entry(
+            "p", tool="add_folder",
+            args={"path": "X"}, result="ok", batch_id=bid,
+            backup_dir="agent-foo-20260530-120000",
+        )
+        path = (self.tmp / "profiles" / "p" / ".cache"
+                / "refonte" / "agent-journal.jsonl")
+        self.assertTrue(path.exists())
+        lines = path.read_text().splitlines()
+        self.assertEqual(len(lines), 1)
+        loaded = json.loads(lines[0])
+        self.assertEqual(loaded["tool"], "add_folder")
+        self.assertEqual(loaded["batch_id"], bid)
+        self.assertEqual(loaded["backup_dir"], "agent-foo-20260530-120000")
+        # Le retour contient bien le ts
+        self.assertIn("ts", entry)
+
+    def test_append_multiple_entries(self):
+        bid = agent_journal.generate_batch_id()
+        for i in range(3):
+            agent_journal.append_entry(
+                "p", tool=f"tool_{i}", args={}, result="ok",
+                batch_id=bid, backup_dir=None,
+            )
+        entries = agent_journal.read_journal("p")
+        self.assertEqual(len(entries), 3)
+        # Ordre d'écriture préservé
+        self.assertEqual(entries[0]["tool"], "tool_0")
+        self.assertEqual(entries[2]["tool"], "tool_2")
+
+    def test_append_with_error(self):
+        bid = agent_journal.generate_batch_id()
+        agent_journal.append_entry(
+            "p", tool="add_folder", args={"path": "X"},
+            result="error", batch_id=bid, error="folder already exists",
+        )
+        entries = agent_journal.read_journal("p")
+        self.assertEqual(entries[0]["result"], "error")
+        self.assertEqual(entries[0]["error"], "folder already exists")
+
+    def test_append_rejects_invalid_result(self):
+        with self.assertRaises(ValueError):
+            agent_journal.append_entry(
+                "p", tool="x", args={}, result="weird",
+                batch_id=agent_journal.generate_batch_id(),
+            )
+
+    def test_append_rejects_empty_batch_id(self):
+        with self.assertRaises(ValueError):
+            agent_journal.append_entry(
+                "p", tool="x", args={}, result="ok", batch_id="",
+            )
+
+
+class TestAgentJournalRead(_AgentC0Base):
+    def test_read_empty_returns_empty_list(self):
+        self.assertEqual(agent_journal.read_journal("p"), [])
+
+    def test_read_skips_corrupted_lines(self):
+        path = (self.tmp / "profiles" / "p" / ".cache"
+                / "refonte" / "agent-journal.jsonl")
+        path.parent.mkdir(parents=True)
+        path.write_text(
+            '{"tool":"ok"}\n'
+            'not json\n'
+            '\n'  # empty line
+            '{"tool":"alsoOk"}\n',
+            encoding="utf-8",
+        )
+        entries = agent_journal.read_journal("p")
+        self.assertEqual(len(entries), 2)
+        self.assertEqual(entries[0]["tool"], "ok")
+        self.assertEqual(entries[1]["tool"], "alsoOk")
+
+    def test_list_entries_recent_first_with_limit(self):
+        for i in range(5):
+            agent_journal.append_entry(
+                "p", tool=f"tool_{i}", args={}, result="ok",
+                batch_id=agent_journal.generate_batch_id(),
+            )
+        entries = agent_journal.list_entries("p", limit=2)
+        self.assertEqual(len(entries), 2)
+        # Plus récents en tête
+        self.assertEqual(entries[0]["tool"], "tool_4")
+        self.assertEqual(entries[1]["tool"], "tool_3")
+
+    def test_list_entries_filter_by_batch_id(self):
+        bid_a = agent_journal.generate_batch_id()
+        bid_b = agent_journal.generate_batch_id()
+        agent_journal.append_entry("p", tool="t1", args={}, result="ok",
+                                    batch_id=bid_a)
+        agent_journal.append_entry("p", tool="t2", args={}, result="ok",
+                                    batch_id=bid_b)
+        agent_journal.append_entry("p", tool="t3", args={}, result="ok",
+                                    batch_id=bid_a)
+        only_a = agent_journal.list_entries("p", batch_id=bid_a)
+        self.assertEqual(len(only_a), 2)
+        self.assertEqual({e["tool"] for e in only_a}, {"t1", "t3"})
+
+
+class TestAgentJournalBatches(_AgentC0Base):
+    def test_list_batches_groups_by_batch_id(self):
+        bid_a = agent_journal.generate_batch_id()
+        bid_b = agent_journal.generate_batch_id()
+        agent_journal.append_entry("p", tool="add_folder",
+                                    args={}, result="ok", batch_id=bid_a)
+        agent_journal.append_entry("p", tool="add_theme_mapping",
+                                    args={}, result="ok", batch_id=bid_a)
+        agent_journal.append_entry("p", tool="rename_folder",
+                                    args={}, result="error",
+                                    batch_id=bid_b, error="busy")
+        batches = agent_journal.list_batches("p")
+        self.assertEqual(len(batches), 2)
+        # Plus récent en tête : bid_b (dernier ajouté)
+        self.assertEqual(batches[0]["batch_id"], bid_b)
+        self.assertEqual(batches[0]["n_error"], 1)
+        self.assertEqual(batches[0]["n_ok"], 0)
+        # bid_a a 2 ok
+        self.assertEqual(batches[1]["batch_id"], bid_a)
+        self.assertEqual(batches[1]["n_ok"], 2)
+        self.assertEqual(batches[1]["tools"], ["add_folder", "add_theme_mapping"])
+
+    def test_list_batches_marks_rolled_back(self):
+        bid = agent_journal.generate_batch_id()
+        agent_journal.append_entry("p", tool="add_folder",
+                                    args={}, result="ok", batch_id=bid,
+                                    backup_dir="agent-foo-bar")
+        # Undo plus tard
+        agent_journal.record_undo("p", bid)
+        batches = agent_journal.list_batches("p")
+        # Le batch initial bid doit être marqué rolled_back, et le undo
+        # est filtré (pas dans la liste des batches "normaux").
+        self.assertEqual(len(batches), 1)
+        self.assertEqual(batches[0]["batch_id"], bid)
+        self.assertTrue(batches[0]["rolled_back"])
+
+    def test_record_undo_creates_new_batch_id(self):
+        bid_orig = agent_journal.generate_batch_id()
+        agent_journal.append_entry("p", tool="add_folder",
+                                    args={}, result="ok", batch_id=bid_orig)
+        undo_entry = agent_journal.record_undo("p", bid_orig)
+        self.assertNotEqual(undo_entry["batch_id"], bid_orig)
+        self.assertEqual(undo_entry["tool"], "undo")
+        self.assertEqual(undo_entry["args"]["target_batch_id"], bid_orig)
+
+
+# ─── Backup ────────────────────────────────────────────────────────────────
+
+
+class TestAgentBackupCreateRestore(_AgentC0Base):
+    def test_create_backup_copies_both_yamls(self):
+        self._seed_prod_yamls(tree="folders: [A, B]\n",
+                              mapping="theme1: A\n")
+        dir_name = agent_backup.create_backup("p", "batch-1")
+        # Le dossier existe avec les 2 fichiers
+        backup_path = (self._profile_root() / ".cache" / "taxonomy-backups"
+                       / dir_name)
+        self.assertTrue(backup_path.is_dir())
+        self.assertTrue((backup_path / "tree.yaml").exists())
+        self.assertTrue((backup_path / "theme_mapping.yaml").exists())
+
+    def test_create_backup_name_format(self):
+        self._seed_prod_yamls()
+        dir_name = agent_backup.create_backup("p", "my-batch-id")
+        self.assertTrue(dir_name.startswith("agent-my-batch-id-"))
+        # Suffix = "YYYYMMDD-HHMMSS" → 15 chars
+        suffix = dir_name[len("agent-my-batch-id-"):]
+        self.assertEqual(len(suffix), 15)
+
+    def test_create_backup_refuses_when_no_prod_yaml(self):
+        # Pas de tree.yaml ni theme_mapping.yaml dans le profil
+        with self.assertRaises(agent_backup.BackupError):
+            agent_backup.create_backup("p", "batch-1")
+        # Aucun dossier vide laissé
+        root = self._profile_root() / ".cache" / "taxonomy-backups"
+        if root.exists():
+            self.assertEqual(list(root.iterdir()), [])
+
+    def test_create_backup_refuses_empty_batch_id(self):
+        self._seed_prod_yamls()
+        with self.assertRaises(agent_backup.BackupError):
+            agent_backup.create_backup("p", "")
+
+    def test_restore_roundtrip(self):
+        self._seed_prod_yamls(tree="folders: [original]\n",
+                              mapping="theme1: original\n")
+        dir_name = agent_backup.create_backup("p", "batch-1")
+        # Modifie les YAML
+        (self._profile_root() / "tree.yaml").write_text(
+            "folders: [modified]\n", encoding="utf-8")
+        (self._profile_root() / "theme_mapping.yaml").write_text(
+            "theme1: modified\n", encoding="utf-8")
+        # Restore
+        result = agent_backup.restore_backup("p", dir_name)
+        self.assertEqual(set(result["restored"]),
+                         {"tree.yaml", "theme_mapping.yaml"})
+        # Les YAML sont remis dans l'état pré-backup
+        tree = (self._profile_root() / "tree.yaml").read_text()
+        self.assertIn("original", tree)
+        self.assertNotIn("modified", tree)
+
+    def test_restore_missing_backup_raises(self):
+        with self.assertRaises(agent_backup.BackupError):
+            agent_backup.restore_backup("p", "agent-ghost-00000000-000000")
+
+
+class TestAgentBackupList(_AgentC0Base):
+    def test_list_backups_sorted_recent_first(self):
+        import time
+        self._seed_prod_yamls()
+        # Crée 3 backups successifs (ts dans le nom différents → besoin d'attendre)
+        dirs = []
+        for bid in ["one", "two", "three"]:
+            dirs.append(agent_backup.create_backup("p", bid))
+            time.sleep(1.05)  # garantir un ts différent
+        listed = agent_backup.list_backups("p")
+        self.assertEqual(len(listed), 3)
+        # Plus récent (three) en tête
+        self.assertEqual(listed[0]["batch_id"], "three")
+        self.assertEqual(listed[2]["batch_id"], "one")
+        # Chaque entrée a les bons champs
+        self.assertEqual(set(listed[0]["files"]),
+                         {"tree.yaml", "theme_mapping.yaml"})
+        self.assertGreater(listed[0]["size_bytes"], 0)
+
+    def test_list_backups_ignores_non_agent_dirs(self):
+        # Un backup manuel "theme_mapping-2026.yaml" doit être ignoré
+        self._seed_prod_yamls()
+        agent_backup.create_backup("p", "real-batch")
+        root = (self._profile_root() / ".cache" / "taxonomy-backups")
+        (root / "manual-backup-12345").mkdir()
+        (root / "theme_mapping-2026.yaml").write_text("foo: bar")
+        listed = agent_backup.list_backups("p")
+        self.assertEqual(len(listed), 1)
+        self.assertEqual(listed[0]["batch_id"], "real-batch")
+
+    def test_list_backups_empty(self):
+        self.assertEqual(agent_backup.list_backups("p"), [])
+
+
+class TestAgentBackupRotate(_AgentC0Base):
+    def test_rotate_keeps_only_max_keep(self):
+        import time
+        self._seed_prod_yamls()
+        for i in range(5):
+            agent_backup.create_backup("p", f"batch-{i}", max_keep=999)
+            time.sleep(1.05)
+        # Force rotation à max_keep=2 → garde les 2 plus récents
+        deleted = agent_backup.rotate_backups("p", max_keep=2)
+        self.assertEqual(deleted, 3)
+        listed = agent_backup.list_backups("p")
+        self.assertEqual(len(listed), 2)
+        self.assertEqual({b["batch_id"] for b in listed}, {"batch-3", "batch-4"})
+
+    def test_rotate_no_op_when_under_limit(self):
+        self._seed_prod_yamls()
+        agent_backup.create_backup("p", "only-one", max_keep=999)
+        deleted = agent_backup.rotate_backups("p", max_keep=50)
+        self.assertEqual(deleted, 0)
+
+
+class TestFindBackupForBatch(_AgentC0Base):
+    def test_finds_when_exists(self):
+        self._seed_prod_yamls()
+        dir_name = agent_backup.create_backup("p", "target-batch")
+        self.assertEqual(
+            agent_backup.find_backup_for_batch("p", "target-batch"),
+            dir_name,
+        )
+
+    def test_returns_none_when_missing(self):
+        self.assertIsNone(
+            agent_backup.find_backup_for_batch("p", "ghost-batch"),
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/auto/test_agent_mutations.py
+++ b/tests/auto/test_agent_mutations.py
@@ -1,0 +1,229 @@
+#!/usr/bin/env python3
+"""Tests pour agents.refonte.mutations — C.1 Phase C.
+
+Stratégie : on mock les helpers `dashboard.taxonomy.*` pour isoler la
+logique de wrapping (backup + journal). Quelques tests d'intégration
+vérifient le flow complet sur un profil temporaire.
+"""
+
+import os
+import shutil
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+PROJECT_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+sys.path.insert(0, PROJECT_ROOT)
+
+from agents.refonte import agent_backup, agent_journal, mutations  # noqa: E402
+from dashboard import data  # noqa: E402
+from dashboard import taxonomy as _tax  # noqa: E402
+
+
+class _MutBase(unittest.TestCase):
+    def setUp(self):
+        self.tmp = Path(tempfile.mkdtemp(prefix="klodo_mut_"))
+        (self.tmp / "profiles" / "p").mkdir(parents=True)
+        self._patcher = mock.patch.object(
+            data, "get_project_root", return_value=self.tmp,
+        )
+        self._patcher.start()
+        # YAML de production minimal pour pouvoir créer un backup
+        (self.tmp / "profiles" / "p" / "tree.yaml").write_text(
+            "folders:\n  - A\n  - B\n", encoding="utf-8",
+        )
+        (self.tmp / "profiles" / "p" / "theme_mapping.yaml").write_text(
+            "theme1: A\n", encoding="utf-8",
+        )
+
+    def tearDown(self):
+        self._patcher.stop()
+        shutil.rmtree(self.tmp, ignore_errors=True)
+
+
+# ─── add_folder ─────────────────────────────────────────────────────────────
+
+
+class TestAddFolder(_MutBase):
+    @mock.patch.object(_tax, "create_folder")
+    def test_happy_path_journals_and_backups(self, mock_create):
+        mock_create.return_value = {"path": "X", "created": True}
+        out = mutations.add_folder("p", parent="", name="X")
+        self.assertEqual(out["tool"], "add_folder")
+        self.assertIsNotNone(out["backup_dir"])
+        # Vérifie journal
+        entries = agent_journal.read_journal("p")
+        self.assertEqual(len(entries), 1)
+        self.assertEqual(entries[0]["tool"], "add_folder")
+        self.assertEqual(entries[0]["result"], "ok")
+        # Vérifie backup existe physiquement
+        self.assertIn(out["backup_dir"],
+                     {b["name"] for b in agent_backup.list_backups("p")})
+
+    @mock.patch.object(_tax, "create_folder")
+    def test_taxonomy_error_journals_error_and_raises(self, mock_create):
+        mock_create.side_effect = ValueError("folder exists")
+        with self.assertRaises(mutations.MutationError):
+            mutations.add_folder("p", parent="", name="X")
+        entries = agent_journal.read_journal("p")
+        self.assertEqual(entries[0]["result"], "error")
+        self.assertIn("folder exists", entries[0]["error"])
+
+    @mock.patch.object(_tax, "create_folder")
+    def test_uses_provided_batch_id(self, mock_create):
+        mock_create.return_value = {}
+        bid = agent_journal.generate_batch_id()
+        out = mutations.add_folder("p", parent="", name="X", batch_id=bid)
+        self.assertEqual(out["batch_id"], bid)
+
+
+# ─── add_theme_mapping ──────────────────────────────────────────────────────
+
+
+class TestAddThemeMapping(_MutBase):
+    @mock.patch.object(_tax, "add_mapping")
+    def test_happy_path(self, mock_add):
+        mock_add.return_value = {"theme": "ML", "folder": "X"}
+        out = mutations.add_theme_mapping("p", theme="ML", folder="X")
+        self.assertEqual(out["tool"], "add_theme_mapping")
+        mock_add.assert_called_once_with("p", "ML", "X")
+        entries = agent_journal.read_journal("p")
+        self.assertEqual(entries[0]["tool"], "add_theme_mapping")
+        self.assertEqual(entries[0]["args"], {"theme": "ML", "folder": "X"})
+
+
+# ─── rename_folder ──────────────────────────────────────────────────────────
+
+
+class TestRenameFolder(_MutBase):
+    @mock.patch.object(_tax, "rename_folder")
+    def test_happy_path(self, mock_rename):
+        mock_rename.return_value = {"old_path": "A", "new_path": "Z"}
+        out = mutations.rename_folder("p", old_path="A", new_name="Z")
+        self.assertEqual(out["tool"], "rename_folder")
+        mock_rename.assert_called_once_with("p", "A", "Z")
+
+
+# ─── bulk_move_files ────────────────────────────────────────────────────────
+
+
+class TestBulkMoveFiles(_MutBase):
+    @mock.patch.object(_tax, "move_file")
+    def test_all_succeed(self, mock_move):
+        mock_move.return_value = {}
+        out = mutations.bulk_move_files(
+            "p", rel_paths=["a.pdf", "b.pdf", "c.pdf"], dest_folder="X",
+        )
+        self.assertEqual(out["result_data"]["moved"],
+                         ["a.pdf", "b.pdf", "c.pdf"])
+        self.assertEqual(out["result_data"]["errors"], [])
+        # 3 appels move_file
+        self.assertEqual(mock_move.call_count, 3)
+        # 1 entrée journal globale (pas N)
+        entries = agent_journal.read_journal("p")
+        self.assertEqual(len(entries), 1)
+        self.assertEqual(entries[0]["result"], "ok")
+
+    @mock.patch.object(_tax, "move_file")
+    def test_partial_failures_continue_and_journal_error(self, mock_move):
+        def fake_move(prof, rel, dest):
+            if rel == "b.pdf":
+                raise ValueError("file not found")
+            return {}
+        mock_move.side_effect = fake_move
+        out = mutations.bulk_move_files(
+            "p", rel_paths=["a.pdf", "b.pdf", "c.pdf"], dest_folder="X",
+        )
+        self.assertEqual(out["result_data"]["moved"], ["a.pdf", "c.pdf"])
+        self.assertEqual(len(out["result_data"]["errors"]), 1)
+        self.assertEqual(out["result_data"]["errors"][0]["path"], "b.pdf")
+        entries = agent_journal.read_journal("p")
+        self.assertEqual(entries[0]["result"], "error")
+        self.assertIn("1 of 3", entries[0]["error"])
+
+
+# ─── merge_folders ──────────────────────────────────────────────────────────
+
+
+class TestMergeFolders(_MutBase):
+    @mock.patch.object(_tax, "delete_folder")
+    @mock.patch.object(_tax, "move_file")
+    @mock.patch.object(_tax, "list_files_in_folder")
+    @mock.patch.object(_tax, "create_folder")
+    @mock.patch.object(_tax, "get_snapshot")
+    def test_happy_path_creates_dest_and_merges_sources(
+        self, mock_snap, mock_create, mock_list, mock_move, mock_delete,
+    ):
+        # dest_path absent dans la snapshot
+        mock_snap.return_value = {"folders": [{"path": "A"}, {"path": "B"}]}
+        mock_list.return_value = {"files": [
+            {"rel_path": "A/file1.pdf"},
+            {"rel_path": "A/file2.pdf"},
+        ]}
+        mock_create.return_value = {}
+        mock_move.return_value = {}
+        mock_delete.return_value = {}
+
+        out = mutations.merge_folders(
+            "p", src_paths=["A"], dest_path="MERGED",
+        )
+        self.assertTrue(out["result_data"]["created_dest"])
+        self.assertEqual(out["result_data"]["sources_merged"], ["A"])
+        # create_folder appelé pour MERGED
+        mock_create.assert_called_once_with("p", "", "MERGED")
+        # move_file appelé pour les 2 fichiers de A
+        self.assertEqual(mock_move.call_count, 2)
+        # delete_folder appelé pour A
+        mock_delete.assert_called_once_with("p", "A", force=True)
+
+    @mock.patch.object(_tax, "get_snapshot")
+    def test_dest_already_exists_skips_create(self, mock_snap):
+        mock_snap.return_value = {"folders": [{"path": "MERGED"}]}
+        with mock.patch.object(_tax, "create_folder") as mock_create, \
+             mock.patch.object(_tax, "list_files_in_folder",
+                               return_value={"files": []}), \
+             mock.patch.object(_tax, "delete_folder"):
+            out = mutations.merge_folders(
+                "p", src_paths=["A"], dest_path="MERGED",
+            )
+            self.assertFalse(out["result_data"]["created_dest"])
+            mock_create.assert_not_called()
+
+
+# ─── Batch grouping ─────────────────────────────────────────────────────────
+
+
+class TestBatchGrouping(_MutBase):
+    """Plusieurs mutations dans le même batch partagent UN seul backup."""
+
+    @mock.patch.object(_tax, "add_mapping")
+    @mock.patch.object(_tax, "create_folder")
+    def test_shared_backup_dir(self, mock_create, mock_add):
+        mock_create.return_value = {}
+        mock_add.return_value = {}
+        bid = agent_journal.generate_batch_id()
+        r1 = mutations.add_folder("p", parent="", name="X", batch_id=bid)
+        r2 = mutations.add_theme_mapping("p", theme="t", folder="X",
+                                          batch_id=bid)
+        # Même backup_dir pour les 2 mutations du batch
+        self.assertEqual(r1["backup_dir"], r2["backup_dir"])
+        # Mais 2 entrées dans le journal
+        entries = agent_journal.read_journal("p")
+        self.assertEqual(len(entries), 2)
+        # 1 seul backup physique
+        self.assertEqual(len(agent_backup.list_backups("p")), 1)
+
+    @mock.patch.object(_tax, "create_folder")
+    def test_separate_batches_have_separate_backups(self, mock_create):
+        mock_create.return_value = {}
+        r1 = mutations.add_folder("p", parent="", name="X")
+        r2 = mutations.add_folder("p", parent="", name="Y")
+        # batch_id et backup_dir différents
+        self.assertNotEqual(r1["batch_id"], r2["batch_id"])
+        self.assertNotEqual(r1["backup_dir"], r2["backup_dir"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/auto/test_agent_refonte_phase_c.py
+++ b/tests/auto/test_agent_refonte_phase_c.py
@@ -1,0 +1,247 @@
+#!/usr/bin/env python3
+"""Tests pour Phase C (C.0 — backup + journal + rollback endpoints)."""
+
+import os
+import shutil
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+PROJECT_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+sys.path.insert(0, PROJECT_ROOT)
+
+from fastapi.testclient import TestClient  # noqa: E402
+
+from agents.refonte import agent_backup, agent_journal  # noqa: E402
+from dashboard import agent_refonte_phase_c, data  # noqa: E402
+
+
+class _PhaseCBase(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        from dashboard.app import app
+        cls.client = TestClient(app)
+
+    def setUp(self):
+        self.tmp = Path(tempfile.mkdtemp(prefix="klodo_phase_c_"))
+        (self.tmp / "profiles" / "p").mkdir(parents=True)
+        self._patcher = mock.patch.object(
+            data, "get_project_root", return_value=self.tmp,
+        )
+        self._patcher.start()
+
+    def tearDown(self):
+        self._patcher.stop()
+        shutil.rmtree(self.tmp, ignore_errors=True)
+
+    def _seed_yamls(self, content: str = "original") -> None:
+        root = self.tmp / "profiles" / "p"
+        (root / "tree.yaml").write_text(f"folders: [{content}]\n",
+                                         encoding="utf-8")
+        (root / "theme_mapping.yaml").write_text(f"theme1: {content}\n",
+                                                  encoding="utf-8")
+
+
+class TestRollbackHappyPath(_PhaseCBase):
+    def test_rollback_restores_yaml_and_journals_undo(self):
+        self._seed_yamls("original")
+        # Simule une mutation : backup + journal entry
+        bid = agent_journal.generate_batch_id()
+        backup_dir = agent_backup.create_backup("p", bid)
+        agent_journal.append_entry(
+            "p", tool="add_folder", args={"path": "X"}, result="ok",
+            batch_id=bid, backup_dir=backup_dir,
+        )
+        # Modifie les YAML après la mutation
+        self._seed_yamls("modified")
+        # Rollback
+        result = agent_refonte_phase_c.rollback_batch("p", bid)
+        self.assertEqual(set(result["restored_files"]),
+                         {"tree.yaml", "theme_mapping.yaml"})
+        self.assertEqual(result["warning_newer_batches"], 0)
+        # Les YAML sont restaurés
+        tree = (self.tmp / "profiles" / "p" / "tree.yaml").read_text()
+        self.assertIn("original", tree)
+        self.assertNotIn("modified", tree)
+        # Le journal contient l'undo
+        batches = agent_journal.list_batches("p")
+        self.assertTrue(batches[0]["rolled_back"])
+
+
+class TestRollbackRejections(_PhaseCBase):
+    def test_empty_profile_raises_value_error(self):
+        with self.assertRaises(ValueError):
+            agent_refonte_phase_c.rollback_batch("", "x")
+
+    def test_empty_batch_id_raises_value_error(self):
+        with self.assertRaises(ValueError):
+            agent_refonte_phase_c.rollback_batch("p", "")
+
+    def test_unknown_profile_raises_file_not_found(self):
+        with self.assertRaises(FileNotFoundError):
+            agent_refonte_phase_c.rollback_batch("ghost", "anything")
+
+    def test_unknown_batch_raises_rollback_error(self):
+        with self.assertRaises(agent_refonte_phase_c.RollbackError) as ctx:
+            agent_refonte_phase_c.rollback_batch("p", "ghost-batch-id")
+        self.assertIn("not found", str(ctx.exception))
+
+    def test_already_rolled_back_raises(self):
+        self._seed_yamls()
+        bid = agent_journal.generate_batch_id()
+        backup_dir = agent_backup.create_backup("p", bid)
+        agent_journal.append_entry(
+            "p", tool="add_folder", args={}, result="ok",
+            batch_id=bid, backup_dir=backup_dir,
+        )
+        # 1er rollback OK
+        agent_refonte_phase_c.rollback_batch("p", bid)
+        # 2e rollback → RollbackError "already"
+        with self.assertRaises(agent_refonte_phase_c.RollbackError) as ctx:
+            agent_refonte_phase_c.rollback_batch("p", bid)
+        self.assertIn("already", str(ctx.exception))
+
+    def test_missing_backup_dir_raises(self):
+        """Cas où le journal a une entrée mais le backup physique a disparu."""
+        self._seed_yamls()
+        bid = agent_journal.generate_batch_id()
+        backup_dir = agent_backup.create_backup("p", bid)
+        agent_journal.append_entry(
+            "p", tool="add_folder", args={}, result="ok",
+            batch_id=bid, backup_dir=backup_dir,
+        )
+        # Supprime physiquement le backup
+        shutil.rmtree(self.tmp / "profiles" / "p" / ".cache"
+                      / "taxonomy-backups" / backup_dir)
+        with self.assertRaises(agent_refonte_phase_c.RollbackError) as ctx:
+            agent_refonte_phase_c.rollback_batch("p", bid)
+        self.assertIn("no backup directory", str(ctx.exception))
+
+
+class TestRollbackWarningsNewerBatches(_PhaseCBase):
+    def test_warns_when_newer_batches_exist(self):
+        import time
+        self._seed_yamls()
+        # 3 mutations successives
+        bids = []
+        for _ in range(3):
+            bid = agent_journal.generate_batch_id()
+            backup_dir = agent_backup.create_backup("p", bid)
+            agent_journal.append_entry(
+                "p", tool="add_folder", args={}, result="ok",
+                batch_id=bid, backup_dir=backup_dir,
+            )
+            bids.append(bid)
+            time.sleep(1.05)
+        # Rollback du 1er batch → 2 plus récents existent
+        result = agent_refonte_phase_c.rollback_batch("p", bids[0])
+        self.assertEqual(result["warning_newer_batches"], 2)
+
+    def test_no_warning_on_last_batch(self):
+        self._seed_yamls()
+        bid = agent_journal.generate_batch_id()
+        backup_dir = agent_backup.create_backup("p", bid)
+        agent_journal.append_entry(
+            "p", tool="add_folder", args={}, result="ok",
+            batch_id=bid, backup_dir=backup_dir,
+        )
+        result = agent_refonte_phase_c.rollback_batch("p", bid)
+        self.assertEqual(result["warning_newer_batches"], 0)
+
+
+# ─── Endpoints HTTP ────────────────────────────────────────────────────────
+
+
+class TestEndpointBatches(_PhaseCBase):
+    def test_lists_batches(self):
+        bid = agent_journal.generate_batch_id()
+        agent_journal.append_entry(
+            "p", tool="add_folder", args={}, result="ok", batch_id=bid,
+        )
+        r = self.client.get("/api/agent/refonte/c/batches?profile=p")
+        self.assertEqual(r.status_code, 200)
+        body = r.json()
+        self.assertEqual(body["profile"], "p")
+        self.assertEqual(len(body["batches"]), 1)
+        self.assertEqual(body["batches"][0]["batch_id"], bid)
+
+    def test_empty_when_no_journal(self):
+        r = self.client.get("/api/agent/refonte/c/batches?profile=p")
+        self.assertEqual(r.status_code, 200)
+        self.assertEqual(r.json()["batches"], [])
+
+    def test_400_when_no_profile(self):
+        r = self.client.get("/api/agent/refonte/c/batches?profile=")
+        self.assertEqual(r.status_code, 400)
+
+
+class TestEndpointEntries(_PhaseCBase):
+    def test_lists_entries_filtered_by_batch(self):
+        bid_a = agent_journal.generate_batch_id()
+        bid_b = agent_journal.generate_batch_id()
+        agent_journal.append_entry("p", tool="t1", args={}, result="ok",
+                                    batch_id=bid_a)
+        agent_journal.append_entry("p", tool="t2", args={}, result="ok",
+                                    batch_id=bid_b)
+        r = self.client.get(
+            f"/api/agent/refonte/c/entries?profile=p&batch_id={bid_a}",
+        )
+        self.assertEqual(r.status_code, 200)
+        entries = r.json()["entries"]
+        self.assertEqual(len(entries), 1)
+        self.assertEqual(entries[0]["tool"], "t1")
+
+
+class TestEndpointRollback(_PhaseCBase):
+    def _make_batch(self) -> str:
+        self._seed_yamls()
+        bid = agent_journal.generate_batch_id()
+        backup_dir = agent_backup.create_backup("p", bid)
+        agent_journal.append_entry(
+            "p", tool="add_folder", args={}, result="ok",
+            batch_id=bid, backup_dir=backup_dir,
+        )
+        return bid
+
+    def test_happy_path(self):
+        bid = self._make_batch()
+        r = self.client.post(
+            "/api/agent/refonte/c/rollback",
+            json={"profile": "p", "batch_id": bid},
+        )
+        self.assertEqual(r.status_code, 200)
+        self.assertEqual(r.json()["batch_id"], bid)
+
+    def test_400_missing_profile(self):
+        r = self.client.post(
+            "/api/agent/refonte/c/rollback",
+            json={"batch_id": "x"},
+        )
+        self.assertEqual(r.status_code, 400)
+
+    def test_404_unknown_batch(self):
+        r = self.client.post(
+            "/api/agent/refonte/c/rollback",
+            json={"profile": "p", "batch_id": "ghost"},
+        )
+        self.assertEqual(r.status_code, 404)
+
+    def test_409_already_rolled_back(self):
+        bid = self._make_batch()
+        # 1er rollback
+        self.client.post(
+            "/api/agent/refonte/c/rollback",
+            json={"profile": "p", "batch_id": bid},
+        )
+        # 2e rollback → 409
+        r = self.client.post(
+            "/api/agent/refonte/c/rollback",
+            json={"profile": "p", "batch_id": bid},
+        )
+        self.assertEqual(r.status_code, 409)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/auto/test_agent_refonte_phase_c.py
+++ b/tests/auto/test_agent_refonte_phase_c.py
@@ -326,5 +326,101 @@ class TestMutateEndpoint(_PhaseCBase):
         self.assertIn("already exists", r.json()["error"])
 
 
+class TestConvEndpoints(_PhaseCBase):
+    def test_start_conv(self):
+        self._seed_yamls()
+        r = self.client.post(
+            "/api/agent/refonte/c/conv",
+            json={"profile": "p"},
+        )
+        self.assertEqual(r.status_code, 200)
+        body = r.json()
+        self.assertEqual(body["profile"], "p")
+        self.assertEqual(body["status"], "idle")
+        self.assertIsNotNone(body["conv_id"])
+
+    def test_start_conv_400_empty_profile(self):
+        r = self.client.post("/api/agent/refonte/c/conv", json={"profile": ""})
+        self.assertEqual(r.status_code, 400)
+
+    def test_start_conv_404_unknown_profile(self):
+        r = self.client.post("/api/agent/refonte/c/conv",
+                              json={"profile": "ghost"})
+        self.assertEqual(r.status_code, 404)
+
+    def test_list_conv_empty(self):
+        r = self.client.get("/api/agent/refonte/c/conv?profile=p")
+        self.assertEqual(r.status_code, 200)
+        self.assertEqual(r.json()["conversations"], [])
+
+    def test_get_conv_404_when_missing(self):
+        r = self.client.get("/api/agent/refonte/c/conv/ghost?profile=p")
+        self.assertEqual(r.status_code, 404)
+
+    @mock.patch("agents.llm.get_agent_llm")
+    @mock.patch("agents.refonte.dialog.run_user_message")
+    def test_send_message_routes_to_dialog(self, mock_run, mock_llm_factory):
+        # mock_llm_factory évite l'erreur "SILICONFLOW_API_KEY required"
+        mock_llm_factory.return_value = mock.MagicMock()
+        self._seed_yamls()
+        from agents.refonte import dialog
+        # 1. Crée une conv
+        state = dialog.make_state("p", conv_id="conv-1")
+        dialog.save_state(state)
+        # 2. Configure mock pour retourner un state d'awaiting_confirm
+        returned_state = dict(state)
+        returned_state["status"] = "awaiting_confirm"
+        returned_state["proposed_mutation"] = {"tool": "add_folder"}
+        mock_run.return_value = returned_state
+        # 3. Envoie message
+        r = self.client.post(
+            "/api/agent/refonte/c/conv/conv-1/message",
+            json={"profile": "p", "text": "crée X"},
+        )
+        self.assertEqual(r.status_code, 200)
+        self.assertEqual(r.json()["status"], "awaiting_confirm")
+        mock_run.assert_called_once()
+
+    def test_send_message_404_unknown_conv(self):
+        r = self.client.post(
+            "/api/agent/refonte/c/conv/ghost/message",
+            json={"profile": "p", "text": "hi"},
+        )
+        self.assertEqual(r.status_code, 404)
+
+    @mock.patch("agents.refonte.dialog.run_user_response")
+    def test_respond_apply(self, mock_resp):
+        self._seed_yamls()
+        from agents.refonte import dialog
+        state = dialog.make_state("p", conv_id="conv-2")
+        state["status"] = "awaiting_confirm"
+        state["proposed_mutation"] = {"tool": "add_folder", "batch_id": "b"}
+        dialog.save_state(state)
+        # Mock dialog response
+        returned = dict(state)
+        returned["status"] = "done"
+        mock_resp.return_value = returned
+        r = self.client.post(
+            "/api/agent/refonte/c/conv/conv-2/respond",
+            json={"profile": "p", "action": "apply"},
+        )
+        self.assertEqual(r.status_code, 200)
+        self.assertEqual(r.json()["status"], "done")
+        # Vérifie l'action passée à run_user_response
+        args = mock_resp.call_args
+        self.assertEqual(args[0][1], "apply")
+
+    def test_respond_400_invalid_action(self):
+        self._seed_yamls()
+        from agents.refonte import dialog
+        state = dialog.make_state("p", conv_id="conv-3")
+        dialog.save_state(state)
+        r = self.client.post(
+            "/api/agent/refonte/c/conv/conv-3/respond",
+            json={"profile": "p", "action": "explode"},
+        )
+        self.assertEqual(r.status_code, 400)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/auto/test_agent_refonte_phase_c.py
+++ b/tests/auto/test_agent_refonte_phase_c.py
@@ -243,5 +243,88 @@ class TestEndpointRollback(_PhaseCBase):
         self.assertEqual(r.status_code, 409)
 
 
+class TestToolsEndpoint(_PhaseCBase):
+    def test_lists_available_tools(self):
+        r = self.client.get("/api/agent/refonte/c/tools")
+        self.assertEqual(r.status_code, 200)
+        tools = r.json()["tools"]
+        self.assertIn("add_folder", tools)
+        self.assertIn("add_theme_mapping", tools)
+        self.assertIn("rename_folder", tools)
+        self.assertIn("bulk_move_files", tools)
+        self.assertIn("merge_folders", tools)
+
+
+class TestMutateEndpoint(_PhaseCBase):
+    def test_400_unknown_tool(self):
+        r = self.client.post(
+            "/api/agent/refonte/c/mutate",
+            json={"profile": "p", "tool": "ghost", "args": {}},
+        )
+        self.assertEqual(r.status_code, 400)
+        self.assertIn("unknown tool", r.json()["error"])
+
+    def test_400_empty_profile(self):
+        r = self.client.post(
+            "/api/agent/refonte/c/mutate",
+            json={"profile": "", "tool": "add_folder", "args": {}},
+        )
+        self.assertEqual(r.status_code, 400)
+
+    def test_404_unknown_profile(self):
+        r = self.client.post(
+            "/api/agent/refonte/c/mutate",
+            json={"profile": "ghost", "tool": "add_folder",
+                  "args": {"parent": "", "name": "X"}},
+        )
+        self.assertEqual(r.status_code, 404)
+
+    def test_400_when_args_not_object(self):
+        r = self.client.post(
+            "/api/agent/refonte/c/mutate",
+            json={"profile": "p", "tool": "add_folder", "args": "not a dict"},
+        )
+        self.assertEqual(r.status_code, 400)
+
+    def test_400_when_args_keys_invalid(self):
+        self._seed_yamls()
+        r = self.client.post(
+            "/api/agent/refonte/c/mutate",
+            json={"profile": "p", "tool": "add_folder",
+                  "args": {"wrong_arg": "X"}},
+        )
+        self.assertEqual(r.status_code, 400)
+        self.assertIn("invalid args", r.json()["error"])
+
+    @mock.patch("dashboard.taxonomy.create_folder")
+    def test_happy_path_with_provided_batch_id(self, mock_create):
+        from agents.refonte import agent_journal
+        self._seed_yamls()
+        mock_create.return_value = {}
+        bid = agent_journal.generate_batch_id()
+        r = self.client.post(
+            "/api/agent/refonte/c/mutate",
+            json={"profile": "p", "tool": "add_folder",
+                  "args": {"parent": "", "name": "X"},
+                  "batch_id": bid},
+        )
+        self.assertEqual(r.status_code, 200)
+        body = r.json()
+        self.assertEqual(body["batch_id"], bid)
+        self.assertEqual(body["tool"], "add_folder")
+
+    @mock.patch("dashboard.taxonomy.create_folder")
+    def test_409_when_mutation_conflicts(self, mock_create):
+        self._seed_yamls()
+        mock_create.side_effect = ValueError("folder already exists")
+        r = self.client.post(
+            "/api/agent/refonte/c/mutate",
+            json={"profile": "p", "tool": "add_folder",
+                  "args": {"parent": "", "name": "X"}},
+        )
+        self.assertEqual(r.status_code, 409)
+        self.assertIn("already exists", r.json()["error"])
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/auto/test_categories.py
+++ b/tests/auto/test_categories.py
@@ -1209,5 +1209,114 @@ class TestOrphanDetection(CategoriesTestBase):
         self.assertNotIn("is_orphan", e)
 
 
+# ─── Suggest target path (heuristique pour assister la correction) ──────
+
+
+class TestSuggestTargetPath(CategoriesTestBase):
+    """`suggest_target_path` propose un chemin du tree.yaml comme cible pour
+    un orphan, par normalisation des préfixes numériques + match suffixe."""
+
+    def _write_tree(self, folders: list[str]):
+        (self.profile_dir / "tree.yaml").write_text(
+            yaml.safe_dump({"folders": folders}, sort_keys=False)
+        )
+
+    def test_high_confidence_normalized_match(self):
+        """Pattern typique : préfixe '0X - ' ajouté au milieu du chemin."""
+        self._write_tree([
+            "01-SCIENCES",
+            "01-SCIENCES/03 - CHIMIE",
+            "01-SCIENCES/03 - CHIMIE/01-Chimie-Organique",
+        ])
+        r = categories.suggest_target_path(
+            self.profile_name, "01-SCIENCES/CHIMIE/01-Chimie-Organique",
+        )
+        self.assertEqual(r["suggestion"],
+                         "01-SCIENCES/03 - CHIMIE/01-Chimie-Organique")
+        self.assertEqual(r["confidence"], "high")
+        self.assertEqual(r["alternatives"], [])
+
+    def test_medium_confidence_suffix_match(self):
+        """Suffixe 2-segments unique sans match normalisé exact."""
+        self._write_tree([
+            "07-LOISIRS",
+            "07-LOISIRS/01 - DESSIN",
+            "07-LOISIRS/01 - DESSIN/Paysage",
+        ])
+        r = categories.suggest_target_path(
+            self.profile_name, "08-LOISIRS/DESSIN/Paysage",
+        )
+        # Le préfixe 08- ≠ 07-, donc le match normalisé exact échoue, mais
+        # le suffixe "dessin/paysage" matche un seul tree path.
+        self.assertEqual(r["suggestion"], "07-LOISIRS/01 - DESSIN/Paysage")
+        self.assertIn(r["confidence"], ("high", "medium"))
+
+    def test_no_match_returns_none(self):
+        self._write_tree(["01-SCIENCES", "02-INFORMATIQUE"])
+        r = categories.suggest_target_path(
+            self.profile_name, "99-RELIGIONS/CHRISTIANISME",
+        )
+        self.assertIsNone(r["suggestion"])
+        self.assertEqual(r["confidence"], "none")
+
+    def test_ambiguous_returns_alternatives(self):
+        """Deux folders dans le tree ont le même chemin normalisé."""
+        self._write_tree([
+            "A",
+            "A/01 - X",
+            "B",
+            "B/02 - X",
+        ])
+        # Orphan "A/X" — normalise en "a/x", deux candidats matchent par suffixe
+        r = categories.suggest_target_path(self.profile_name, "Z/X")
+        # Le match exact normalisé n'existe pas pour "z/x" (Z absent), mais
+        # via suffixe ou nom de base, on a 2 candidats : A/01 - X et B/02 - X.
+        self.assertIsNotNone(r["suggestion"])
+        self.assertEqual(r["confidence"], "low")
+        self.assertGreaterEqual(len(r["alternatives"]), 1)
+
+    def test_chemin_already_exists_in_tree_high_confidence(self):
+        """Cas dégénéré : le chemin n'est pas orphan, on retourne tel quel."""
+        self._write_tree(["X/Y", "Z"])
+        r = categories.suggest_target_path(self.profile_name, "X/Y")
+        self.assertEqual(r["suggestion"], "X/Y")
+        self.assertEqual(r["confidence"], "high")
+
+    def test_no_tree_yaml_returns_none(self):
+        # Pas de tree.yaml créé du tout
+        r = categories.suggest_target_path(self.profile_name, "anything")
+        self.assertIsNone(r["suggestion"])
+        self.assertEqual(r["confidence"], "none")
+
+    def test_empty_chemin_returns_none(self):
+        self._write_tree(["X"])
+        r = categories.suggest_target_path(self.profile_name, "")
+        self.assertIsNone(r["suggestion"])
+
+
+class TestSuggestPathEndpoint(CategoriesTestBase):
+
+    def test_endpoint_returns_suggestion(self):
+        from fastapi.testclient import TestClient
+
+        from dashboard.app import app
+        (self.profile_dir / "tree.yaml").write_text(
+            yaml.safe_dump({"folders": [
+                "01-SCIENCES",
+                "01-SCIENCES/03 - CHIMIE",
+            ]}, sort_keys=False)
+        )
+        with TestClient(app) as client:
+            r = client.get(
+                "/api/categories/suggest-path",
+                params={"profile": self.profile_name,
+                        "chemin": "01-SCIENCES/CHIMIE"},
+            )
+        self.assertEqual(r.status_code, 200)
+        body = r.json()
+        self.assertEqual(body["suggestion"], "01-SCIENCES/03 - CHIMIE")
+        self.assertEqual(body["confidence"], "high")
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/auto/test_categories.py
+++ b/tests/auto/test_categories.py
@@ -1039,5 +1039,175 @@ class TestEntryFilesEndpoint(WriteTestBase):
         # limit clamped at 500 server-side
 
 
+# ─── Cascade rename (taxonomy → categories) ──────────────────────────────
+
+
+class TestCascadeRenameTarget(CategoriesTestBase):
+    """`cascade_rename_target` doit rewriter les `chemin:` qui matchent
+    l'ancien chemin (en exact ou en préfixe), backup la version pré-rename,
+    invalider le cache, et fusionner intelligemment les collisions."""
+
+    def _write_tree(self, folders: list[str]):
+        (self.profile_dir / "tree.yaml").write_text(
+            yaml.safe_dump({"folders": folders}, sort_keys=False)
+        )
+
+    def test_exact_path_renamed(self):
+        self._write_yaml({
+            "loisirs": [
+                {"chemin": "08-LOISIRS/JEUX-VIDEO",
+                 "priorite": 2, "mots_cles": ["gaming", "console"]},
+            ],
+        })
+        r = categories.cascade_rename_target(
+            self.profile_name,
+            "08-LOISIRS/JEUX-VIDEO",
+            "08-LOISIRS/06 - JEUX-VIDEO",
+        )
+        self.assertEqual(r["n_entries_updated"], 1)
+        self.assertEqual(r["n_merged"], 0)
+        self.assertIsNotNone(r["backup"])
+        # Snapshot reflète le nouveau chemin
+        snap = categories.build_snapshot(self.profile_name, force_reload=True)
+        chemins = [e["chemin"] for g in snap["groups"] for e in g["entries"]]
+        self.assertIn("08-LOISIRS/06 - JEUX-VIDEO", chemins)
+        self.assertNotIn("08-LOISIRS/JEUX-VIDEO", chemins)
+
+    def test_prefix_path_renamed_cascades_children(self):
+        """rename `08-LOISIRS` → `LOISIRS-NEW` doit aussi remapper
+        `08-LOISIRS/JEUX-VIDEO` vers `LOISIRS-NEW/JEUX-VIDEO`."""
+        self._write_yaml({
+            "loisirs": [
+                {"chemin": "08-LOISIRS/JEUX-VIDEO", "priorite": 2, "mots_cles": []},
+                {"chemin": "08-LOISIRS/CUISINE",    "priorite": 5, "mots_cles": []},
+                {"chemin": "01-AUTRE",              "priorite": 5, "mots_cles": []},
+            ],
+        })
+        r = categories.cascade_rename_target(
+            self.profile_name, "08-LOISIRS", "LOISIRS-NEW",
+        )
+        self.assertEqual(r["n_entries_updated"], 2)
+        snap = categories.build_snapshot(self.profile_name, force_reload=True)
+        chemins = [e["chemin"] for g in snap["groups"] for e in g["entries"]]
+        self.assertIn("LOISIRS-NEW/JEUX-VIDEO", chemins)
+        self.assertIn("LOISIRS-NEW/CUISINE", chemins)
+        self.assertIn("01-AUTRE", chemins)  # intouché
+
+    def test_no_match_no_backup_no_op(self):
+        self._write_yaml({
+            "informatique": [
+                {"chemin": "02-INFO/AI", "priorite": 2, "mots_cles": ["ai"]},
+            ],
+        })
+        r = categories.cascade_rename_target(
+            self.profile_name, "08-LOISIRS", "LOISIRS-NEW",
+        )
+        self.assertEqual(r["n_entries_updated"], 0)
+        self.assertIsNone(r["backup"])
+
+    def test_missing_categories_yaml_returns_no_op(self):
+        r = categories.cascade_rename_target(
+            self.profile_name, "any", "thing",
+        )
+        self.assertEqual(r["n_entries_updated"], 0)
+        self.assertIn("skipped", r)
+
+    def test_same_old_new_returns_no_op(self):
+        self._write_yaml({"g": [{"chemin": "X", "priorite": 1, "mots_cles": []}]})
+        r = categories.cascade_rename_target(self.profile_name, "X", "X")
+        self.assertEqual(r["n_entries_updated"], 0)
+        self.assertIsNone(r["backup"])
+
+    def test_collision_merges_keywords_and_takes_min_priority(self):
+        """User avait déjà créé manuellement une entry au futur chemin.
+        Lors du rename, les deux entries collident → on fusionne mots_cles
+        (dedup case-insensitive) + on garde la priorite minimale."""
+        self._write_yaml({
+            "loisirs": [
+                {"chemin": "JV-OLD",
+                 "priorite": 7, "mots_cles": ["gaming", "console"]},
+                {"chemin": "JV-NEW",
+                 "priorite": 3, "mots_cles": ["Gaming", "jeu video"]},
+            ],
+        })
+        r = categories.cascade_rename_target(
+            self.profile_name, "JV-OLD", "JV-NEW",
+        )
+        self.assertEqual(r["n_entries_updated"], 1)
+        self.assertEqual(r["n_merged"], 1)
+        snap = categories.build_snapshot(self.profile_name, force_reload=True)
+        loisirs = next(g for g in snap["groups"] if g["group"] == "loisirs")
+        self.assertEqual(len(loisirs["entries"]), 1)
+        entry = loisirs["entries"][0]
+        self.assertEqual(entry["chemin"], "JV-NEW")
+        self.assertEqual(entry["priorite"], 3)  # min(7, 3)
+        # Dedup case-insensitive : "gaming" et "Gaming" → 1 seul
+        mots_lower = sorted(m.lower() for m in entry["mots_cles"])
+        self.assertEqual(mots_lower, ["console", "gaming", "jeu video"])
+
+    def test_collision_with_priority_zero_takes_other(self):
+        """priorite=0 dans le YAML = absente. Quand on fusionne, on prend
+        l'autre valeur si l'une est 0."""
+        self._write_yaml({
+            "g": [
+                {"chemin": "OLD", "priorite": 0, "mots_cles": ["a"]},
+                {"chemin": "NEW", "priorite": 5, "mots_cles": ["b"]},
+            ],
+        })
+        r = categories.cascade_rename_target(self.profile_name, "OLD", "NEW")
+        self.assertEqual(r["n_merged"], 1)
+        snap = categories.build_snapshot(self.profile_name, force_reload=True)
+        e = snap["groups"][0]["entries"][0]
+        self.assertEqual(e["priorite"], 5)
+
+
+# ─── Orphan detection in snapshot ────────────────────────────────────────
+
+
+class TestOrphanDetection(CategoriesTestBase):
+
+    def _write_tree(self, folders: list[str]):
+        (self.profile_dir / "tree.yaml").write_text(
+            yaml.safe_dump({"folders": folders}, sort_keys=False)
+        )
+
+    def test_is_orphan_when_chemin_absent_from_tree(self):
+        self._write_tree(["02-INFO", "02-INFO/AI"])
+        self._write_yaml({
+            "informatique": [
+                {"chemin": "02-INFO/AI", "priorite": 2, "mots_cles": ["ai"]},
+                {"chemin": "02-INFO/REMOVED-FOLDER",
+                 "priorite": 5, "mots_cles": ["x"]},
+            ],
+        })
+        r = categories.build_snapshot(self.profile_name, force_reload=True)
+        entries = {e["chemin"]: e for g in r["groups"] for e in g["entries"]}
+        self.assertFalse(entries["02-INFO/AI"]["is_orphan"])
+        self.assertTrue(entries["02-INFO/REMOVED-FOLDER"]["is_orphan"])
+
+    def test_stats_counts_n_orphans(self):
+        self._write_tree(["A"])
+        self._write_yaml({
+            "g": [
+                {"chemin": "A",   "priorite": 1, "mots_cles": []},
+                {"chemin": "B",   "priorite": 2, "mots_cles": []},
+                {"chemin": "C",   "priorite": 3, "mots_cles": []},
+            ],
+        })
+        r = categories.build_snapshot(self.profile_name, force_reload=True)
+        self.assertEqual(r["stats"]["n_orphans"], 2)
+        self.assertEqual(r["groups"][0]["n_orphans"], 2)
+
+    def test_no_tree_yaml_falls_back_without_orphan_flag(self):
+        """Profil sans tree.yaml → on ne crash pas, on n'annote pas."""
+        self._write_yaml({
+            "g": [{"chemin": "X", "priorite": 1, "mots_cles": []}],
+        })
+        r = categories.build_snapshot(self.profile_name, force_reload=True)
+        e = r["groups"][0]["entries"][0]
+        # is_orphan absent quand pas de tree_folders disponible
+        self.assertNotIn("is_orphan", e)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/auto/test_taxonomy.py
+++ b/tests/auto/test_taxonomy.py
@@ -963,6 +963,54 @@ class TestRenameFolder(TaxonomyTestBase):
         self.assertIn("01-SCIENCES/PHYSIQUE", tree["folders"])
 
 
+class TestRenameFolderCascadeCategories(TaxonomyTestBase):
+    """Intégration : rename d'un folder doit cascader sur categories.yaml
+    via cascade_rename_target. Sans ce relayage, les `chemin:` resteraient
+    figés sur l'ancien path → entries orphelines."""
+
+    def test_rename_cascades_to_categories_yaml(self):
+        from dashboard import categories as _cat
+        (self.profile_dir / "categories.yaml").write_text(
+            yaml.safe_dump({
+                "loisirs": [
+                    {"chemin": "01-SCIENCES/PHYSIQUE",
+                     "priorite": 2, "mots_cles": ["physics"]},
+                    {"chemin": "01-SCIENCES/PHYSIQUE/QUANTUM",
+                     "priorite": 5, "mots_cles": ["quantum"]},
+                    {"chemin": "01-SCIENCES/MATHEMATIQUES",
+                     "priorite": 5, "mots_cles": ["math"]},
+                ],
+            }, sort_keys=False)
+        )
+        _cat.reset_cache()
+
+        r = taxonomy.rename_folder(
+            self.profile_name, "01-SCIENCES/PHYSIQUE", "PHYS",
+        )
+        # Réponse remonte le compteur cascade
+        self.assertEqual(r["n_categories_updated"], 2)
+        self.assertEqual(r.get("n_categories_merged", 0), 0)
+        self.assertIsNotNone(r.get("categories_backup"))
+
+        # Le YAML reflète bien le nouveau chemin
+        cats = yaml.safe_load((self.profile_dir / "categories.yaml").read_text())
+        chemins = [e["chemin"] for e in cats["loisirs"]]
+        self.assertIn("01-SCIENCES/PHYS", chemins)
+        self.assertIn("01-SCIENCES/PHYS/QUANTUM", chemins)
+        self.assertIn("01-SCIENCES/MATHEMATIQUES", chemins)  # intouché
+        self.assertNotIn("01-SCIENCES/PHYSIQUE", chemins)
+
+    def test_rename_without_categories_yaml_is_noop_safe(self):
+        """Profil sans categories.yaml ne doit pas crasher le rename."""
+        # Pas de categories.yaml créé. Rename normal doit fonctionner.
+        r = taxonomy.rename_folder(
+            self.profile_name, "01-SCIENCES/PHYSIQUE", "PHYS",
+        )
+        self.assertTrue(r["ok"])
+        self.assertEqual(r["n_categories_updated"], 0)
+        self.assertIsNone(r.get("categories_backup"))
+
+
 class TestRenameFolderEndpoint(TaxonomyTestBase):
 
     def setUp(self):

--- a/tests/auto/test_taxonomy.py
+++ b/tests/auto/test_taxonomy.py
@@ -2584,5 +2584,206 @@ class TestFileOpsEndpoints(TaxonomyTestBase):
         self.assertEqual(body["dest_folder"], "02-INFORMATIQUE")
 
 
+# ─── 9. Routage — breakdown stable / incoming / outgoing ─────────────────
+
+
+class TestFolderThemeBreakdown(TaxonomyTestBase):
+    """`compute_folder_theme_breakdown` doit classer correctement :
+
+      - stable  : thème mappé ICI + détecté sur fichiers ICI
+      - incoming: thème mappé ICI mais ABSENT des fichiers actuels
+      - outgoing: thème DÉTECTÉ ICI mais mappé AILLEURS (ou orphelin)
+    """
+
+    def _setup_fixture(self):
+        """Construit un set où chaque cas est représenté."""
+        from lib.thumbnail import compute_content_key
+
+        # Réinitialise la lib avec des fichiers de contenu DISTINCT (head bytes
+        # différents) pour que les content_keys soient uniques.
+        shutil.rmtree(self.target, ignore_errors=True)
+        self.target.mkdir(parents=True)
+        (self.target / "01-SCIENCES" / "PHYSIQUE").mkdir(parents=True)
+        (self.target / "01-SCIENCES" / "MATHEMATIQUES").mkdir(parents=True)
+        (self.target / "02-INFORMATIQUE").mkdir(parents=True)
+
+        # Fichier 1: dans PHYSIQUE, thème "physics" mappé vers PHYSIQUE → stable
+        f1 = self.target / "01-SCIENCES" / "PHYSIQUE" / "mech.pdf"
+        f1.write_bytes(b"%PDF-1.4 file-1-unique-content")
+        # Fichier 2: dans PHYSIQUE, thème "machine learning" mappé AILLEURS
+        f2 = self.target / "01-SCIENCES" / "PHYSIQUE" / "wrong.pdf"
+        f2.write_bytes(b"%PDF-1.4 file-2-unique-content")
+        # Fichier 3: dans PHYSIQUE, thème "unknown-theme" non mappé → outgoing orphan
+        f3 = self.target / "01-SCIENCES" / "PHYSIQUE" / "orphan.pdf"
+        f3.write_bytes(b"%PDF-1.4 file-3-unique-content")
+        # Fichier 4: dans MATHS, théoriquement hors panneau PHYSIQUE
+        f4 = self.target / "01-SCIENCES" / "MATHEMATIQUES" / "alg.pdf"
+        f4.write_bytes(b"%PDF-1.4 file-4-unique-content")
+
+        k1 = compute_content_key(f1)
+        k2 = compute_content_key(f2)
+        k3 = compute_content_key(f3)
+        k4 = compute_content_key(f4)
+
+        # Mapping : physics → PHYSIQUE, quantum mechanics → PHYSIQUE
+        # (quantum mechanics est dans le mapping mais ABSENT des fichiers → incoming)
+        # machine learning → 02-INFORMATIQUE
+        # algebra → MATHS (pour f4)
+        mapping = {
+            "physics": "01-SCIENCES/PHYSIQUE",
+            "quantum mechanics": "01-SCIENCES/PHYSIQUE",
+            "machine learning": "02-INFORMATIQUE",
+            "algebra": "01-SCIENCES/MATHEMATIQUES",
+        }
+        (self.profile_dir / "theme_mapping.yaml").write_text(
+            yaml.safe_dump(mapping, sort_keys=False)
+        )
+
+        # vision_cache : confiance > 0.5 pour tous (sinon filtré par _MIN_CONFIDENCE)
+        vc = {
+            k1: {"result": {"themes": [
+                {"theme": "Physics", "confidence": 0.9},
+            ]}},
+            k2: {"result": {"themes": [
+                {"theme": "machine learning", "confidence": 0.85},
+            ]}},
+            k3: {"result": {"themes": [
+                {"theme": "unknown-niche-topic", "confidence": 0.8},
+            ]}},
+            k4: {"result": {"themes": [
+                {"theme": "algebra", "confidence": 0.9},
+                # quantum mechanics aussi sur f4 → boost le count_expected
+                {"theme": "quantum mechanics", "confidence": 0.95},
+            ]}},
+        }
+        (self.profile_dir / ".cache" / "vision_cache.json").write_text(
+            json.dumps(vc)
+        )
+        taxonomy.reset_cache()
+
+    def test_stable_theme_classified_correctly(self):
+        self._setup_fixture()
+        out = taxonomy.compute_folder_theme_breakdown(
+            self.profile_name, "01-SCIENCES/PHYSIQUE",
+        )
+        themes_stable = {x["theme"].lower() for x in out["stable"]}
+        self.assertIn("physics", themes_stable)
+
+    def test_incoming_theme_when_mapped_but_absent(self):
+        """quantum mechanics est mappé vers PHYSIQUE mais aucun fichier IN
+        PHYSIQUE ne le porte. Doit apparaître en incoming."""
+        self._setup_fixture()
+        out = taxonomy.compute_folder_theme_breakdown(
+            self.profile_name, "01-SCIENCES/PHYSIQUE",
+        )
+        themes_incoming = {x["theme"].lower() for x in out["incoming"]}
+        self.assertIn("quantum mechanics", themes_incoming)
+        qm = next(x for x in out["incoming"] if x["theme"].lower() == "quantum mechanics")
+        # quantum mechanics est détecté sur f4 (mathematiques) → count_expected ≥ 1
+        self.assertGreaterEqual(qm["count_expected"], 1)
+
+    def test_outgoing_when_mapped_elsewhere(self):
+        """machine learning détecté dans PHYSIQUE mais mappé vers INFO."""
+        self._setup_fixture()
+        out = taxonomy.compute_folder_theme_breakdown(
+            self.profile_name, "01-SCIENCES/PHYSIQUE",
+        )
+        outgoing = {x["theme"].lower(): x for x in out["outgoing"]}
+        self.assertIn("machine learning", outgoing)
+        self.assertEqual(
+            outgoing["machine learning"]["target"], "02-INFORMATIQUE",
+        )
+        self.assertEqual(outgoing["machine learning"]["reason"], "mapped_elsewhere")
+
+    def test_outgoing_orphan_when_not_mapped(self):
+        self._setup_fixture()
+        out = taxonomy.compute_folder_theme_breakdown(
+            self.profile_name, "01-SCIENCES/PHYSIQUE",
+        )
+        outgoing = {x["theme"].lower(): x for x in out["outgoing"]}
+        self.assertIn("unknown-niche-topic", outgoing)
+        self.assertIsNone(outgoing["unknown-niche-topic"]["target"])
+        self.assertEqual(outgoing["unknown-niche-topic"]["reason"], "orphan")
+
+    def test_summary_counts(self):
+        self._setup_fixture()
+        out = taxonomy.compute_folder_theme_breakdown(
+            self.profile_name, "01-SCIENCES/PHYSIQUE",
+        )
+        s = out["summary"]
+        self.assertEqual(s["path"], "01-SCIENCES/PHYSIQUE")
+        self.assertEqual(s["n_stable"], len(out["stable"]))
+        self.assertEqual(s["n_incoming"], len(out["incoming"]))
+        self.assertEqual(s["n_outgoing"], len(out["outgoing"]))
+        # n_mapped_rules = physics + quantum mechanics = 2
+        self.assertEqual(s["n_mapped_rules"], 2)
+
+    def test_empty_folder_returns_empty_lists(self):
+        """02-INFORMATIQUE est vide et a aucun mapping → tout vide."""
+        self._setup_fixture()
+        out = taxonomy.compute_folder_theme_breakdown(
+            self.profile_name, "02-INFORMATIQUE",
+        )
+        self.assertEqual(out["stable"], [])
+        # machine learning est mappé vers INFO mais le fichier qui le porte
+        # est dans PHYSIQUE → incoming (le folder INFO le verra arriver).
+        themes_incoming = {x["theme"].lower() for x in out["incoming"]}
+        self.assertIn("machine learning", themes_incoming)
+        self.assertEqual(out["outgoing"], [])
+
+    def test_nonexistent_path_returns_empty(self):
+        out = taxonomy.compute_folder_theme_breakdown(
+            self.profile_name, "99-DOES-NOT-EXIST",
+        )
+        self.assertEqual(out["stable"], [])
+        self.assertEqual(out["outgoing"], [])
+
+    def test_low_confidence_themes_filtered(self):
+        """Les thèmes avec confidence < 0.5 ne doivent pas être comptés."""
+        from lib.thumbnail import compute_content_key
+
+        shutil.rmtree(self.target, ignore_errors=True)
+        self.target.mkdir(parents=True)
+        (self.target / "01-SCIENCES" / "PHYSIQUE").mkdir(parents=True)
+
+        f = self.target / "01-SCIENCES" / "PHYSIQUE" / "doc.pdf"
+        f.write_bytes(b"%PDF-1.4 low-conf-test")
+        k = compute_content_key(f)
+
+        (self.profile_dir / "theme_mapping.yaml").write_text(
+            yaml.safe_dump({"physics": "01-SCIENCES/PHYSIQUE"}, sort_keys=False)
+        )
+        (self.profile_dir / ".cache" / "vision_cache.json").write_text(
+            json.dumps({k: {"result": {"themes": [
+                {"theme": "Physics", "confidence": 0.3},  # < seuil
+            ]}}})
+        )
+        taxonomy.reset_cache()
+        out = taxonomy.compute_folder_theme_breakdown(
+            self.profile_name, "01-SCIENCES/PHYSIQUE",
+        )
+        # Pas de stable car le seul thème est en dessous du seuil.
+        self.assertEqual(out["stable"], [])
+
+
+class TestFolderThemeBreakdownEndpoint(TaxonomyTestBase):
+
+    def test_endpoint_happy(self):
+        from fastapi.testclient import TestClient
+
+        from dashboard.app import app
+        with TestClient(app) as client:
+            r = client.get(
+                "/api/taxonomy/folder/theme-breakdown",
+                params={"profile": self.profile_name, "path": "01-SCIENCES/PHYSIQUE"},
+            )
+        self.assertEqual(r.status_code, 200)
+        body = r.json()
+        self.assertIn("stable", body)
+        self.assertIn("incoming", body)
+        self.assertIn("outgoing", body)
+        self.assertIn("summary", body)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
**Status: 🚧 WIP draft** — chantier Phase C de l'agent Refonte. Ouvert tôt pour visibilité progressive.

## Plan

| Sub | Description | État |
|---|---|---|
| **C.0** | Backup + journal + rollback (filet de sécurité) | ✅ commit pushé |
| **C.1** | Tools mutables (add_folder, merge, rename, bulk_move) | 🚧 prochain |
| **C.2** | Agent conversationnel LangGraph + streaming SSE | ⏳ |
| **C.3** | UI chat + timeline mutations + ship | ⏳ |

## Décisions de cadrage

- Sub-PRs en interne sur cette branche (commits progressifs, ouvre 1 seule PR finale)
- Modèle LLM : reste GLM-4.7 (cohérence Phase A/B)
- Cible : `default` directement, avec backup full snapshot rotation 50
- Rollback : batch ciblé uniquement (pas cascade), warning si batches plus récents
- Ordre INVERSÉ vs la spec : C.0 (backup) d'abord, AVANT C.1 (mutations) → impossible de muter sans filet

## C.0 livré

- `agents/refonte/agent_journal.py` — append-only JSONL
- `agents/refonte/agent_backup.py` — snapshot YAML + rotation
- `dashboard/agent_refonte_phase_c.py` — couche fine wrapper
- 3 endpoints : `/api/agent/refonte/c/{batches,entries,rollback}`
- +43 tests, ruff clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)