### PR TITLE
fix(refonte): badge readonly — refléter Phases A+B (plus seulement A)

### DIFF
--- a/dashboard/templates/partials/agent_refonte_panel.html
+++ b/dashboard/templates/partials/agent_refonte_panel.html
@@ -34,8 +34,8 @@
         </div>
         <div class="tax-refonte-toolbar-right">
             <span class="tax-refonte-readonly-badge"
-                  title="L'agent n'écrit jamais sur les YAML — il produit uniquement un rapport markdown.">
-                🔒 Lecture seule · Phase A
+                  title="L'agent ne modifie pas les YAML de production (tree.yaml, theme_mapping.yaml, categories.yaml). Phase A produit un rapport markdown ; Phase B écrit un tree-proposed.yaml dans .cache/refonte/ que vous validez ensuite.">
+                🔒 YAML prod intacts · Phases A + B
             </span>
         </div>
     </div>


### PR DESCRIPTION
## Summary

Le badge en haut à droite du sub-tab Refonte disait `🔒 Lecture seule · Phase A` avec tooltip "L'agent n'écrit jamais sur les YAML — il produit uniquement un rapport markdown". C'était exact quand seule Phase A existait. Phase B est désormais accessible via le bouton "Proposer une refonte" et écrit `tree-proposed.yaml` + impact reclassify dans `.cache/refonte/`, donc :

- **"Phase A" seul est trompeur** : Phase B est aussi exposée à l'utilisateur
- **"rapport markdown uniquement" est faux** : Phase B écrit un YAML proposé + diff tree + impact reclassify

## Changements

| Élément | Avant | Après |
|---|---|---|
| Badge | `🔒 Lecture seule · Phase A` | `🔒 YAML prod intacts · Phases A + B` |
| Tooltip | "L'agent n'écrit jamais sur les YAML — il produit uniquement un rapport markdown." | "L'agent ne modifie pas les YAML de production (tree.yaml, theme_mapping.yaml, categories.yaml). Phase A produit un rapport markdown ; Phase B écrit un tree-proposed.yaml dans .cache/refonte/ que vous validez ensuite." |

La garantie de fond — pas de mutation sur prod YAML sans validation explicite — reste vraie pour A et B. Le nouveau wording le dit honnêtement.

## Test plan

- [x] Diff 1-ligne, pas de risque structurel
- [ ] Vérifier visuellement que le badge est bien rendu (textuel) sans casser le layout toolbar

🤖 Generated with [Claude Code](https://claude.com/claude-code)