### PR TITLE
fix(overview): pie chart canvas wrapping prevents infinite page growth

### DIFF
--- a/dashboard/static/style.css
+++ b/dashboard/static/style.css
@@ -6589,6 +6589,16 @@ th {
     grid-template-columns: repeat(4, minmax(0, 1fr));
     gap: 10px;
     margin-top: 20px;
+    align-items: start; /* évite que les cartes courtes s'étirent à la
+                           hauteur de la cellule la plus haute */
+}
+/* Wrapper du pie chart — Chart.js avec maintainAspectRatio:false a
+   besoin d'une hauteur fixée sur le parent direct, sinon il essaie de
+   remplir l'infini (page qui s'étend vers le bas). */
+.dash-pie-wrap {
+    position: relative;
+    height: 200px;
+    width: 100%;
 }
 
 /* Responsive */

--- a/dashboard/templates/partials/overview_general.html
+++ b/dashboard/templates/partials/overview_general.html
@@ -61,7 +61,13 @@
   <div class="dash-card">
     <h3>💵 Coûts cumulés</h3>
     {% if g.global_cost.by_profile %}
-    <canvas id="dash-cost-pie" height="140"></canvas>
+    {# Container avec hauteur fixée — Chart.js avec maintainAspectRatio:false
+       a besoin d'un parent à hauteur définie sinon il essaie de remplir
+       l'infini et casse le layout de la grille (bug observé : page qui
+       s'étire vers le bas). Cf. https://www.chartjs.org/docs/latest/configuration/responsive.html #}
+    <div class="dash-pie-wrap">
+      <canvas id="dash-cost-pie"></canvas>
+    </div>
     <script>
       (function() {
         var ctx = document.getElementById('dash-cost-pie');


### PR DESCRIPTION
## Summary

Hotfix pour le bug visuel observé sur Overview : la page s'étendait infiniment vers le bas après le merge de PR #167.

## Root cause

Le \`<canvas id=\"dash-cost-pie\">\` Chart.js utilise \`maintainAspectRatio: false\` + \`responsive: true\`. Sans hauteur définie sur le parent direct, Chart.js entre en boucle de redimensionnement et étire la cellule du grid à l'infini.

## Fix

1. Wrap le canvas dans \`<div class=\"dash-pie-wrap\">\` avec \`height: 200px; position: relative\` (pattern officiel Chart.js)
2. Retire l'attribut \`height=\"140\"\` du canvas (géré par le wrapper)
3. Ajoute \`align-items: start\` sur \`.dash-general-grid\` pour que les cartes courtes ne s'étirent pas à la hauteur de la plus haute

## Test plan

- [x] Smoke test : page rend en 200, contient le wrapper, le canvas existe
- [ ] Visuel : vérifier dans le browser que la page ne s'étend plus vers le bas

🤖 Generated with [Claude Code](https://claude.com/claude-code)