### PR TITLE
fix(refonte-B): categories cascade plante sur les blocs config non-liste (apprentissage)

### DIFF
--- a/agents/refonte/proposition_tools.py
+++ b/agents/refonte/proposition_tools.py
@@ -270,8 +270,9 @@ def _cascade_categories_changes(
             n = sum(
                 1
                 for entries in current_categories.values()
+                if isinstance(entries, list)
                 for e in entries
-                if e.get("chemin") == d["path"]
+                if isinstance(e, dict) and e.get("chemin") == d["path"]
             )
             if n > 0:
                 log.append({
@@ -624,7 +625,12 @@ def propose_changes(
         if changes.creations:
             from agents.llm import get_agent_llm
             llm = get_agent_llm()
-            existing_groupes = list(current_cats.keys())
+            # Ne garder que les groupes-catégories (list[dict]) : exclut les
+            # blocs config non-liste (ex. `apprentissage`) qui ne sont pas des
+            # cibles de classement et qui ne se slicent pas ([:2] → KeyError).
+            existing_groupes = [
+                g for g in current_cats if isinstance(current_cats[g], list)
+            ]
             groupe_inference = {
                 c.path: _groupe_from_path_prefix(c.path, current_cats)
                 for c in changes.creations

--- a/agents/refonte/proposition_tools.py
+++ b/agents/refonte/proposition_tools.py
@@ -98,7 +98,13 @@ def _groupe_from_path_prefix(
         prefix = "/".join(parts[:n_segments])
         scores: dict[str, int] = {}
         for groupe, entries in existing_categories.items():
+            # Skip les blocs de config (ex. `apprentissage` = dict, pas une
+            # liste d'entries). Cf. lib/keyword_classifier.py:225.
+            if not isinstance(entries, list):
+                continue
             for entry in entries:
+                if not isinstance(entry, dict):
+                    continue
                 chemin = entry.get("chemin", "")
                 if chemin.startswith(prefix + "/") or chemin == prefix:
                     scores[groupe] = scores.get(groupe, 0) + 1
@@ -121,11 +127,17 @@ def _cascade_categories_changes(
         - new_categories : structure YAML mise à jour
         - log_modifications : liste de dicts pour _render_rationale_markdown
     """
-    # Copy défensive
-    new_categories: dict[str, list[dict]] = {
-        groupe: [dict(e) for e in entries]
-        for groupe, entries in current_categories.items()
-    }
+    # Copy défensive. Le vrai categories.yaml mélange des groupes-catégories
+    # (list[dict]) et des blocs de config (ex. `apprentissage` = dict). On ne
+    # cascade que les groupes-catégories ; les blocs config sont préservés
+    # verbatim et ré-injectés à la fin. Cf. lib/keyword_classifier.py:223-225.
+    preserved: dict[str, object] = {}
+    new_categories: dict[str, list[dict]] = {}
+    for groupe, entries in current_categories.items():
+        if not isinstance(entries, list):
+            preserved[groupe] = entries
+            continue
+        new_categories[groupe] = [dict(e) for e in entries if isinstance(e, dict)]
     log: list[dict] = []
 
     # Apply fusions FIRST : transformer chaque source en target dans les
@@ -268,6 +280,8 @@ def _cascade_categories_changes(
                     "n_entries": n,
                 })
 
+    # Ré-injecte les blocs de config préservés (ex. `apprentissage`).
+    new_categories.update(preserved)
     return new_categories, log
 
 
@@ -280,12 +294,23 @@ def _merge_categories_changes(
     absent). Les champs `groupe` des new_entries sont consommés (le groupe
     est utilisé comme clé, pas conservé dans l'entry).
     """
-    merged: dict[str, list[dict]] = {
-        g: [dict(e) for e in entries] for g, entries in intermediate.items()
-    }
+    # Préserve les blocs de config non-liste (ex. `apprentissage`) verbatim.
+    merged: dict[str, object] = {}
+    for g, entries in intermediate.items():
+        if not isinstance(entries, list):
+            merged[g] = entries
+            continue
+        merged[g] = [dict(e) for e in entries if isinstance(e, dict)]
     for entry in new_entries:
         groupe = entry.get("groupe", "autres")
-        merged.setdefault(groupe, []).append({
+        # Ne jamais écraser un bloc config : si la cible n'est pas une liste,
+        # bascule sur "autres" (cas théorique — l'inférence de groupe skippe
+        # déjà les blocs config).
+        if not isinstance(merged.get(groupe), list):
+            if groupe in merged:
+                groupe = "autres"
+            merged.setdefault(groupe, [])
+        merged[groupe].append({
             "chemin": entry["chemin"],
             "priorite": int(entry.get("priorite", 5)),
             "mots_cles": list(entry.get("mots_cles", [])),

--- a/tests/auto/test_agent_refonte_categories.py
+++ b/tests/auto/test_agent_refonte_categories.py
@@ -454,6 +454,26 @@ class TestCategoriesNonListGroups(unittest.TestCase):
             "02-INFORMATIQUE/05-IA-ML/RAG", self._real_shape())
         self.assertEqual(groupe, "informatique")
 
+    def test_cascade_deletion_with_config_block(self):
+        # La boucle de comptage des deletions lit current_categories brut →
+        # doit skipper le bloc config (régression du loop ligne ~272).
+        from agents.refonte.proposition_tools import _cascade_categories_changes
+        current = {
+            "informatique": [
+                {"chemin": "02-INFORMATIQUE/14-Web", "priorite": 3,
+                 "mots_cles": ["html"]},
+            ],
+            "apprentissage": {"actif": True, "seuil_minimum_fichiers": 3},
+        }
+        deletions = [{"path": "02-INFORMATIQUE/14-Web"}]
+        new_cats, log = _cascade_categories_changes(
+            current, renamings=[], fusions=[], deletions=deletions)
+        # Deletion comptée + appliquée, pas de crash sur le bloc config
+        del_log = next(le for le in log if le["type"] == "deletion")
+        self.assertEqual(del_log["n_entries"], 1)
+        self.assertEqual(new_cats["informatique"], [])
+        self.assertEqual(new_cats["apprentissage"], current["apprentissage"])
+
     def test_merge_preserves_config_block(self):
         from agents.refonte.proposition_tools import _merge_categories_changes
         intermediate = self._real_shape()

--- a/tests/auto/test_agent_refonte_categories.py
+++ b/tests/auto/test_agent_refonte_categories.py
@@ -410,5 +410,64 @@ class TestRenderRationale(unittest.TestCase):
         self.assertIn("retrieval", md)
 
 
+class TestCategoriesNonListGroups(unittest.TestCase):
+    """Régression : le vrai categories.yaml mélange des groupes-catégories
+    (list[dict]) et des blocs de config (dict), ex. `apprentissage`
+    {actif, seuil_minimum_fichiers, ...}. Les helpers ne doivent pas
+    planter sur les blocs config (`dict(e) for e in <dict>` → ValueError
+    'dictionary update sequence element #0 has length 1; 2 is required')
+    et doivent les préserver verbatim dans la sortie.
+    Cf. crash run 3ccdb8d7 sur le profil default (2026-06-08).
+    """
+
+    def _real_shape(self):
+        return {
+            "informatique": [
+                {"chemin": "02-INFORMATIQUE/14-Web", "priorite": 3,
+                 "mots_cles": ["html"]},
+            ],
+            # Bloc de config — PAS une liste d'entries
+            "apprentissage": {
+                "actif": True,
+                "seuil_minimum_fichiers": 3,
+                "poids_apprentissage": 0.4,
+            },
+        }
+
+    def test_cascade_preserves_config_block(self):
+        from agents.refonte.proposition_tools import _cascade_categories_changes
+        current = self._real_shape()
+        renamings = [{"old_path": "02-INFORMATIQUE/14-Web",
+                      "new_path": "02-INFORMATIQUE/14-Web-Frontend"}]
+        new_cats, _log = _cascade_categories_changes(
+            current, renamings=renamings, fusions=[], deletions=[])
+        # Pas de crash + le rename a bien été appliqué
+        chemins = [e["chemin"] for e in new_cats["informatique"]]
+        self.assertIn("02-INFORMATIQUE/14-Web-Frontend", chemins)
+        # Le bloc config est préservé verbatim
+        self.assertEqual(new_cats["apprentissage"],
+                         current["apprentissage"])
+
+    def test_groupe_inference_skips_config_block(self):
+        # Le bloc apprentissage ne doit pas faire planter l'inférence
+        groupe = _groupe_from_path_prefix(
+            "02-INFORMATIQUE/05-IA-ML/RAG", self._real_shape())
+        self.assertEqual(groupe, "informatique")
+
+    def test_merge_preserves_config_block(self):
+        from agents.refonte.proposition_tools import _merge_categories_changes
+        intermediate = self._real_shape()
+        new_entries = [{
+            "chemin": "02-INFORMATIQUE/05-IA-ML/RAG", "groupe": "informatique",
+            "priorite": 5, "mots_cles": ["retrieval", "embedding", "vector"],
+        }]
+        merged = _merge_categories_changes(intermediate, new_entries)
+        chemins = [e["chemin"] for e in merged["informatique"]]
+        self.assertIn("02-INFORMATIQUE/05-IA-ML/RAG", chemins)
+        # Bloc config intact
+        self.assertEqual(merged["apprentissage"],
+                         intermediate["apprentissage"])
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/auto/test_agent_refonte_proposition.py
+++ b/tests/auto/test_agent_refonte_proposition.py
@@ -682,7 +682,15 @@ class TestProposeChangesCategoriesIntegration(unittest.TestCase):
         """End-to-end : 1 rename + 1 création + 1 fusion + 1 deletion.
         Vérifie que les 4 artefacts proposed existent + rationale.md contient
         la section CATÉGORIES."""
-        # Étendre categories.yaml avec entries supplémentaires
+        # Étendre categories.yaml avec entries supplémentaires + un bloc de
+        # config NON-LISTE (`apprentissage`) pour reproduire le shape réel du
+        # profil default. Exerce le chemin complet propose_changes (cascade +
+        # bloc LLM sample_entries + merge + write) sur des données réalistes.
+        self._apprentissage = {
+            "actif": True,
+            "seuil_minimum_fichiers": 3,
+            "poids_apprentissage": 0.4,
+        }
         (self.profiles_root / "test_p" / "categories.yaml").write_text(
             yaml.safe_dump({
                 "informatique": [
@@ -697,6 +705,7 @@ class TestProposeChangesCategoriesIntegration(unittest.TestCase):
                     {"chemin": "09-BUREAU/Microsoft-Excel", "priorite": 3,
                      "mots_cles": ["microsoft excel"]},
                 ],
+                "apprentissage": self._apprentissage,
             }, allow_unicode=True),
             encoding="utf-8",
         )
@@ -748,6 +757,7 @@ class TestProposeChangesCategoriesIntegration(unittest.TestCase):
         chemins = sorted(
             e["chemin"]
             for entries in proposed.values()
+            if isinstance(entries, list)  # skip les blocs config (apprentissage)
             for e in entries
         )
         self.assertIn("02-INFORMATIQUE/14-Web-Frontend", chemins)   # rename
@@ -756,6 +766,8 @@ class TestProposeChangesCategoriesIntegration(unittest.TestCase):
         self.assertNotIn("02-INFORMATIQUE/14-Web", chemins)         # ancien rename
         self.assertNotIn("09-BUREAU/Excel", chemins)                # source fusion
         self.assertNotIn("02-INFORMATIQUE/Old-Tag", chemins)        # deletion
+        # Le bloc config non-liste survit au round-trip end-to-end
+        self.assertEqual(proposed.get("apprentissage"), self._apprentissage)
 
         # rationale.md contient la section
         rationale = (out_dir / "refonte-rationale.md").read_text(encoding="utf-8")


### PR DESCRIPTION
## Bug

Run Phase B sur le profil `default` (run `3ccdb8d7`, 2026-06-08) crashé avec :

```
ValueError: dictionary update sequence element #0 has length 1; 2 is required
  proposition_tools.py:126, in _cascade_categories_changes
    groupe: [dict(e) for e in entries]
```

## Root cause

Le vrai `categories.yaml` n'est **pas** purement `dict[str, list[dict]]` : la clé `apprentissage` est un **bloc de config** (`{actif, seuil_minimum_fichiers, poids_apprentissage, ...}`), pas une liste d'entries.

Les 3 helpers categories de Phase B supposaient que chaque valeur de groupe est une `list[dict]` :

| Helper | Bug |
|---|---|
| `_cascade_categories_changes` | `dict(e) for e in entries` itérait les **clés** du dict apprentissage (`'actif'`...) → `dict('actif')` → ValueError |
| `_groupe_from_path_prefix` | `entry.get(...)` sur une clé string → AttributeError |
| `_merge_categories_changes` | même ValueError que la cascade |

Le run écrivait `tree-proposed.yaml` + `theme_mapping-proposed.yaml` puis crashait **avant** `categories-proposed.yaml`.

## Pourquoi les tests étaient verts

Les fixtures utilisaient un shape propre `dict[str, list[dict]]`, jamais le vrai fichier avec le bloc `apprentissage`. **Gap de test** : pas de couverture du shape réel.

## Fix

Suit le pattern éprouvé de `lib/keyword_classifier.py:223-225` — skipper les valeurs non-liste. Les blocs config sont **préservés verbatim** dans la sortie (pas perdus). Défense en profondeur : skip aussi les entries non-dict dans une liste.

## Test plan

- [x] `TestCategoriesNonListGroups` — 3 régressions (cascade / inference / merge avec bloc `apprentissage`)
- [x] Smoke test sur le **vrai** `categories.yaml` du profil default → no crash, config préservée, groupe inféré correct
- [x] 65 tests Phase B verts (62 + 3)
- [x] Ruff clean

## Note connexe (hors-scope)

Le run a duré 76 min avant de crasher — c'est la latence de l'agent LangGraph sur SiliconFlow avec 200 mappings_added, indépendant de ce crash. À surveiller séparément si gênant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)