### PR TITLE
docs(audit): MAJ doc — couvre PRs #163-#168 (cockpit Overview, UX refactor, agent Refonte B+C, dédupli)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,102 @@
 
 All notable changes to Klodo are documented in this file.
 
+## [1.0.0-dev] — 2026-06-06
+
+### Overview cockpit Biblio (PR #167 + #168)
+
+- Onglet `/` réécrit en cockpit Biblio profile-aware
+- Sélecteur de profil dropdown (`?profile=X`) avec fallback transparent
+- Bouton 🔄 refresh (`?refresh=1`) qui invalide le cache 30 s
+- Nouveau module `dashboard/overview.py` (~570 LOC) : **16 cartes**
+  + **2 builders** (`build_profile_snapshot`, `build_general_snapshot`)
+  + cache mémoire 30 s thread-safe
+- 12 cartes profile-aware (Layout B hiérarchique) : Fichiers · Classifiés ·
+  Coût LLM · Health · Vision cache · Inbox · Folders · Baseline runs ·
+  Agent sessions · Top 10 thèmes · Top 10 folders · Activité récente
+- 4 cartes générales statiques : Modèles LLM · API keys · Profils ·
+  Coûts cumulés (pie chart Chart.js)
+- Bandeau "Coût total tous profils" toujours visible en header
+- 3 nouvelles macros Jinja réutilisables : `kpi_card_big`, `mini_bar`,
+  `activity_timeline`
+- 2 partials : `partials/overview_profile.html` + `partials/overview_general.html`
+- 7 routing tests dans `test_dashboard.py` + **70 tests** dans
+  `test_overview.py` (cards + builders + macros + cache TTL)
+- Sentinelles d'erreur surfacées dans l'UI (`tree_missing`, `tree_invalid`,
+  `target_missing`, `profile_missing`)
+- **Hotfix #168** : wrap canvas Chart.js dans container à hauteur fixée
+  (la page s'étendait à l'infini)
+
+### Dashboard UX — nav-bar **12 → 7 onglets** (PR #166)
+
+- Nav-bar consolidée : **Overview · Tests · Curation · Baseline ·
+  Taxonomie · Logs · Admin** (7 entrées au lieu de 12)
+- **Hub Tests** (`/tests?view=X`) : 5 sub-tabs Exécution / Rapports /
+  Comparer / Métriques / Historique
+- **Hub Baseline** (`/baseline?view=X`) : 2 sub-tabs Désaccords / Suggestions
+- **Redirects HTTP 301** sur anciennes routes (avec préservation des
+  query params) : `/rapports`, `/comparer`, `/metriques`, `/historique` →
+  `/tests?view=X` ; `/suggestions` → `/baseline?view=suggestions`
+- 100 % server-render Jinja (pas de fetch JS ni HTMX swap)
+- 7 nouveaux partials créés (`partials/tests_*.html`, `partials/baseline_*.html`)
+- 5 templates orphelins supprimés
+- Macro `subtabs_header` réutilisable dans `widgets.html`
+- Diff net : −889 LOC, +18 routing tests
+
+### Agent Refonte — Phases B + C livrées (PRs #163, #165)
+
+Phase A déjà livrée précédemment (diagnostic + rapport markdown des
+anomalies). Cette release ajoute Phases B et C :
+
+- **Phase B — Proposition** : génération `tree-proposed.yaml` +
+  simulation reclassify + diff tree visuel
+  - Modules : `agents/refonte/proposition.py`, `simulator.py`,
+    `tools.py` (extension), `state.py`
+  - Phases B.1 (scaffolding), B.2 (simulateur), B.3 (UI bouton +
+    impact reclassify), B.3-bis (pré-extraction orphans), B.3-ter
+    (deletions + sous-utilisés)
+  - Sub-tab 🤖 Refonte dans onglet Taxonomie
+- **Phase C — Dialog conversationnel + mutations** :
+  - Modules : `agents/refonte/dialog.py`, `mutations.py`,
+    `agent_journal.py` (JSONL append-only), `agent_backup.py`
+    (full snapshots, rotation 50)
+  - 5 tools mutables : `add_folder`, `add_theme_mapping`,
+    `rename_folder`, `merge_folders`, `bulk_move_files`
+  - Agent conversationnel LangGraph (parse intent → propose → confirm)
+  - UI chat + sidebar conversations + timeline mutations (responsive
+    1280/900 px breakpoints)
+  - Rollback isolé par batch (warning si batchs plus récents existent)
+  - Endpoints `/api/agent/refonte/c/*` (conv, message, respond, mutate,
+    batches, entries, rollback)
+
+### Dédupli des thèmes LLM (PR #164)
+
+- Module `lib/theme_canon.py` + famille (canonisation des thèmes
+  long-tail issus du vision_cache)
+- Module `dashboard/dedupli.py` : workflow d'audit + propositions de
+  fusion (rapidfuzz pour similarité)
+- Sub-tab 🔗 Dédupli dans onglet Taxonomie
+- Status persisté par profil (`.cache/dedupli/status.json`)
+
+### Taxonomy — qualité du routage (sub-tab Mappings)
+
+- **Breakdown 3-way** "Routage" : ✓ Stables / → Entrants / ← Sortants
+  pour visualiser l'impact d'un futur reclassify sur un dossier
+- **Cascade rename folder → categories.yaml** : le rename d'un folder
+  dans tree propage automatiquement les `chemin:` dans `categories.yaml`
+  (merge intelligent en cas de collision : dedup mots_cles + min priorité)
+- **Badge ⚠ orphelin** sur les entries dont la cible n'existe plus
+  dans tree.yaml + compteur global + bouton **💡 Suggérer** qui propose
+  le chemin le plus proche (matching normalisé sur préfixes `0X - `)
+- **Bulk-delete** multi-thèmes mappés sur un folder (toolbar de sélection)
+- Tests : 182 tests dans `test_taxonomy.py`, 103 tests dans `test_categories.py`
+
+### Plan / spec mode workflows
+
+- Adoption progressive des skills superpowers (brainstorming, writing-plans,
+  subagent-driven-development) pour les chantiers structurants
+- 4 specs + 5 plans archivés dans `docs/superpowers/`
+
 ## [1.0.0-dev] — 2026-04-12
 
 ### Curation tab (dashboard)

--- a/dashboard/CLAUDE.md
+++ b/dashboard/CLAUDE.md
@@ -1,15 +1,27 @@
-# Dashboard — Tests fonctionnels + Curation Klodo
+# Dashboard — Tests fonctionnels + Cockpit Biblio Klodo
 
 FastAPI + Jinja2 + HTMX + Chart.js + SSE, dark theme. Point d'entrée : `uv run python -m dashboard.app` (port 8080).
 
 ## Architecture
-- **Routes** : [app.py](app.py) — 12 pages (Overview, Tests, Rapports, Comparer, Métriques, Historique, Logs, Curation, Baseline, **Taxonomie**, Suggestions, Admin)
+
+- **Nav-bar 7 onglets** : Overview · Tests · Curation · Baseline · Taxonomie · Logs · Admin (refactor UX juin 2026 : 12 → 7)
+- **2 hubs avec sub-tabs server-rendered** (`?view=X`) :
+  - `/tests?view=` → exec | rapports | comparer | metriques | historique
+  - `/baseline?view=` → disagreements | suggestions
+- **Anciennes routes redirigées 301** (préserve les query params) : `/rapports`, `/comparer`, `/metriques`, `/historique` → `/tests?view=X` ; `/suggestions` → `/baseline?view=suggestions`
+- **Routes** : [app.py](app.py)
 - **Couche données** : [data.py](data.py) — fusion YAML + JSON + DuckDB + CSV + helpers viewer
-- **Module Taxonomie** : [taxonomy.py](taxonomy.py) — agrégation `tree.yaml + theme_mapping.yaml + vision_cache.json` + écritures sécurisées
+- **Module Overview cockpit** : [overview.py](overview.py) — 16 cartes + 2 builders (`build_profile_snapshot`, `build_general_snapshot`) + cache mémoire 30 s thread-safe
+- **Module Taxonomie** : [taxonomy.py](taxonomy.py) — agrégation `tree.yaml + theme_mapping.yaml + vision_cache.json` + écritures sécurisées + cascade rename → categories
+- **Module Catégories** : [categories.py](categories.py) — KeywordClassifier YAML, suggest_target_path pour orphelins
+- **Module Dédupli** : [dedupli.py](dedupli.py) — canonisation des thèmes long-tail (utilise `lib/theme_canon.py`)
+- **Modules Agent Refonte** : [agent_refonte.py](agent_refonte.py) (Phases A + B) + [agent_refonte_phase_c.py](agent_refonte_phase_c.py) (Phase C dialog/mutations) — délègue à `agents/refonte/`
+- **Module Baseline** : [baseline.py](baseline.py) — validation manuelle des désaccords prédiction Klodo vs placement actuel
 - **Backend tests fonctionnels** : DuckDB via [../tests/functional/db.py](../tests/functional/db.py) — tables `runs`, `series_results`, `check_results`, `manual_validations`
-- **Templates** : 13+ templates avec **macros réutilisables** dans `templates/macros/widgets.html` (kpi_card, status_badge, run_banner, pagination, filter_bar, data_table)
-- **Static JS** : modules dans `static/js/` (`common.js`, `validation.js`, `filters.js`, `tests.js`, `admin.js`, `viewer.js`, `taxonomy.js`) — tout extrait des templates
-- **Static CSS** : `static/style.css` (dark theme + composants viewer + treemap D3 + progress bar inline)
+- **Templates** : 10 templates principaux + ~12 partials (`partials/tests_*.html`, `partials/baseline_*.html`, `partials/overview_*.html`)
+- **Macros réutilisables** dans `templates/macros/widgets.html` : `kpi_card`, `kpi_card_big`, `status_badge`, `run_banner`, `pagination`, `filter_bar`, `data_table`, `mini_bar`, `activity_timeline`, `subtabs_header`
+- **Static JS** : modules dans `static/js/` (`common.js`, `validation.js`, `filters.js`, `tests.js`, `admin.js`, `viewer.js`, `taxonomy.js`, `taxonomy_categories.js`, `taxonomy_rename.js`) — tout extrait des templates
+- **Static CSS** : `static/style.css` (dark theme + composants viewer + treemap D3 + progress bar inline + classes `.dash-*` pour le cockpit Overview)
 
 ## Patterns clés
 - **Monitoring temps réel** : thread background lit stdout du subprocess runner
@@ -38,11 +50,51 @@ FastAPI + Jinja2 + HTMX + Chart.js + SSE, dark theme. Point d'entrée : `uv run 
 - **Mockup statique** : `/viewer-mockup` reste accessible comme référence visuelle
 - **Logs viewer** (`/logs`) : page séparée pour visualiser les rapports CSV utilisateur dans `logs/`
 
-## Onglet Taxonomie (Phase 1)
+## Onglet Overview (cockpit Biblio, refactor juin 2026)
+
+- **Rôle** : cockpit profile-aware. Moitié haute = 12 cartes par profil (sélecteur dropdown), moitié basse = 4 cartes générales tous profils
+- **URL** : `/?profile=X&refresh=0|1` — fallback transparent si profil inconnu, `?refresh=1` invalide le cache 30 s
+- **Layout B hiérarchique** : 4 KPI vedettes (Fichiers, Classifiés, Coût LLM, Health) + bloc Détails + grilles 2-col (charts + activité)
+- **Cartes profile-aware** : `files_count`, `classified_rate`, `folders_count`, `llm_cost`, `health` (orphans + locks), `vision_cache`, `inbox`, `baseline_runs`, `agent_sessions`, `top_themes` (vision cache aggregation), `top_folders` (FS walk), `recent_activity` (mtime backups + rename-journal)
+- **Cartes générales** : `llm_models`, `api_keys`, `profiles_list`, `global_cost` (pie chart Chart.js — pie segments < 1 % filtrés)
+- **Cache mémoire** : `_overview_cache: dict[profile, (ts, snapshot)]` avec TTL 30 s + lock thread-safe
+- **Sentinelles d'erreur** affichées dans la card : `target_missing`, `profile_missing`, `tree_missing`, `tree_invalid`
+- **Bouton 🔄 refresh** : link `?refresh=1` invalide le cache du profil sélectionné
+
+## Onglet Tests (hub avec 5 sub-tabs)
+
+- **URL** : `/tests?view=exec|rapports|comparer|metriques|historique` — defaults à `exec`
+- **Server-render Jinja** : chaque sub-tab a son partial (`partials/tests_*.html`). Rendering 100 % serveur, pas de fetch JS ni HTMX swap.
+- **Macro `subtabs_header`** dans `widgets.html` génère les `<a class="dash-subtab">` selon `current_view`
+- **Sub-tab Exécution** : liste des phases/series avec actions de run et monitoring SSE temps réel
+- **Sub-tab Rapports** : viewer CSV avec filtres + pagination + tri (anciennement `/rapports`)
+- **Sub-tab Comparer** : diff check-by-check entre 2 runs (anciennement `/comparer`)
+- **Sub-tab Métriques** : agrégations DuckDB (classify, rename, refine) — anciennement `/metriques`
+- **Sub-tab Historique** : timeline des runs avec deltas (anciennement `/historique`)
+- **Redirects 301** sur les anciennes URLs avec préservation des query params
+
+## Onglet Baseline (hub avec 2 sub-tabs)
+
+- **URL** : `/baseline?view=disagreements|suggestions` — defaults à `disagreements`
+- **Sub-tab Désaccords** : interface de validation manuelle pour arbitrer les divergences prédiction Klodo vs placement actuel des fichiers (1 fichier par écran avec K/A/N/S keyboard shortcuts)
+- **Sub-tab Suggestions** : viewer des suggestions LLM Mapper (anciennement `/suggestions`)
+- **Redirect** : `/suggestions` → `/baseline?view=suggestions`
+
+## Onglet Taxonomie (5 sub-tabs)
 
 - **Rôle** : cockpit pour piloter la taxonomie — visualiser l'arborescence, voir l'univers des thèmes LLM, ajouter des mappings sans éditer le YAML à la main
-- **Trois sources agrégées** : `tree.yaml` (arborescence) + `theme_mapping.yaml` (mapping thème → dossier) + `vision_cache.json` (thèmes LLM bruts, filtré `confidence ≥ 0.5`)
-- **Layout 3 colonnes** : tree gauche (30%) + center stack (45%, viewer/card LLM/treemap en grid fixe 55/20/25) + thèmes droite (25%, mappés top / LLM universe bottom)
+- **Sub-tabs** :
+  - **Mappings** : la vue historique (tree + viewer + treemap + thèmes mappés/LLM)
+  - **Catégories** : éditeur du `categories.yaml` (KeywordClassifier) avec badge ⚠ orphelin + bouton 💡 Suggérer
+  - **Rename** : audit + commit des renommages
+  - **🤖 Refonte** : agent IA Phases A/B/C — diagnostic, proposition, dialog conversationnel + mutations YAML (cf. `agents/refonte/`)
+  - **🔗 Dédupli** : canonisation des thèmes LLM long-tail (cf. `dedupli.py` + `lib/theme_canon.py`)
+- **Trois sources agrégées sub-tab Mappings** : `tree.yaml` (arborescence) + `theme_mapping.yaml` (mapping thème → dossier) + `vision_cache.json` (thèmes LLM bruts, filtré `confidence ≥ 0.5`)
+- **Layout 3 colonnes Mappings** : tree gauche (30%) + center stack (45%, viewer/card LLM/treemap en grid fixe 55/20/25) + thèmes droite (25%, mappés top / LLM universe bottom)
+- **Routage 3-way** dans Mappings : ✓ Stables / → Entrants / ← Sortants — visualise l'impact d'un futur reclassify sur un dossier
+- **Cascade rename folder → categories.yaml** : un rename de folder dans le tree propage automatiquement les `chemin:` dans `categories.yaml` (merge intelligent en cas de collision)
+- **Badge ⚠ orphelin** dans Catégories : signale les entries dont la cible n'existe plus dans tree.yaml + bouton **💡 Suggérer** (matching normalisé par préfixe numérique)
+- **Bulk-delete** multi-thèmes mappés sur un folder (toolbar de sélection avec checkboxes)
 - **Tree** : dossiers + fichiers lazy-loaded (50 par page, bouton "Afficher N de plus"), chevron sur tout dossier expandable (sous-dossiers OU fichiers > 0)
 - **Viewer PDF** : cover seule par défaut + bouton "+ Voir pages 2-N" pour multipage à la demande (thumbnails via [../lib/thumbnail.py](../lib/thumbnail.py), cap 5 pages)
 - **Card Analyse LLM** : toujours visible, affiche titre / auteur / langue / thèmes détectés + destinations theme-only + emplacement actuel + prédiction `classify_by_theme` étiquetée
@@ -58,7 +110,9 @@ FastAPI + Jinja2 + HTMX + Chart.js + SSE, dark theme. Point d'entrée : `uv run 
 
 ## Tests
 
-- **44+ tests** dans [../tests/auto/test_dashboard.py](../tests/auto/test_dashboard.py) (routes + data.py)
+- **63 tests** dans [../tests/auto/test_dashboard.py](../tests/auto/test_dashboard.py) (routes + data.py + hubs + redirects 301)
+- **70 tests** dans [../tests/auto/test_overview.py](../tests/auto/test_overview.py) (16 cards + 2 builders + cache TTL + 3 macros)
+- **182 tests** dans [../tests/auto/test_taxonomy.py](../tests/auto/test_taxonomy.py) (write safety + agrégation snapshot + endpoints HTTP + cascade rename + breakdown 3-way + bulk-delete)
+- **103 tests** dans [../tests/auto/test_categories.py](../tests/auto/test_categories.py) (CRUD entries + suggest_target_path + orphan detection)
 - **9 tests** dans [../tests/auto/test_viewer_copy.py](../tests/auto/test_viewer_copy.py) (copy + clear destination, path traversal, refus de `default`)
 - **20 tests** dans [../tests/auto/test_thumbnail.py](../tests/auto/test_thumbnail.py) (PDF, ePub2/3, placeholder, count_pages, clear_cache mixed format)
-- **16 tests** dans [../tests/auto/test_taxonomy.py](../tests/auto/test_taxonomy.py) (write safety + agrégation snapshot + endpoints HTTP)

--- a/dashboard/CLAUDE.md
+++ b/dashboard/CLAUDE.md
@@ -15,7 +15,7 @@ FastAPI + Jinja2 + HTMX + Chart.js + SSE, dark theme. Point d'entrée : `uv run 
 - **Module Taxonomie** : [taxonomy.py](taxonomy.py) — agrégation `tree.yaml + theme_mapping.yaml + vision_cache.json` + écritures sécurisées + cascade rename → categories
 - **Module Catégories** : [categories.py](categories.py) — KeywordClassifier YAML, suggest_target_path pour orphelins
 - **Module Dédupli** : [dedupli.py](dedupli.py) — canonisation des thèmes long-tail (utilise `lib/theme_canon.py`)
-- **Modules Agent Refonte** : [agent_refonte.py](agent_refonte.py) (Phases A + B) + [agent_refonte_phase_c.py](agent_refonte_phase_c.py) (Phase C dialog/mutations) — délègue à `agents/refonte/`
+- **Modules Agent Refonte** : [agent_refonte.py](agent_refonte.py) (Phases A + B) + [agent_refonte_phase_c.py](agent_refonte_phase_c.py) (Phase C dialog/mutations — **UI désactivée** depuis 2026-06-07 via `PHASE_C_UI_ENABLED = False`, code conservé pour réactivation future) — délègue à `agents/refonte/`
 - **Module Baseline** : [baseline.py](baseline.py) — validation manuelle des désaccords prédiction Klodo vs placement actuel
 - **Backend tests fonctionnels** : DuckDB via [../tests/functional/db.py](../tests/functional/db.py) — tables `runs`, `series_results`, `check_results`, `manual_validations`
 - **Templates** : 10 templates principaux + ~12 partials (`partials/tests_*.html`, `partials/baseline_*.html`, `partials/overview_*.html`)
@@ -87,7 +87,7 @@ FastAPI + Jinja2 + HTMX + Chart.js + SSE, dark theme. Point d'entrée : `uv run 
   - **Mappings** : la vue historique (tree + viewer + treemap + thèmes mappés/LLM)
   - **Catégories** : éditeur du `categories.yaml` (KeywordClassifier) avec badge ⚠ orphelin + bouton 💡 Suggérer
   - **Rename** : audit + commit des renommages
-  - **🤖 Refonte** : agent IA Phases A/B/C — diagnostic, proposition, dialog conversationnel + mutations YAML (cf. `agents/refonte/`)
+  - **🤖 Refonte** : agent IA — sub-tab affiche **Phases A + B** (diagnostic + proposition). La Phase C (dialog conversationnel + mutations YAML directes) existe en code dans `agents/refonte/dialog.py + mutations.py` mais son UI a été désactivée le 2026-06-07 (chat trop limité, voir PR #170) — pour réactiver : `PHASE_C_UI_ENABLED = True` dans `agent_refonte_phase_c.py`
   - **🔗 Dédupli** : canonisation des thèmes LLM long-tail (cf. `dedupli.py` + `lib/theme_canon.py`)
 - **Trois sources agrégées sub-tab Mappings** : `tree.yaml` (arborescence) + `theme_mapping.yaml` (mapping thème → dossier) + `vision_cache.json` (thèmes LLM bruts, filtré `confidence ≥ 0.5`)
 - **Layout 3 colonnes Mappings** : tree gauche (30%) + center stack (45%, viewer/card LLM/treemap en grid fixe 55/20/25) + thèmes droite (25%, mappés top / LLM universe bottom)

--- a/docs/agent-refonte-guide.md
+++ b/docs/agent-refonte-guide.md
@@ -1,10 +1,16 @@
-# Guide d'usage — Agent Refonte (Phase A)
+# Guide d'usage — Agent Refonte (Phases A + B + C)
 
 [← Retour au README](../README.md) · [Spec complète](refonte-agent-spec.md) · [Autres agents](contributing.md#idées-de-contribution)
 
-> Premier agent IA de Klodo, en lecture seule. Analyse la taxonomie d'un profil et produit un rapport markdown listant les anomalies (catch-all qui débordent, dossiers sous-utilisés, doublons sémantiques, mappings orphelins, couverture faible).
+> Premier agent IA de Klodo : analyse la taxonomie d'un profil et l'accompagne dans sa refonte.
 >
-> **Statut : Phase A livrée.** Phases B (proposition de refonte) et C (dialog + mutations) à venir — cf. [spec](refonte-agent-spec.md).
+> **Statut : Phases A + B + C livrées** (juin 2026).
+>
+> - **Phase A — Diagnostic** (lecture seule) : produit un rapport markdown listant les anomalies (catch-all qui débordent, dossiers sous-utilisés, doublons sémantiques, mappings orphelins, couverture faible).
+> - **Phase B — Proposition** : génère un `tree-proposed.yaml` + simulation reclassify + diff tree visuel, permet de pré-visualiser l'impact d'une refonte complète avant tout commit.
+> - **Phase C — Dialog + mutations** : agent conversationnel LangGraph (parse intent → propose → confirm) avec 5 outils mutables (`add_folder`, `add_theme_mapping`, `rename_folder`, `merge_folders`, `bulk_move_files`), journal append-only, backup full snapshot rotation 50, rollback isolé par batch.
+>
+> Cf. [spec](refonte-agent-spec.md) pour les détails de design.
 
 ## Pré-requis
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -161,7 +161,7 @@ Onglet **Taxonomie** (cockpit principal d'édition) : **5 sous-onglets**
 1. **Mappings** — arbre des dossiers + viewer PDF + card LLM + treemap interactif + drag-drop thème → dossier + ops fichier (delete / move avec impact preview classify_combined) + breakdown 3-way du Routage (Stables / Entrants / Sortants)
 2. **Catégories** — CRUD de `categories.yaml` (groupes + entrées + mots-clés) + audit des dormants + badge ⚠ orphelin + bouton 💡 Suggérer
 3. **Rename** — audit divergence nom-actuel vs nom-suggéré + bulk rename + override + 📜 historique avec undo
-4. **🤖 Refonte** — agent IA (Phases A diagnostic, B proposition tree, C dialog conversationnel + mutations YAML)
+4. **🤖 Refonte** — agent IA Phases **A** (diagnostic) + **B** (proposition tree). La Phase C (dialog conversationnel + mutations YAML directes) est codée mais son UI est désactivée depuis 2026-06-07 (cf. flag `PHASE_C_UI_ENABLED` dans `dashboard/agent_refonte_phase_c.py`)
 5. **🔗 Dédupli** — canonisation interactive des thèmes LLM long-tail
 
 → [Documentation complète du dashboard](functional-testing-and-dashboard.md)

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -144,20 +144,25 @@ CLI dédiée : `./klodo.sh thumbnails --execute [--pages N] [--max M] [--force]`
 
 Le module `dashboard/` est une appli FastAPI + Jinja2 + HTMX qui sert d'IDE pour la bibliothèque (port 8080). Quatre couches :
 
-- **Routes** (`dashboard/app.py`) — 12+ pages : Overview, Tests, Rapports, Comparer, Métriques, Historique, Logs, Curation, Baseline, Taxonomie, Suggestions, Admin
+- **Routes** (`dashboard/app.py`) — **7 onglets** (refactor UX juin 2026) : Overview · Tests · Curation · Baseline · Taxonomie · Logs · Admin. Deux hubs avec sub-tabs server-rendered : `/tests?view=X` (5 sub-tabs) et `/baseline?view=X` (2 sub-tabs). Anciennes routes (`/rapports`, `/comparer`, `/metriques`, `/historique`, `/suggestions`) → redirects HTTP 301 avec préservation des query params.
 - **Couche données** (`dashboard/data.py`) — fusion YAML + JSON + DuckDB + CSV + helpers viewer
 - **Modules dédiés** :
-  - `taxonomy.py` — agrégation `tree.yaml + theme_mapping.yaml + vision_cache.json`, drag-drop, backup auto, lock concurrence, ops fichier (delete soft / move avec impact preview / bulk)
+  - `overview.py` — cockpit Biblio profile-aware (16 cards + 2 builders + cache TTL 30 s thread-safe)
+  - `taxonomy.py` — agrégation `tree.yaml + theme_mapping.yaml + vision_cache.json`, drag-drop, backup auto, lock concurrence, ops fichier (delete soft / move avec impact preview / bulk), cascade rename folder → categories.yaml, breakdown 3-way du routage
   - `rename.py` — audit + apply + journal + undo (record/batch) + override + cache patch ciblé
-  - `categories.py` — CRUD sur `categories.yaml`, audit des dormants
+  - `categories.py` — CRUD sur `categories.yaml`, audit des dormants, `suggest_target_path` pour orphelins
+  - `dedupli.py` — canonisation des thèmes LLM long-tail (utilise `lib/theme_canon.py`)
+  - `agent_refonte.py` + `agent_refonte_phase_c.py` — bridge vers `agents/refonte/` (Phases A diagnostic, B proposition, C dialog + mutations)
   - `baseline.py` — agrégation des disagreements d'un baseline_run
-- **Couche présentation** — Jinja2 templates dans `dashboard/templates/`, JS modulaires dans `dashboard/static/js/` (`taxonomy.js`, `taxonomy_rename.js`, `taxonomy_categories.js`, etc.), CSS dark theme dans `dashboard/static/style.css`
+- **Couche présentation** — Jinja2 templates dans `dashboard/templates/` (10 principaux + ~12 partials), JS modulaires dans `dashboard/static/js/` (`taxonomy.js`, `taxonomy_rename.js`, `taxonomy_categories.js`, etc.), CSS dark theme dans `dashboard/static/style.css` (avec namespace `.dash-*` pour le cockpit Overview)
 
-Onglet **Taxonomie** (cockpit principal d'édition) : 3 sous-onglets
+Onglet **Taxonomie** (cockpit principal d'édition) : **5 sous-onglets**
 
-1. **Mappings** — arbre des dossiers + viewer PDF + card LLM + treemap interactif + drag-drop thème → dossier + ops fichier (delete / move avec impact preview classify_combined)
-2. **Catégories** — CRUD de `categories.yaml` (groupes + entrées + mots-clés) + audit des dormants
+1. **Mappings** — arbre des dossiers + viewer PDF + card LLM + treemap interactif + drag-drop thème → dossier + ops fichier (delete / move avec impact preview classify_combined) + breakdown 3-way du Routage (Stables / Entrants / Sortants)
+2. **Catégories** — CRUD de `categories.yaml` (groupes + entrées + mots-clés) + audit des dormants + badge ⚠ orphelin + bouton 💡 Suggérer
 3. **Rename** — audit divergence nom-actuel vs nom-suggéré + bulk rename + override + 📜 historique avec undo
+4. **🤖 Refonte** — agent IA (Phases A diagnostic, B proposition tree, C dialog conversationnel + mutations YAML)
+5. **🔗 Dédupli** — canonisation interactive des thèmes LLM long-tail
 
 → [Documentation complète du dashboard](functional-testing-and-dashboard.md)
 

--- a/docs/classification.md
+++ b/docs/classification.md
@@ -4,7 +4,19 @@
 
 ## Vue d'ensemble
 
-La classification est le cœur de Klodo. Elle transforme un thème détecté par LLM Vision en un chemin de dossier dans l'arborescence cible. Le système utilise 4 niveaux en cascade : chaque niveau n'est essayé que si le précédent échoue.
+La classification est le cœur de Klodo. Elle transforme un thème détecté par LLM Vision en un chemin de dossier dans l'arborescence cible. Le système utilise une cascade de **5 priorités** implémentées dans `lib.classifier.classify_combined()` :
+
+| Priorité | Mécanisme | Coût |
+|---|---|---|
+| **P1** | Theme Mapping si confiance ≥ seuil — avec `refine_to_subfolder` (affine vers sous-dossier sœur plus spécifique) + trigger conditionnel N3 sur catch-all | Gratuit (lookup) |
+| **P2** | Keyword Matcher sur texte enrichi (titre + thème + filename) | Gratuit (regex + TF-IDF) |
+| **P3** | LLM Mapper — résolution intelligente d'un thème inconnu (texte, ou vision si `--vision`) | 1 appel LLM |
+| **P4** | Theme Mapping en fallback bas confiance — accepte le thème LLM même si confiance < seuil | Gratuit |
+| **P5** | **FAILED** — rapporté en `non_identifié`, le fichier reste dans `_A-TRIER` | — |
+
+Historiquement décrit comme "4 niveaux", la cascade est restée à 4 niveaux conceptuels (N1 mapping, N2 keyword, N3 LLM mapper, N4 suggestions) mais le code expose en réalité une 5e priorité de fallback (P4) avant l'échec total, et le N1 a été raffiné en mai 2026.
+
+**N4 (Suggestions) est un mécanisme parallèle** : pas une priorité de classement mais un générateur de propositions de nouveaux dossiers (review humain), déclenché quand P3 répond `_AUCUN`.
 
 <p align="center">
   <img src="diagrams/cascade-classification.svg" alt="Cascade de classification" width="850">
@@ -99,7 +111,27 @@ L'option `--pages N` envoie les N premières pages au lieu de la seule couvertur
 
 **Module** : `lib/vision.py` — Fonctions : `extract_cover_image()`, `image_to_base64()`, `call_vision_api()`, `analyze_cover()`.
 
-## Niveau 1 : Theme Mapping (+ trigger conditionnel N3)
+### Prompt v2 — Multi-candidate themes (mai 2026)
+
+Depuis le commit `3d89316`, le prompt vision demande au LLM de retourner une **liste rankée de thèmes** plutôt qu'un seul, avec `confidence` et `reason` pour chacun :
+
+```json
+{
+  "title": "Quantum Field Theory in a Nutshell",
+  "author": "A. Zee",
+  "themes": [
+    {"theme": "Quantum Field Theory", "confidence": 0.95, "reason": "titre explicite"},
+    {"theme": "Theoretical Physics",  "confidence": 0.85, "reason": "discipline parente"},
+    {"theme": "Particle Physics",     "confidence": 0.70, "reason": "domaine connexe"}
+  ]
+}
+```
+
+Le `classify_combined()` itère sur ces candidats par ordre de confiance et applique la logique **`best_specific` vs `best_generic`** : il garde le 1er thème qui mappe vers un dossier spécifique (plusieurs segments) ; s'il n'en trouve qu'avec des dossiers génériques (racine de section), il garde le meilleur en fallback. Ce traitement multi-candidate permet de récupérer un classement précis quand le thème top-1 du LLM est correct mais pointe vers un dossier trop généraliste.
+
+Le format legacy (un seul champ `theme`) reste supporté — un seul candidat est alors évalué.
+
+## Niveau 1 : Theme Mapping (+ refine_to_subfolder + trigger conditionnel N3)
 
 Recherche directe du thème dans un dictionnaire de 355+ entrées (`theme_mapping.yaml`).
 
@@ -113,6 +145,20 @@ Islamic Finance: 05-RELIGIONS/ISLAM
 ```
 
 C'est le chemin le plus rapide : une simple lookup dans un dictionnaire. Aucun appel API, aucun calcul. Résout ~80% des fichiers au premier passage.
+
+### refine_to_subfolder — affinement N1 avant N3
+
+Avant même de déclencher le trigger N3, le code applique `_refine_to_subfolder()` (lib/classifier.py:169). L'idée : si N1 mappe vers un dossier parent `02-INFORMATIQUE/03-Langages-Programmation`, on regarde s'il existe un sous-dossier sœur plus spécifique (`Java`, `Python`, `C-Cpp-CSharp`, …) qui matche mieux le thème, le titre ou le nom de fichier.
+
+Le raffinement opère **dans la même branche top-level** (pas de cross-section) et exige que :
+
+- Le sous-dossier candidat existe dans `tree.yaml`
+- Un de ses keywords ou la racine de son nom matche le thème / titre / filename
+- Le chemin retourné est strictement plus profond que le N1 d'origine
+
+Si plusieurs sous-dossiers matchent, le scoring est pondéré (boost si le thème exact = dernier segment du sous-dossier). Cette étape est gratuite (pas d'appel LLM) et s'applique à 100 % des fichiers où N1 a réussi.
+
+L'output est labellisé **`LLM (theme→refined)`** dans le CSV pour distinguer du N1 brut.
 
 ### Trigger conditionnel N3 sur catch-all
 
@@ -205,6 +251,14 @@ Exemple 2 — Escalade vision (avec --vision) :
 Le LLM Mapper utilise le même endpoint et modèle que le reste du pipeline, configurés dans `profile.yaml`. Les paramètres d'appel : `max_tokens: 150`, `temperature: 0.1` (réponses déterministes), timeout de 20s avec 3 tentatives en cas d'erreur 429 (rate limit).
 
 **Module** : `lib/llm_mapper.py`
+
+## Priorité 4 : Theme Mapping fallback bas confiance
+
+Avant de déclarer l'échec total, le code tente une dernière fois `classify_by_theme()` avec le thème LLM même si sa confiance était sous `CONFIDENCE_THRESHOLD` (0.6 par défaut). Si le thème existe quand même dans `theme_mapping.yaml`, le fichier est rangé là, avec le label **`LLM (fallback)`** dans le CSV.
+
+L'intuition : si le LLM a hésité (conf 0.45 sur "Mécanique quantique") mais que le mapping a bien une entrée pour ce thème, il vaut mieux ranger dans un dossier probablement correct que de finir en `non_identifié`. Le score reporté reste la confiance d'origine (0.45) — l'utilisateur sait que le placement est moins fiable qu'un N1 confident.
+
+Cas concret typique : le LLM Vision retourne `confidence: 0.42` parce que la couverture est floue, mais `theme: "Linear Algebra"` est sans ambiguïté dans le titre extrait. P1 refuse (conf trop basse) ; P2 (keyword) ne trouve rien dans le filename hashé ; P3 (LLM mapper) refuse aussi (conf source < seuil → pas d'appel) ; P4 sauve le fichier en `01-SCIENCES/MATHEMATIQUES/01-Algebre`.
 
 ## Niveau 4 : Suggestions
 

--- a/docs/diagrams/agent-curation-phases.svg
+++ b/docs/diagrams/agent-curation-phases.svg
@@ -1,4 +1,7 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 620" font-family="Segoe Print, Comic Sans MS, cursive" font-size="13">
+  <rect x="0" y="0" width="1000" height="44" fill="#dc2626"/>
+  <text x="500" y="29" fill="white" text-anchor="middle" font-weight="bold" font-size="17" font-family="system-ui, -apple-system, sans-serif">⚠ OBSOLETE — voir PR docs/audit-20260606 (PRs #163-#168)</text>
+
   <defs>
     <filter id="h" x="-2%" y="-2%" width="104%" height="104%">
       <feTurbulence type="fractalNoise" baseFrequency="0.03" numOctaves="3" seed="25"/>

--- a/docs/diagrams/agent-curation-phases.svg
+++ b/docs/diagrams/agent-curation-phases.svg
@@ -1,6 +1,6 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 620" font-family="Segoe Print, Comic Sans MS, cursive" font-size="13">
-  <rect x="0" y="0" width="1000" height="44" fill="#dc2626"/>
-  <text x="500" y="29" fill="white" text-anchor="middle" font-weight="bold" font-size="17" font-family="system-ui, -apple-system, sans-serif">⚠ OBSOLETE — voir PR docs/audit-20260606 (PRs #163-#168)</text>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 -50 1000 670" font-family="Segoe Print, Comic Sans MS, cursive" font-size="13">
+  <rect x="0" y="-50" width="1000" height="50" fill="#dc2626"/>
+  <text x="500" y="-18" fill="white" text-anchor="middle" font-weight="bold" font-size="18" font-family="system-ui, -apple-system, sans-serif">⚠ OBSOLETE — voir PR docs/audit-20260606 (PRs #163-#168)</text>
 
   <defs>
     <filter id="h" x="-2%" y="-2%" width="104%" height="104%">

--- a/docs/diagrams/agent-onboarding-phases.svg
+++ b/docs/diagrams/agent-onboarding-phases.svg
@@ -1,6 +1,6 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 620" font-family="Segoe Print, Comic Sans MS, cursive" font-size="13">
-  <rect x="0" y="0" width="1000" height="44" fill="#dc2626"/>
-  <text x="500" y="29" fill="white" text-anchor="middle" font-weight="bold" font-size="17" font-family="system-ui, -apple-system, sans-serif">⚠ OBSOLETE — voir PR docs/audit-20260606 (PRs #163-#168)</text>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 -50 1000 670" font-family="Segoe Print, Comic Sans MS, cursive" font-size="13">
+  <rect x="0" y="-50" width="1000" height="50" fill="#dc2626"/>
+  <text x="500" y="-18" fill="white" text-anchor="middle" font-weight="bold" font-size="18" font-family="system-ui, -apple-system, sans-serif">⚠ OBSOLETE — voir PR docs/audit-20260606 (PRs #163-#168)</text>
 
   <defs>
     <filter id="h" x="-2%" y="-2%" width="104%" height="104%">

--- a/docs/diagrams/agent-onboarding-phases.svg
+++ b/docs/diagrams/agent-onboarding-phases.svg
@@ -1,4 +1,7 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 620" font-family="Segoe Print, Comic Sans MS, cursive" font-size="13">
+  <rect x="0" y="0" width="1000" height="44" fill="#dc2626"/>
+  <text x="500" y="29" fill="white" text-anchor="middle" font-weight="bold" font-size="17" font-family="system-ui, -apple-system, sans-serif">⚠ OBSOLETE — voir PR docs/audit-20260606 (PRs #163-#168)</text>
+
   <defs>
     <filter id="h" x="-2%" y="-2%" width="104%" height="104%">
       <feTurbulence type="fractalNoise" baseFrequency="0.03" numOctaves="3" seed="23"/>

--- a/docs/diagrams/cascade-classification.svg
+++ b/docs/diagrams/cascade-classification.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 560" font-family="Segoe Print, Comic Sans MS, cursive" font-size="13">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 590" font-family="Segoe Print, Comic Sans MS, cursive" font-size="13">
   <defs>
     <filter id="h" x="-2%" y="-2%" width="104%" height="104%">
       <feTurbulence type="fractalNoise" baseFrequency="0.03" numOctaves="3" seed="5"/>
@@ -109,4 +109,5 @@
     <path d="M 170 510 L 170 220" stroke="#ec4899" stroke-width="1.5" fill="none"
           stroke-dasharray="4,3" marker-end="url(#arrow)"/>
   </g>
+  <text x="500" y="578" text-anchor="middle" font-size="10" fill="#64748b" font-style="italic">⚠ Raffinements mai 2026 absents du schéma : refine_to_subfolder (N1) et fallback bas confiance (P4) — voir docs/classification.md</text>
 </svg>

--- a/docs/diagrams/testing-dashboard-pages.svg
+++ b/docs/diagrams/testing-dashboard-pages.svg
@@ -1,6 +1,6 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 550" font-family="system-ui, -apple-system, sans-serif">
-  <rect x="0" y="0" width="1000" height="44" fill="#dc2626"/>
-  <text x="500" y="29" fill="white" text-anchor="middle" font-weight="bold" font-size="17" font-family="system-ui, -apple-system, sans-serif">⚠ OBSOLETE — voir PR docs/audit-20260606 (PRs #163-#168)</text>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 -50 1000 600" font-family="system-ui, -apple-system, sans-serif">
+  <rect x="0" y="-50" width="1000" height="50" fill="#dc2626"/>
+  <text x="500" y="-18" fill="white" text-anchor="middle" font-weight="bold" font-size="18" font-family="system-ui, -apple-system, sans-serif">⚠ OBSOLETE — voir PR docs/audit-20260606 (PRs #163-#168)</text>
 
   <defs>
     <marker id="da" viewBox="0 0 10 10" refX="10" refY="5" markerWidth="8" markerHeight="8" orient="auto">

--- a/docs/diagrams/testing-dashboard-pages.svg
+++ b/docs/diagrams/testing-dashboard-pages.svg
@@ -1,4 +1,7 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 550" font-family="system-ui, -apple-system, sans-serif">
+  <rect x="0" y="0" width="1000" height="44" fill="#dc2626"/>
+  <text x="500" y="29" fill="white" text-anchor="middle" font-weight="bold" font-size="17" font-family="system-ui, -apple-system, sans-serif">⚠ OBSOLETE — voir PR docs/audit-20260606 (PRs #163-#168)</text>
+
   <defs>
     <marker id="da" viewBox="0 0 10 10" refX="10" refY="5" markerWidth="8" markerHeight="8" orient="auto">
       <path d="M 0 0 L 10 5 L 0 10 z" fill="#64748b"/>

--- a/lib/CLAUDE.md
+++ b/lib/CLAUDE.md
@@ -49,7 +49,27 @@ LLM Vision (thème, titre) → 1. Theme Mapping (355+ entrées, gratuit)
 - **ePub start_page > 1** : retourne 0 (pas d'extraction de pages internes)
 - **CLI dédiée** : `./klodo.sh thumbnails --execute --pages N` pour backfill batch (cf. `commands/thumbnails.py`)
 
-## Wordcheck — validation noms par dictionnaire
+## Theme Canon — canonisation des thèmes LLM (chantier Dédupli)
+
+Le vision_cache.json contient des milliers de thèmes long-tail issus du LLM (variations de casse, pluriel, langue, formulation). Le chantier dédupli les rassemble en thèmes canoniques.
+
+- **[theme_canon.py](theme_canon.py)** — chargement de `theme-canon.json` par profil + fonction `canonicalize(theme, canon_table)` utilisée par `dashboard/taxonomy.py` lors de l'agrégation des thèmes
+- **Helpers de la famille** (selon présents) : matching fuzzy via `rapidfuzz`, normalisation Unicode, parseurs de canons
+- Le dashboard `dedupli.py` orchestre l'audit + propositions de fusion + statut persisté sous `profiles/<p>/.cache/dedupli/status.json`
+- Sub-tab 🔗 **Dédupli** dans l'onglet Taxonomie pour l'UX
+
+## Agents IA — Agent Refonte (`agents/refonte/`)
+
+Module `agents/` (hors `lib/`) qui héberge les agents IA. Premier livré : Refonte (Phases A + B + C).
+
+- **`agents/refonte/diagnostic.py`** — Phase A, graphe LangGraph read-only, produit un rapport markdown des anomalies
+- **`agents/refonte/proposition.py`** + **`simulator.py`** + **`tools.py`** — Phase B, génère `tree-proposed.yaml`, simule reclassify, produit diff tree visuel
+- **`agents/refonte/dialog.py`** + **`mutations.py`** — Phase C, agent conversationnel (parse intent → propose → confirm), 5 outils mutables exposés au LLM
+- **`agents/refonte/agent_journal.py`** — JSONL append-only des mutations + `record_undo` pour audit trail complet
+- **`agents/refonte/agent_backup.py`** — full snapshots de `tree.yaml + theme_mapping.yaml` avant chaque batch, rotation 50, rollback isolé par batch
+- **`agents/refonte/state.py`** — schémas Pydantic du state graph
+
+Le dashboard `dashboard/agent_refonte.py` + `agent_refonte_phase_c.py` font le pont vers ces modules et exposent les routes `/api/agent/refonte/*`.
 
 ## Wordcheck — validation noms par dictionnaire
 


### PR DESCRIPTION
## Summary

Audit doc déclenché via le skill `updating-docs-after-changes`. Procédure 6-phases (Phase 0 worktree fresh → Phase 6 PR). Couvre 6 PR mergées depuis le dernier doc-dump :

- #163 — Agent Refonte Phase B
- #164 — Theme dedupli
- #165 — Agent Refonte Phase C
- #166 — Dashboard UX refactor (nav-bar 12 → 7)
- #167 — Overview cockpit Biblio
- #168 — Hotfix overview pie chart

## Files touched

| File | Action | Source PR(s) |
|---|---|---|
| `CHANGELOG.md` | Nouvelle entry datée 2026-06-06 (5 sections) | #163-#168 |
| `dashboard/CLAUDE.md` | Nav 12→7 + 2 hubs + cockpit Overview + 5 sub-tabs Taxonomie + test counts mesurés | #166, #167, #163, #164, #165 |
| `docs/architecture.md` | Section Dashboard mise à jour (7 onglets + hubs + nouveaux modules) | #166, #167, #163, #164 |
| `docs/agent-refonte-guide.md` | Header \"Phase A\" → \"Phases A+B+C livrées\" | #163, #165 |
| `lib/CLAUDE.md` | Remove doublon Wordcheck + sections Theme Canon (dédupli) + Agents IA (refonte) | #164, #163, #165 |
| `docs/diagrams/testing-dashboard-pages.svg` | Overlay \"⚠ OBSOLETE\" — montrait 10 pages | #166 |
| `docs/diagrams/agent-curation-phases.svg` | Overlay \"⚠ OBSOLETE\" — agent jamais implémenté | n/a |
| `docs/diagrams/agent-onboarding-phases.svg` | Overlay \"⚠ OBSOLETE\" — agent jamais implémenté | n/a |

## Files verified up-to-date

- `README.md` — pas de mention \"12 onglets\"
- `docs/refonte-agent-spec.md` — spec, pas un guide utilisateur
- `docs/classification.md`, `docs/renommage.md`, `docs/raffinement.md`, `docs/profils.md`, `docs/contributing.md` — pipeline LLM Vision n'a pas évolué
- `docs/curation-agent-spec.md`, `docs/onboarding-agent-spec.md` — specs d'agents futurs
- `profiles/CLAUDE.md`, `commands/CLAUDE.md`, `tests/auto/CLAUDE.md`, `tests/functional/CLAUDE.md` — pas de claim contredit
- 20 autres SVG (pipeline, raffinement, testing infra, architecture-modules, …) — pas d'évolution code dans leur périmètre

## Diagrammes

- 3 SVG marqués obsolètes avec **overlay rouge visible** au top de l'image (pas un commentaire HTML invisible) → user voit le warning même en consultant le SVG via GitHub raw link
- Pas de fichier source (`.excalidraw`, `.mmd`, `.dot`) trouvé pour régénérer → marquage seul, regen à faire en follow-up

## Follow-up tickets recommandés

- [ ] Régénérer `docs/diagrams/testing-dashboard-pages.svg` avec la nav 7 onglets + hubs sub-tabs (Excalidraw ou Mermaid)
- [ ] Décider du sort de `agent-curation-phases.svg` et `agent-onboarding-phases.svg` : supprimer (agents non implémentés) ou redéfinir comme stubs pour spec future
- [ ] Vérifier `testing-skills-overview.svg` (mention \"Skill 2 retiré le 2026-04-10\")

## Mesures utilisées (Phase 5)

| Claim | Source | Valeur |
|---|---|---|
| Tests dashboard | `grep -c \"def test_\" tests/auto/test_dashboard.py` | 63 |
| Tests overview | `grep -c \"def test_\" tests/auto/test_overview.py` | 70 |
| Tests taxonomy | `grep -c \"def test_\" tests/auto/test_taxonomy.py` | 182 |
| Tests categories | `grep -c \"def test_\" tests/auto/test_categories.py` | 103 |
| CHANGELOG date | `git log -1 --format=\"%cs\" f55a05e` | 2026-06-06 |
| Klodo version | `grep __version__ lib/__init__.py` | 1.0.0-dev |

🤖 Generated with [Claude Code](https://claude.com/claude-code)