### PR TITLE
feat(refonte): désactiver l'UI Phase C (chat agentique) — code conservé pour réactivation future

### DIFF
--- a/dashboard/agent_refonte_phase_c.py
+++ b/dashboard/agent_refonte_phase_c.py
@@ -13,6 +13,19 @@ from typing import Any
 from agents.refonte import agent_backup, agent_journal, mutations
 from dashboard import data
 
+# ─── Feature flag UI ───────────────────────────────────────────────────
+# Si False, le sous-onglet Refonte du dashboard masque tous les éléments
+# Phase C (bouton "Nouvelle conversation", sidebar Conversations, vue
+# chat, timeline mutations). Les endpoints API et tout le code Python
+# restent intacts — seule la découverte UI est désactivée.
+#
+# Désactivé le 2026-06-07 (cf. discussion : pas assez de valeur ajoutée
+# vs UI atomique existante ; chat agentique limité à 5 tools, pas de
+# delete, 1 mutation/tour). Les actions disponibles dans le sub-tab
+# restent : "Lancer un diagnostic" (Phase A) + "Proposer une refonte"
+# (Phase B). Le code Phase C est conservé pour re-activation future.
+PHASE_C_UI_ENABLED: bool = False
+
 
 class RollbackError(Exception):
     """Tentative de rollback impossible (batch inexistant, déjà rollback, etc.)."""

--- a/dashboard/app.py
+++ b/dashboard/app.py
@@ -1612,6 +1612,7 @@ async def baseline_stats_api(profile: str, run_id: str | None = None):
 @app.get("/taxonomy")
 async def taxonomy_page(request: Request, profile: str | None = None):
     """Interactive viewer of tree.yaml + theme_mapping.yaml + LLM themes."""
+    from dashboard.agent_refonte_phase_c import PHASE_C_UI_ENABLED
     profiles = taxonomy.list_profiles()
     if not profile and profiles:
         profile = profiles[0]["name"]
@@ -1622,6 +1623,7 @@ async def taxonomy_page(request: Request, profile: str | None = None):
             "active": "taxonomy",
             "profile": profile,
             "profiles": profiles,
+            "phase_c_ui_enabled": PHASE_C_UI_ENABLED,
         },
     )
 
@@ -2369,6 +2371,7 @@ async def taxonomy_file_move_api(request: Request):
 @app.get("/agent/refonte")
 async def agent_refonte_page(request: Request, profile: str = "default"):
     """Page dédiée à l'agent Refonte (Phase A — Diagnostic)."""
+    from dashboard.agent_refonte_phase_c import PHASE_C_UI_ENABLED
     available = [
         p["name"] if isinstance(p, dict) else p
         for p in data.get_available_profiles(include_all=True)
@@ -2384,6 +2387,7 @@ async def agent_refonte_page(request: Request, profile: str = "default"):
             "profile": profile,
             "available_profiles": available,
             "runs": runs,
+            "phase_c_ui_enabled": PHASE_C_UI_ENABLED,
         },
     )
 

--- a/dashboard/templates/partials/agent_refonte_panel.html
+++ b/dashboard/templates/partials/agent_refonte_panel.html
@@ -20,11 +20,13 @@
                 <span class="tax-refonte-start-icon">🔧</span>
                 <span>Proposer une refonte</span>
             </button>
+            {% if phase_c_ui_enabled %}
             <button id="tax-refonte-new-conv" class="tax-refonte-propose-btn"
                     title="Démarrer une conversation avec l'agent (Phase C) — créer/renommer/fusionner des dossiers, ajouter des mappings">
                 <span class="tax-refonte-start-icon">🗨</span>
                 <span>Nouvelle conversation</span>
             </button>
+            {% endif %}
             <div class="tax-refonte-budget-field">
                 <label for="tax-refonte-budget" class="filter-label">Budget LLM</label>
                 <input type="number" id="tax-refonte-budget" value="5" min="1" max="20">
@@ -38,19 +40,21 @@
         </div>
     </div>
 
-    <div class="tax-refonte-c-grid">
+    <div class="tax-refonte-c-grid {% if not phase_c_ui_enabled %}tax-refonte-c-grid--no-timeline{% endif %}">
         <!-- COL 1 : runs récents + conversations -->
         <div>
             <h3 style="margin-top: 0;">Runs récents</h3>
             <div id="tax-refonte-runs">
                 <p class="muted small">Chargement…</p>
             </div>
+            {% if phase_c_ui_enabled %}
             <h3 style="margin-top: 20px; display: flex; align-items: center; gap: 6px;">
                 <span>🗨 Conversations</span>
             </h3>
             <div id="tax-refonte-convs">
                 <p class="muted small">Aucune conversation.</p>
             </div>
+            {% endif %}
         </div>
         <!-- COL 2 : rapport courant OU chat (selon sélection) -->
         <div>
@@ -75,6 +79,7 @@
                     <div id="tax-refonte-report" class="tax-refonte-md"></div>
                 </div>
             </div>
+            {% if phase_c_ui_enabled %}
             <!-- Wrapper centré pour le chat (limite max-width sur ultra-wide) -->
             <div id="tax-refonte-chat-wrapper" class="tax-refonte-chat-wrapper" style="display: none;">
             <!-- Mode CHAT (Phase C) -->
@@ -105,7 +110,9 @@
                 </div>
             </div>
             </div><!-- /chat-wrapper -->
+            {% endif %}
         </div>
+        {% if phase_c_ui_enabled %}
         <!-- COL 3 : timeline mutations (visible ≥ 1280px) -->
         <div id="tax-refonte-timeline-col" class="tax-refonte-timeline-col">
             <h3 style="margin-top: 0; display:flex; align-items:center; gap:6px;">
@@ -118,6 +125,7 @@
                 <p class="muted small">Aucune mutation.</p>
             </div>
         </div>
+        {% endif %}
     </div>
 </div>
 
@@ -563,6 +571,12 @@
     grid-template-columns: 320px minmax(0, 1fr);
     gap: 16px;
     margin-top: 16px;
+}
+/* Modifier : Phase C UI désactivée → force 2 colonnes à TOUS les
+   breakpoints (sinon la règle 1280px+ réserve 320px à droite alors
+   qu'il n'y a pas de col 3 timeline à y mettre). */
+.tax-refonte-c-grid--no-timeline {
+    grid-template-columns: 320px minmax(0, 1fr) !important;
 }
 .tax-refonte-timeline-col { display: none; }
 .tax-refonte-chat-wrapper {
@@ -1554,6 +1568,7 @@
     // ════════════════════════════════════════════════════════════════════
     //  Phase C — Agent conversationnel (C.3 UI)
     // ════════════════════════════════════════════════════════════════════
+    {% if phase_c_ui_enabled %}
 
     const newConvBtn = document.getElementById('tax-refonte-new-conv');
     const convsEl = document.getElementById('tax-refonte-convs');
@@ -1951,5 +1966,6 @@
     // Chargement initial des convs + timeline
     loadConvs();
     loadTimeline();
+    {% endif %}
 })();
 </script>

--- a/dashboard/templates/partials/agent_refonte_panel.html
+++ b/dashboard/templates/partials/agent_refonte_panel.html
@@ -572,12 +572,10 @@
     gap: 16px;
     margin-top: 16px;
 }
-/* Modifier : Phase C UI désactivée → force 2 colonnes à TOUS les
-   breakpoints (sinon la règle 1280px+ réserve 320px à droite alors
-   qu'il n'y a pas de col 3 timeline à y mettre). */
-.tax-refonte-c-grid--no-timeline {
-    grid-template-columns: 320px minmax(0, 1fr) !important;
-}
+/* Modifier : Phase C UI désactivée → la col 3 timeline n'existe pas dans
+   le DOM. Les overrides spécifiques sont injectés dans chaque media
+   query ci-dessous (≥1280px et ≥1920px) pour neutraliser le 3e track
+   sans `!important` et sans casser le breakpoint mobile (<900px → 1fr). */
 .tax-refonte-timeline-col { display: none; }
 .tax-refonte-chat-wrapper {
     max-width: 960px;       /* limite la largeur du chat même sans col 3 */
@@ -590,6 +588,10 @@
     .tax-refonte-c-grid {
         grid-template-columns: 320px minmax(0, 1fr) 320px;
     }
+    /* Phase C désactivée → garde 2 colonnes (pas de col 3 vide à droite) */
+    .tax-refonte-c-grid--no-timeline {
+        grid-template-columns: 320px minmax(0, 1fr);
+    }
     .tax-refonte-timeline-col { display: block; }
     .tax-refonte-chat-wrapper { max-width: 920px; }
 }
@@ -599,6 +601,11 @@
     .tax-refonte-c-grid {
         grid-template-columns: 340px minmax(0, 1100px) 380px;
         justify-content: center;  /* centre toute la grille horizontalement */
+    }
+    /* Phase C désactivée → 2 colonnes, garde la grille centrée */
+    .tax-refonte-c-grid--no-timeline {
+        grid-template-columns: 340px minmax(0, 1100px);
+        justify-content: center;
     }
     .tax-refonte-chat-wrapper { max-width: 1100px; }
 }


### PR DESCRIPTION
## Summary

Désactivation de l'UI Phase C (chat agentique) du sous-onglet Refonte. Le code backend (modules `agents/refonte/`, endpoints `/api/agent/refonte/c/*`, tests) est conservé intact pour une éventuelle réactivation.

## Pourquoi

Discussion approfondie sur la valeur ajoutée du chat — verdict : trop limité pour son coût visuel/cognitif :

- **5 tools seulement** (add_folder, add_theme_mapping, rename_folder, merge_folders, bulk_move_files). Pas de `delete_*`, pas de `move_folder` (changer le parent), pas de `split_folder`
- **\"Une seule mutation par message\"** rule dans le system prompt → impossible de planifier multi-étapes
- **Pas de tools de lecture** → l'agent ne peut pas répondre à des questions exploratoires (\"qu'est-ce qui est bizarre ?\", \"quels folders sont sur-utilisés ?\")
- **Doublonne le reste du dashboard** pour les actions atomiques (drag-drop Mappings, bouton 💡 Suggérer Catégories, bulk-delete toolbar)

## Mécanisme

Constante `PHASE_C_UI_ENABLED = False` dans `dashboard/agent_refonte_phase_c.py`, passée au contexte template via les 2 routes (`/taxonomy` et `/agent/refonte`). Le partial wrappe les blocs Phase C dans `{% if phase_c_ui_enabled %}`.

**Pour réactiver** : passer `PHASE_C_UI_ENABLED = True`. Aucune autre modification requise.

## UI résultante

Reste visible dans le sub-tab Refonte :

- 🚀 \"Lancer le diagnostic\" (Phase A)
- 🔧 \"Proposer une refonte\" (Phase B)
- Liste \"Runs récents\" (col 1)
- Rapport courant (col 2)
- Budget LLM + badge \"🔒 Lecture seule\"

Masqué :

- Bouton \"Nouvelle conversation\"
- Section \"🗨 Conversations\" (sidebar col 1)
- Vue chat (col 2)
- Timeline mutations (col 3)
- Tout le JS Phase C (déclarations + event listeners + loadConvs)

## Code conservé

- `agents/refonte/dialog.py`, `mutations.py`, `agent_journal.py`, `agent_backup.py`
- Endpoints FastAPI `/api/agent/refonte/c/*`
- Tests `tests/auto/test_agent_*.py`

## Test plan

- [x] 245 tests verts (`test_dashboard` + `test_taxonomy`)
- [x] HTTP 200 sur `/taxonomy` et `/agent/refonte`
- [x] Aucune référence Phase C dans le HTML rendu (sauf CSS dead selectors sans effet visuel)
- [x] IIFE JS structure préservée (compte d'opens/closes équilibré)
- [x] Grille 2-col forcée à tous les breakpoints via `.tax-refonte-c-grid--no-timeline` (évite vide blanc à 1280px+)

## Suite possible (à discuter)

3 directions pour le chat à plus long terme :

A. **Étendre** — ajouter `delete_*`, tools de lecture, multi-step planning
B. **Pivoter Q&A read-only** — drop write-tools, ajouter browsing/analysis
C. **Garder désactivé** — la grosse infra journal/backup sert Phase B et les mutations atomiques

Pas de décision actée — réévaluer après usage prolongé sans chat.

🤖 Generated with [Claude Code](https://claude.com/claude-code)